### PR TITLE
Update table azure_sql_server to return null instead of empty object, if not configured. Closes #67

### DIFF
--- a/azure-test/tests/azure_sql_server/test-hydrate-expected.json
+++ b/azure-test/tests/azure_sql_server/test-hydrate-expected.json
@@ -1,60 +1,68 @@
 [
 	{
-		"encryption_protector": {
-			"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/encryptionProtector/current",
-			"kind": "servicemanaged",
-			"name": "current",
-			"serverKeyName": "ServiceManaged",
-			"serverKeyType": "ServiceManaged",
-			"subRegion": null,
-			"thumbPrint": null,
-			"uri": null
-		},
+		"encryption_protector": [
+			{
+				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/encryptionProtector/current",
+				"kind": "servicemanaged",
+				"name": "current",
+				"properties": {
+					"serverKeyName": "ServiceManaged",
+					"serverKeyType": "ServiceManaged"
+				},
+				"type": "Microsoft.Sql/servers/encryptionProtector"
+			}
+		],
 		"firewall_rules": [],
 		"name": "{{ resourceName }}",
-		"server_audit_policy": {
-			"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/auditingSettings/Default",
-			"name": "Default",
-			"properties": {
-				"auditActionsAndGroups": [
-					"SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
-					"FAILED_DATABASE_AUTHENTICATION_GROUP",
-					"BATCH_COMPLETED_GROUP"
-				],
-				"isAzureMonitorTargetEnabled": true,
-				"isStorageSecondaryKeyInUse": true,
-				"retentionDays": 6,
-				"state": "Enabled",
-				"storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
-				"storageEndpoint": "https://{{ resourceName }}.blob.core.windows.net/"
-			},
-			"type": "Microsoft.Sql/servers/auditingSettings"
-		},
-		"server_azure_ad_administrator": {},
-		"server_security_alert_policy": {
-			"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/securityAlertPolicies/Default",
-			"name": "Default",
-			"properties": {
-				"disabledAlerts": [""],
-				"emailAccountAdmins": false,
-				"emailAddresses": [""],
-				"retentionDays": 0,
-				"state": "Disabled",
-				"storageAccountAccessKey": "",
-				"storageEndpoint": ""
-			},
-			"type": "Microsoft.Sql/servers/securityAlertPolicies"
-		},
-		"server_vulnerability_assessment": {
-			"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/vulnerabilityAssessments/Default",
-			"name": "Default",
-			"properties": {
-				"recurringScans": {
-					"emailSubscriptionAdmins": true,
-					"isEnabled": false
-				}
-			},
-			"type": "Microsoft.Sql/servers/vulnerabilityAssessments"
-		}
+		"server_audit_policy": [
+			{
+				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/auditingSettings/Default",
+				"name": "Default",
+				"properties": {
+					"auditActionsAndGroups": [
+						"SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+						"FAILED_DATABASE_AUTHENTICATION_GROUP",
+						"BATCH_COMPLETED_GROUP"
+					],
+					"isAzureMonitorTargetEnabled": true,
+					"isStorageSecondaryKeyInUse": true,
+					"retentionDays": 6,
+					"state": "Enabled",
+					"storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
+					"storageEndpoint": "https://{{ resourceName }}.blob.core.windows.net/"
+				},
+				"type": "Microsoft.Sql/servers/auditingSettings"
+			}
+		],
+		"server_azure_ad_administrator": "<null>",
+		"server_security_alert_policy": [
+			{
+				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/securityAlertPolicies/Default",
+				"name": "Default",
+				"properties": {
+					"disabledAlerts": [""],
+					"emailAccountAdmins": false,
+					"emailAddresses": [""],
+					"retentionDays": 0,
+					"state": "Disabled",
+					"storageAccountAccessKey": "",
+					"storageEndpoint": ""
+				},
+				"type": "Microsoft.Sql/servers/securityAlertPolicies"
+			}
+		],
+		"server_vulnerability_assessment": [
+			{
+				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/vulnerabilityAssessments/Default",
+				"name": "Default",
+				"properties": {
+					"recurringScans": {
+						"emailSubscriptionAdmins": true,
+						"isEnabled": false
+					}
+				},
+				"type": "Microsoft.Sql/servers/vulnerabilityAssessments"
+			}
+		]
 	}
 ]

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -246,18 +246,29 @@ func getSQLServerAuditPolicy(ctx context.Context, d *plugin.QueryData, h *plugin
 	client := sql.NewServerBlobAuditingPoliciesClient(subscriptionID)
 	client.Authorizer = session.Authorizer
 
-	op, err := client.Get(ctx, resourceGroupName, *server.Name)
+	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	auditPolicyData := map[string]interface{}{
-		"id":         op.ID,
-		"name":       op.Name,
-		"type":       op.Type,
-		"properties": op.ServerBlobAuditingPolicyProperties,
+	var auditPolicies []map[string]interface{}
+	for _, i := range op.Values() {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.ServerBlobAuditingPolicyProperties != nil {
+			objectMap["properties"] = i.ServerBlobAuditingPolicyProperties
+		}
+		auditPolicies = append(auditPolicies, objectMap)
 	}
-	return auditPolicyData, nil
+	return auditPolicies, nil
 }
 
 func getSQLServerSecurityAlertPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -274,18 +285,29 @@ func getSQLServerSecurityAlertPolicy(ctx context.Context, d *plugin.QueryData, h
 	client := sql.NewServerSecurityAlertPoliciesClient(subscriptionID)
 	client.Authorizer = session.Authorizer
 
-	op, err := client.Get(ctx, resourceGroupName, *server.Name)
+	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	securityAlertPolicyData := map[string]interface{}{
-		"id":         op.ID,
-		"name":       op.Name,
-		"type":       op.Type,
-		"properties": op.SecurityAlertPolicyProperties,
+	var securityAlertPolicies []map[string]interface{}
+	for _, i := range op.Values() {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.SecurityAlertPolicyProperties != nil {
+			objectMap["properties"] = i.SecurityAlertPolicyProperties
+		}
+		securityAlertPolicies = append(securityAlertPolicies, objectMap)
 	}
-	return securityAlertPolicyData, nil
+	return securityAlertPolicies, nil
 }
 
 func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -299,10 +321,10 @@ func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, 
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	serverAzureADAdministratorClient := sql.NewServerAzureADAdministratorsClient(subscriptionID)
-	serverAzureADAdministratorClient.Authorizer = session.Authorizer
+	client := sql.NewServerAzureADAdministratorsClient(subscriptionID)
+	client.Authorizer = session.Authorizer
 
-	op, err := serverAzureADAdministratorClient.Get(ctx, resourceGroupName, *server.Name)
+	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			return nil, nil
@@ -310,13 +332,24 @@ func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, 
 		return nil, err
 	}
 
-	administratorData := map[string]interface{}{
-		"id":         op.ID,
-		"name":       op.Name,
-		"type":       op.Type,
-		"properties": op.ServerAdministratorProperties,
+	var serverAdministrators []map[string]interface{}
+	for _, i := range *op.Value {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.ServerAdministratorProperties != nil {
+			objectMap["properties"] = i.ServerAdministratorProperties
+		}
+		serverAdministrators = append(serverAdministrators, objectMap)
 	}
-	return administratorData, nil
+	return serverAdministrators, nil
 }
 
 func getSQLServerEncryptionProtector(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -333,23 +366,36 @@ func getSQLServerEncryptionProtector(ctx context.Context, d *plugin.QueryData, h
 	client := sql.NewEncryptionProtectorsClient(subscriptionID)
 	client.Authorizer = session.Authorizer
 
-	op, err := client.Get(ctx, resourceGroupName, *server.Name)
+	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	encryptionData := map[string]interface{}{
-		"id":            op.ID,
-		"name":          op.Name,
-		"kind":          op.Kind,
-		"subRegion":     op.EncryptionProtectorProperties.Subregion,
-		"serverKeyName": op.EncryptionProtectorProperties.ServerKeyName,
-		"serverKeyType": string(op.ServerKeyType),
-		"uri":           op.URI,
-		"thumbPrint":    op.Thumbprint,
+	var encryptionProtectors []map[string]interface{}
+	for _, i := range op.Values() {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.Location != nil {
+			objectMap["location"] = i.Location
+		}
+		if i.Kind != nil {
+			objectMap["kind"] = i.Kind
+		}
+		if i.EncryptionProtectorProperties != nil {
+			objectMap["properties"] = i.EncryptionProtectorProperties
+		}
+		encryptionProtectors = append(encryptionProtectors, objectMap)
 	}
 
-	return encryptionData, nil
+	return encryptionProtectors, nil
 }
 
 func getSQLServerVulnerabilityAssessment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -366,18 +412,29 @@ func getSQLServerVulnerabilityAssessment(ctx context.Context, d *plugin.QueryDat
 	client := sqlv.NewServerVulnerabilityAssessmentsClient(subscriptionID)
 	client.Authorizer = session.Authorizer
 
-	op, err := client.Get(ctx, resourceGroupName, *server.Name)
+	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	vulnerabilityAssessmentData := map[string]interface{}{
-		"id":         op.ID,
-		"name":       op.Name,
-		"type":       op.Type,
-		"properties": op.ServerVulnerabilityAssessmentProperties,
+	var vulnerabilityAssessments []map[string]interface{}
+	for _, i := range op.Values() {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.ServerVulnerabilityAssessmentProperties != nil {
+			objectMap["properties"] = i.ServerVulnerabilityAssessmentProperties
+		}
+		vulnerabilityAssessments = append(vulnerabilityAssessments, objectMap)
 	}
-	return vulnerabilityAssessmentData, nil
+	return vulnerabilityAssessments, nil
 }
 
 func listSQLServerFirewallRules(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -403,5 +460,23 @@ func listSQLServerFirewallRules(ctx context.Context, d *plugin.QueryData, h *plu
 		return op.Value, nil
 	}
 
-	return nil, nil
+	var firewallRules []map[string]interface{}
+	for _, i := range *op.Value {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.FirewallRuleProperties != nil {
+			objectMap["properties"] = i.FirewallRuleProperties
+		}
+		firewallRules = append(firewallRules, objectMap)
+	}
+
+	return firewallRules, nil
 }

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -132,7 +132,13 @@ func tableAzureSQLServer(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Tags"),
 			},
 
-			// steampipe standard columns
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
 			{
 				Name:        "tags",
 				Description: ColumnDescriptionTags,
@@ -144,14 +150,8 @@ func tableAzureSQLServer(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("ID").Transform(idToAkas),
 			},
-			{
-				Name:        "title",
-				Description: ColumnDescriptionTitle,
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Name"),
-			},
 
-			// azure standard columns
+			// Azure standard columns
 			{
 				Name:        "region",
 				Description: ColumnDescriptionRegion,

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -61,7 +61,7 @@ func tableAzureSQLServer(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "administrator_login",
-				Description: "Specifies the username of the Administrator for this server.",
+				Description: "Specifies the username of the administrator for this server.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("ServerProperties.AdministratorLogin"),
 			},
@@ -251,6 +251,8 @@ func getSQLServerAuditPolicy(ctx context.Context, d *plugin.QueryData, h *plugin
 		return nil, err
 	}
 
+	// If we return the API response directly, the output only gives
+	// the contents of ServerBlobAuditingPolicyProperties
 	var auditPolicies []map[string]interface{}
 	for _, i := range op.Values() {
 		objectMap := make(map[string]interface{})
@@ -290,6 +292,8 @@ func getSQLServerSecurityAlertPolicy(ctx context.Context, d *plugin.QueryData, h
 		return nil, err
 	}
 
+	// If we return the API response directly, the output only gives
+	// the contents of SecurityAlertPolicyProperties
 	var securityAlertPolicies []map[string]interface{}
 	for _, i := range op.Values() {
 		objectMap := make(map[string]interface{})
@@ -332,6 +336,8 @@ func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, 
 		return nil, err
 	}
 
+	// If we return the API response directly, the output only gives
+	// the contents of ServerAdministratorProperties
 	var serverAdministrators []map[string]interface{}
 	for _, i := range *op.Value {
 		objectMap := make(map[string]interface{})
@@ -371,6 +377,8 @@ func getSQLServerEncryptionProtector(ctx context.Context, d *plugin.QueryData, h
 		return nil, err
 	}
 
+	// If we return the API response directly, the output only gives
+	// the contents of EncryptionProtectorProperties
 	var encryptionProtectors []map[string]interface{}
 	for _, i := range op.Values() {
 		objectMap := make(map[string]interface{})
@@ -417,6 +425,8 @@ func getSQLServerVulnerabilityAssessment(ctx context.Context, d *plugin.QueryDat
 		return nil, err
 	}
 
+	// If we return the API response directly, the output only gives
+	// the contents of ServerVulnerabilityAssessmentProperties
 	var vulnerabilityAssessments []map[string]interface{}
 	for _, i := range op.Values() {
 		objectMap := make(map[string]interface{})
@@ -460,6 +470,8 @@ func listSQLServerFirewallRules(ctx context.Context, d *plugin.QueryData, h *plu
 		return op.Value, nil
 	}
 
+	// If we return the API response directly, the output only gives
+	// the contents of FirewallRuleProperties
 	var firewallRules []map[string]interface{}
 	for _, i := range *op.Value {
 		objectMap := make(map[string]interface{})

--- a/docs/tables/azure_sql_server.md
+++ b/docs/tables/azure_sql_server.md
@@ -18,7 +18,7 @@ where
   audit -> 'properties' ->> 'state' = 'Disabled';
 ```
 
-### List servers with an audit log retention period that is less than 90 days
+### List servers with an audit log retention period less than 90 days
 
 ```sql
 select

--- a/docs/tables/azure_sql_server.md
+++ b/docs/tables/azure_sql_server.md
@@ -4,7 +4,7 @@ An Azure SQL server is a relational database management system. As a database se
 
 ## Examples
 
-### List of servers that have auditing disabled
+### List servers that have auditing disabled
 
 ```sql
 select
@@ -18,7 +18,7 @@ where
   audit -> 'properties' ->> 'state' = 'Disabled';
 ```
 
-### List of servers with an audit log retention period that is less than 90 days
+### List servers with an audit log retention period that is less than 90 days
 
 ```sql
 select
@@ -32,7 +32,7 @@ where
   (audit -> 'properties' ->> 'retentionDays')::integer < 90;
 ```
 
-### List of servers that have advanced data security disabled
+### List servers that have advanced data security disabled
 
 ```sql
 select
@@ -46,7 +46,7 @@ where
   security -> 'properties' ->> 'state' = 'Disabled';
 ```
 
-### List of servers that have Advanced Threat Protection types set to All
+### List servers that have Advanced Threat Protection types set to All
 
 ```sql
 select
@@ -63,7 +63,7 @@ where
   and disabled_alerts = '';
 ```
 
-### List of servers that do not have an Active Directory admin set
+### List servers that do not have an Active Directory admin set
 
 ```sql
 select
@@ -75,7 +75,7 @@ where
   server_azure_ad_administrator is null;
 ```
 
-### List of servers for which TDE protector is encrypted with the service-managed key
+### List servers for which TDE protector is encrypted with the service-managed key
 
 ```sql
 select

--- a/docs/tables/azure_sql_server.md
+++ b/docs/tables/azure_sql_server.md
@@ -13,7 +13,7 @@ select
   audit -> 'properties' ->> 'state' as audit_policy_state
 from
   azure_sql_server,
-  jsonb(server_audit_policy) as audit
+  jsonb_array_elements(server_audit_policy) as audit
 where
   audit -> 'properties' ->> 'state' = 'Disabled';
 ```
@@ -24,12 +24,12 @@ where
 select
   name,
   id,
-  audit -> 'properties' -> 'retentionDays' as audit_policy_retention_days
+  (audit -> 'properties' ->> 'retentionDays')::integer as audit_policy_retention_days
 from
   azure_sql_server,
-  jsonb(server_audit_policy) as audit
+  jsonb_array_elements(server_audit_policy) as audit
 where
-  audit -> 'properties' ->> 'retentionDays' < '90';
+  (audit -> 'properties' ->> 'retentionDays')::integer < 90;
 ```
 
 ### List of servers that have advanced data security disabled
@@ -41,7 +41,7 @@ select
   security -> 'properties' ->> 'state' as security_alert_policy_state
 from
   azure_sql_server,
-  jsonb(server_security_alert_policy) as security
+  jsonb_array_elements(server_security_alert_policy) as security
 where
   security -> 'properties' ->> 'state' = 'Disabled';
 ```
@@ -55,7 +55,7 @@ select
   security -> 'properties' -> 'disabledAlerts' as security_alert_policy_state
 from
   azure_sql_server,
-  jsonb(server_security_alert_policy) as security,
+  jsonb_array_elements(server_security_alert_policy) as security,
   jsonb_array_elements_text(security -> 'properties' -> 'disabledAlerts') as disabled_alerts,
   jsonb_array_length(security -> 'properties' -> 'disabledAlerts') as alert_length
 where
@@ -84,7 +84,7 @@ select
   encryption ->> 'kind' as encryption_protector_kind
 from
   azure_sql_server,
-  jsonb(encryption_protector) as encryption
+  jsonb_array_elements(encryption_protector) as encryption
 where
   encryption ->> 'kind' = 'servicemanaged';
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/azure_sql_server []

PRETEST: tests/azure_sql_server

TEST: tests/azure_sql_server
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 36s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Storage/storageAccounts/turbottest95686]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m30s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m39s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: "extended_auditing_policy": [DEPRECATED] the `extended_auditing_policy` block has been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.

  on variables.tf line 49, in resource "azurerm_sql_server" "named_test_resource":
  49: resource "azurerm_sql_server" "named_test_resource" {



Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

auditing_policy = [
  {
    "log_monitoring_enabled" = true
    "retention_in_days" = 6
    "storage_account_access_key" = "kpUFVoduK1vVgpwA9FGAqMVoQZykvPmoIglfEHHUvJmObc4/pTFOfubjFVIcuuha5zlo2tcwV5K3l/g8ccGSTg=="
    "storage_account_access_key_is_secondary" = true
    "storage_endpoint" = "https://turbottest95686.blob.core.windows.net/"
  },
]
location = eastus
resource_aka = azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686
resource_aka_lower = azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest95686/providers/microsoft.sql/servers/turbottest95686
resource_id = /subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686
resource_name = turbottest95686
subscription_id = ********-****-****-****-************

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "fully_qualified_domain_name": "turbottest95686.database.windows.net",
    "kind": "v12.0",
    "location": "eastus",
    "name": "turbottest95686",
    "region": "eastus",
    "resource_group": "turbottest95686",
    "subscription_id": "********-****-****-****-************",
    "tags_src": {
      "name": "turbottest95686"
    },
    "type": "Microsoft.Sql/servers",
    "version": "12.0"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "encryption_protector": [
      {
        "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686/encryptionProtector/current",
        "kind": "servicemanaged",
        "name": "current",
        "properties": {
          "serverKeyName": "ServiceManaged",
          "serverKeyType": "ServiceManaged"
        },
        "type": "Microsoft.Sql/servers/encryptionProtector"
      }
    ],
    "firewall_rules": [],
    "name": "turbottest95686",
    "server_audit_policy": [
      {
        "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686/auditingSettings/Default",
        "name": "Default",
        "properties": {
          "auditActionsAndGroups": [
            "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
            "FAILED_DATABASE_AUTHENTICATION_GROUP",
            "BATCH_COMPLETED_GROUP"
          ],
          "isAzureMonitorTargetEnabled": true,
          "isStorageSecondaryKeyInUse": true,
          "retentionDays": 6,
          "state": "Enabled",
          "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
          "storageEndpoint": "https://turbottest95686.blob.core.windows.net/"
        },
        "type": "Microsoft.Sql/servers/auditingSettings"
      }
    ],
    "server_azure_ad_administrator": "<null>",
    "server_security_alert_policy": [
      {
        "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686/securityAlertPolicies/Default",
        "name": "Default",
        "properties": {
          "disabledAlerts": [
            ""
          ],
          "emailAccountAdmins": false,
          "emailAddresses": [
            ""
          ],
          "retentionDays": 0,
          "state": "Disabled",
          "storageAccountAccessKey": "",
          "storageEndpoint": ""
        },
        "type": "Microsoft.Sql/servers/securityAlertPolicies"
      }
    ],
    "server_vulnerability_assessment": [
      {
        "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686/vulnerabilityAssessments/Default",
        "name": "Default",
        "properties": {
          "recurringScans": {
            "emailSubscriptionAdmins": true,
            "isEnabled": false
          }
        },
        "type": "Microsoft.Sql/servers/vulnerabilityAssessments"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686",
    "location": "eastus",
    "name": "turbottest95686"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest95686/providers/Microsoft.Sql/servers/turbottest95686",
      "azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest95686/providers/microsoft.sql/servers/turbottest95686"
    ],
    "name": "turbottest95686",
    "title": "turbottest95686"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_server

TEARDOWN: tests/azure_sql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List servers that have auditing disabled

```sql
select
  name,
  id,
  audit -> 'properties' ->> 'state' as audit_policy_state
from
  azure_sql_server,
  jsonb_array_elements(server_audit_policy) as audit
where
  audit -> 'properties' ->> 'state' = 'Disabled';
```
```
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+--------------------+
| name                   | id                                                                                                                                  | audit_policy_state |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+--------------------+
| testsqlserver230032021 | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver230032021 | Disabled           |
| testsqlserver30032021  | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver30032021  | Disabled           |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+--------------------+
```

### List servers with an audit log retention period that is less than 90 days

```sql
select
  name,
  id,
  (audit -> 'properties' ->> 'retentionDays')::integer as audit_policy_retention_days
from
  azure_sql_server,
  jsonb_array_elements(server_audit_policy) as audit
where
  (audit -> 'properties' ->> 'retentionDays')::integer < 90;
```
```
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| name                   | id                                                                                                                                  | audit_policy_retention_days |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| testsqlserver230032021 | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver230032021 | 0                           |
| testsqlserver30032021  | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver30032021  | 0                           |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
```

### List servers that have advanced data security disabled

```sql
select
  name,
  id,
  security -> 'properties' ->> 'state' as security_alert_policy_state
from
  azure_sql_server,
  jsonb_array_elements(server_security_alert_policy) as security
where
  security -> 'properties' ->> 'state' = 'Disabled';
```
```
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| name                   | id                                                                                                                                  | security_alert_policy_state |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| testsqlserver30032021  | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver30032021  | Disabled                    |
| testsqlserver230032021 | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver230032021 | Disabled                    |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
```

### List servers that have Advanced Threat Protection types set to All

```sql
select
  name,
  id,
  security -> 'properties' -> 'disabledAlerts' as security_alert_policy_state
from
  azure_sql_server,
  jsonb_array_elements(server_security_alert_policy) as security,
  jsonb_array_elements_text(security -> 'properties' -> 'disabledAlerts') as disabled_alerts,
  jsonb_array_length(security -> 'properties' -> 'disabledAlerts') as alert_length
where
  alert_length = 1
  and disabled_alerts = '';
```
```
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| name                   | id                                                                                                                                  | security_alert_policy_state |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| testsqlserver30032021  | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver30032021  | [""]                        |
| testsqlserver230032021 | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver230032021 | [""]                        |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
```

### List servers that do not have an Active Directory admin set

```sql
select
  name,
  id
from
  azure_sql_server
where
  server_azure_ad_administrator is null;
```
```
+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
| name                  | id                                                                                                                                 |
+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
| testsqlserver30032021 | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver30032021 |
+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
```

### List servers for which TDE protector is encrypted with the service-managed key

```sql
select
  name,
  id,
  encryption ->> 'kind' as encryption_protector_kind
from
  azure_sql_server,
  jsonb_array_elements(encryption_protector) as encryption
where
  encryption ->> 'kind' = 'servicemanaged';
```
```
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------------------------+
| name                   | id                                                                                                                                  | encryption_protector_kind |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------------------------+
| testsqlserver30032021  | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver30032021  | servicemanaged            |
| testsqlserver230032021 | /subscriptions/********-****-****-****-************/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/testsqlserver230032021 | servicemanaged            |
+------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------------------------+
```
</details>
