### PR TITLE
[Fix] subscription_id column not displaying wrong value in azure_diagnostic_setting table. Closes #98

### DIFF
--- a/azure/table_azure_diagnostic_setting.go
+++ b/azure/table_azure_diagnostic_setting.go
@@ -2,8 +2,10 @@ package azure
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
+	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
@@ -115,7 +117,7 @@ func tableAzureDiagnosticSetting(_ context.Context) *plugin.Table {
 				Name:        "subscription_id",
 				Description: ColumnDescriptionSubscription,
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ID").Transform(idToSubscriptionID),
+				Transform:   transform.FromField("ID").Transform(diagnosticSettingSubscriptionID),
 			},
 		},
 	}
@@ -169,4 +171,12 @@ func getDiagnosticSetting(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	}
 
 	return op, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func diagnosticSettingSubscriptionID(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	id := types.SafeString(d.Value)
+	subscriptionid := strings.Split(id, "/")[1]
+	return subscriptionid, nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select resource_group, subscription_id from azure_diagnostic_setting;

+----------------+--------------------------------------+
| resource_group | subscription_id                      |
+----------------+--------------------------------------+
| turbot_rg      | d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8 |
| turbot_rg      | d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8 |
| turbot_rg      | d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8 |
+----------------+--------------------------------------+

select resource_group, subscription_id from azure_diagnostic_setting;

+----------------+--------------------------------------+
| resource_group | subscription_id                      |
+----------------+--------------------------------------+
| turbot_rg      | d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8 |
| turbot_rg      | d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8 |
| turbot_rg      | d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8 |
+----------------+--------------------------------------+
```
</details>
