### PR TITLE
Add support to query logging information for key vault. Closes #95

### DIFF
--- a/azure-test/tests/azure_key_vault/test-logging-expected.json
+++ b/azure-test/tests/azure_key_vault/test-logging-expected.json
@@ -1,0 +1,8 @@
+[
+	{
+		"category": "AuditEvent",
+		"log_retention_days": 30,
+		"name": "{{ resourceName }}",
+		"storage_account_id": "{{ output.storage_account_id.value }}"
+	}
+]

--- a/azure-test/tests/azure_key_vault/test-logging-query.sql
+++ b/azure-test/tests/azure_key_vault/test-logging-query.sql
@@ -1,0 +1,15 @@
+select
+  name,
+  setting -> 'properties' ->> 'storageAccountId' storage_account_id,
+  log ->> 'category' category,
+  (log -> 'retentionPolicy' ->> 'days')::integer log_retention_days
+from
+  azure_key_vault,
+  jsonb_array_elements(diagnostic_settings) setting,
+  jsonb_array_elements(setting -> 'properties' -> 'logs') log
+where
+  diagnostic_settings is not null
+  and setting -> 'properties' ->> 'storageAccountId' <> ''
+  and (log ->> 'enabled')::boolean
+  and log ->> 'category' = 'AuditEvent'
+  and (log -> 'retentionPolicy' ->> 'days')::integer > 0;

--- a/azure-test/tests/azure_key_vault/variables.tf
+++ b/azure-test/tests/azure_key_vault/variables.tf
@@ -13,7 +13,7 @@ variable "azure_environment" {
 
 variable "azure_subscription" {
   type        = string
-  default     = "3510ae4d-530b-497d-8f30-53b9616fc6c1"
+  default     = "3510ae4d-530b-497d-8f30-53c0616fc6c1"
   description = "Azure subscription used for the test."
 }
 
@@ -62,6 +62,30 @@ resource "azurerm_key_vault_access_policy" "named_test_resource" {
   ]
 }
 
+resource "azurerm_storage_account" "named_test_resource" {
+  name                     = var.resource_name
+  location                 = azurerm_resource_group.named_test_resource.location
+  resource_group_name      = azurerm_resource_group.named_test_resource.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "named_test_resource" {
+  name               = var.resource_name
+  target_resource_id = azurerm_key_vault.named_test_resource.id
+  storage_account_id = azurerm_storage_account.named_test_resource.id
+
+  log {
+    category = "AuditEvent"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days    = 30
+    }
+  }
+}
+
 output "resource_aka" {
   value = "azure://${azurerm_key_vault.named_test_resource.id}"
 }
@@ -88,4 +112,8 @@ output "tenant_id" {
 
 output "object_id" {
   value = data.azurerm_client_config.current.object_id
+}
+
+output "storage_account_id" {
+  value = azurerm_storage_account.named_test_resource.id
 }

--- a/azure/table_azure_key_vault.go
+++ b/azure/table_azure_key_vault.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -118,6 +119,13 @@ func tableAzureKeyVault(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Properties.AccessPolicies"),
 			},
+			{
+				Name:        "diagnostic_settings",
+				Description: "A list of active diagnostic settings for the vault.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listKmsKeyVaultDiagnosticSettings,
+				Transform:   transform.FromValue(),
+			},
 
 			// Standard columns
 			{
@@ -217,4 +225,45 @@ func getKeyVault(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 	}
 
 	return nil, nil
+}
+
+func listKmsKeyVaultDiagnosticSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listKmsKeyVaultDiagnosticSettings")
+	data := h.Item.(keyvault.Vault)
+
+	// Create session
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	client := insights.NewDiagnosticSettingsClient(subscriptionID)
+	client.Authorizer = session.Authorizer
+
+	op, err := client.List(ctx, *data.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we return the API response directly, the output only gives
+	// the contents of DiagnosticSettings
+	var diagnosticSettings []map[string]interface{}
+	for _, i := range *op.Value {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.DiagnosticSettings != nil {
+			objectMap["properties"] = i.DiagnosticSettings
+		}
+		diagnosticSettings = append(diagnosticSettings, objectMap)
+	}
+	return diagnosticSettings, nil
 }

--- a/docs/tables/azure_key_vault.md
+++ b/docs/tables/azure_key_vault.md
@@ -75,3 +75,24 @@ from
   azure_key_vault
   cross join jsonb_array_elements(access_policies) as policy;
 ```
+
+
+### List vaults with logging enabled
+
+```sql
+select
+  name,
+  setting -> 'properties' ->> 'storageAccountId' storage_account_id,
+  log ->> 'category' category,
+  log -> 'retentionPolicy' ->> 'days' log_retention_days
+from
+  azure_key_vault,
+  jsonb_array_elements(diagnostic_settings) setting,
+  jsonb_array_elements(setting -> 'properties' -> 'logs') log
+where
+  diagnostic_settings is not null
+  and setting -> 'properties' ->> 'storageAccountId' <> ''
+  and (log ->> 'enabled')::boolean
+  and log ->> 'category' = 'AuditEvent'
+  and (log -> 'retentionPolicy' ->> 'days')::integer > 0;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/azure_key_vault []

PRETEST: tests/azure_key_vault

TEST: tests/azure_key_vault
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_key_vault.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Creating...
azurerm_key_vault.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 35s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.Storage/storageAccounts/turbottest2949]
azurerm_key_vault.named_test_resource: Still creating... [40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m20s elapsed]
azurerm_key_vault.named_test_resource: Creation complete after 2m25s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949]
azurerm_key_vault_access_policy.named_test_resource: Creating...
azurerm_monitor_diagnostic_setting.named_test_resource: Creating...
azurerm_key_vault_access_policy.named_test_resource: Creation complete after 3s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949/objectId/********-****-****-****-************]
azurerm_monitor_diagnostic_setting.named_test_resource: Creation complete after 10s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949|turbottest2949]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

object_id = ********-****-****-****-************
resource_aka = azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949
resource_aka_lower = azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest2949/providers/microsoft.keyvault/vaults/turbottest2949
resource_id = /subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949
resource_name = turbottest2949
storage_account_id = /subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.Storage/storageAccounts/turbottest2949
subscription_id = ********-****-****-****-************
tenant_id = ********-****-****-****-************

Running SQL query: test-get-query.sql
[
  {
    "enabled_for_deployment": false,
    "enabled_for_disk_encryption": false,
    "enabled_for_template_deployment": false,
    "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949",
    "name": "turbottest2949",
    "region": "westus",
    "resource_group": "turbottest2949",
    "sku_name": "standard",
    "tenant_id": "********-****-****-****-************",
    "type": "Microsoft.KeyVault/vaults",
    "vault_uri": "https://turbottest2949.vault.azure.net/"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_policies": [
      {
        "objectId": "********-****-****-****-************",
        "permissions": {
          "certificates": [],
          "keys": [
            "get"
          ],
          "secrets": [
            "get"
          ],
          "storage": []
        },
        "tenantId": "********-****-****-****-************"
      }
    ],
    "akas": [
      "azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949",
      "azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest2949/providers/microsoft.keyvault/vaults/turbottest2949"
    ],
    "name": "turbottest2949",
    "tags": {
      "name": "turbottest2949"
    },
    "title": "turbottest2949"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949",
    "name": "turbottest2949"
  }
]
✔ PASSED

Running SQL query: test-logging-query.sql
[
  {
    "category": "AuditEvent",
    "log_retention_days": 30,
    "name": "turbottest2949",
    "storage_account_id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.Storage/storageAccounts/turbottest2949"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest2949/providers/Microsoft.KeyVault/vaults/turbottest2949",
      "azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest2949/providers/microsoft.keyvault/vaults/turbottest2949"
    ],
    "name": "turbottest2949",
    "tags": {
      "name": "turbottest2949"
    },
    "title": "turbottest2949"
  }
]
✔ PASSED

POSTTEST: tests/azure_key_vault

TEARDOWN: tests/azure_key_vault

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List vaults with logging enabled

```sql
select
  name,
  setting -> 'properties' ->> 'storageAccountId' storage_account_id,
  log ->> 'category' category,
  log -> 'retentionPolicy' ->> 'days' log_retention_days
from
  azure_key_vault,
  jsonb_array_elements(diagnostic_settings) setting,
  jsonb_array_elements(setting -> 'properties' -> 'logs') log
where
  diagnostic_settings is not null
  and setting -> 'properties' ->> 'storageAccountId' <> ''
  and (log ->> 'enabled')::boolean
  and log ->> 'category' = 'AuditEvent'
  and (log -> 'retentionPolicy' ->> 'days')::integer > 0;
```
```
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------+------------+--------------------+
| name             | storage_account_id                                                                                                                          | category   | log_retention_days |
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------+------------+--------------------+
| testkeyvault0012 | /subscriptions/********-****-****-****-************/resourceGroups/dummy1234/providers/Microsoft.Storage/storageAccounts/sqlva4pz6nakavj3mi | AuditEvent | 3                  |
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------+------------+--------------------+
```
</details>
