### PR TITLE
Add support for VHD (Virtual Hard Disks) encryption check. closes #50

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -238,6 +238,12 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VirtualMachineProperties.AdditionalCapabilities.UltraSSDEnabled"),
 			},
 			{
+				Name:        "vhd_uri",
+				Description: "Specifies the virtual hard disk's uri.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("VirtualMachineProperties.StorageProfile.OsDisk.Vhd.URI").Transform(transform.ToString),
+			},
+			{
 				Name:        "data_disks",
 				Description: "A list of parameters that are used to add a data disk to a virtual machine",
 				Type:        proto.ColumnType_JSON,

--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -208,6 +208,12 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VirtualMachineProperties.StorageProfile.OsDisk.Name"),
 			},
 			{
+				Name:        "os_disk_vhd_uri",
+				Description: "Specifies the virtual hard disk's uri.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("VirtualMachineProperties.StorageProfile.OsDisk.Vhd.URI").Transform(transform.ToString),
+			},
+			{
 				Name:        "os_type",
 				Description: "Specifies the type of the OS that is included in the disk if creating a VM from user-image or a specialized VHD",
 				Type:        proto.ColumnType_STRING,
@@ -236,12 +242,6 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Description: "Specifies whether managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set, or not",
 				Type:        proto.ColumnType_BOOL,
 				Transform:   transform.FromField("VirtualMachineProperties.AdditionalCapabilities.UltraSSDEnabled"),
-			},
-			{
-				Name:        "vhd_uri",
-				Description: "Specifies the virtual hard disk's uri.",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("VirtualMachineProperties.StorageProfile.OsDisk.Vhd.URI").Transform(transform.ToString),
 			},
 			{
 				Name:        "data_disks",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_virtual_machine []

PRETEST: tests/azure_compute_virtual_machine

TEST: tests/azure_compute_virtual_machine
Running terraform
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Creation complete after 9s [id=/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Network/virtualNetworks/turbottest69292]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 2s [id=/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Network/virtualNetworks/turbottest69292/subnets/turbottest69292]
azurerm_network_interface.named_test_resource: Creating...
azurerm_network_interface.named_test_resource: Creation complete after 6s [id=/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Network/networkInterfaces/turbottest69292]
azurerm_virtual_machine.named_test_resource: Creating...
azurerm_virtual_machine.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [20s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [30s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [40s elapsed]
azurerm_virtual_machine.named_test_resource: Creation complete after 47s [id=/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Compute/virtualMachines/turbottest69292]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 22, in provider "azurerm":
  22:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.


Warning: Interpolation-only expressions are deprecated

  on variables.tf line 117, in output "resource_name_upper":
 117:   value = "${upper(var.resource_name)}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Compute/virtualMachines/turbottest69292"
resource_aka_lower = "azure:///subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourcegroups/turbottest69292/providers/microsoft.compute/virtualmachines/turbottest69292"
resource_id = "/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Compute/virtualMachines/turbottest69292"
resource_name = "turbottest69292"
resource_name_upper = "TURBOTTEST69292"
subscription_id = "cd4401c4-3cc8-4565-a594-839c1e345f1e"

Running SQL query: test-get-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Compute/virtualMachines/turbottest69292",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest69292",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest69292",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest69292",
    "size": "Standard_DS1_v2",
    "subscription_id": "cd4401c4-3cc8-4565-a594-839c1e345f1e",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Compute/virtualMachines/turbottest69292",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest69292",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest69292",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest69292",
    "size": "Standard_DS1_v2",
    "subscription_id": "cd4401c4-3cc8-4565-a594-839c1e345f1e",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/TURBOTTEST69292/providers/Microsoft.Compute/virtualMachines/turbottest69292",
    "name": "turbottest69292",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourceGroups/turbottest69292/providers/Microsoft.Compute/virtualMachines/turbottest69292",
      "azure:///subscriptions/cd4401c4-3cc8-4565-a594-839c1e345f1e/resourcegroups/turbottest69292/providers/microsoft.compute/virtualmachines/turbottest69292"
    ],
    "name": "turbottest69292",
    "tags": {
      "name": "turbottest69292"
    },
    "title": "turbottest69292"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_virtual_machine

TEARDOWN: tests/azure_compute_virtual_machine

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### Virtual machine VHD info

```sql
select
  name,
  power_state,
  vm_id,
  os_type,
  os_disk_vhd_uri
from
  azure_compute_virtual_machine;
```

```
+----------------+-------------+--------------------------------------+---------+-----------------------------------------------------------------------------------+
| name           | power_state | vm_id                                | os_type | os_disk_vhd_uri                                                                           |
+----------------+-------------+--------------------------------------+---------+-----------------------------------------------------------------------------------+
| test-steampipe | running     | b7c39910-84b0-4548-a143-5999dd36a913 | Linux   | https://turbotrgdisks.blob.core.windows.net/vhds/test-steampipe20210409155939.vhd |
+----------------+-------------+--------------------------------------+---------+-----------------------------------------------------------------------------------+
```
</details>

We can fetch the storage account name from the VHD URI & from that storage account name, we can check the encryption status for the storage account containing the VHD blob