### PR TITLE
[Fix] Getting error `cannot convert 2021-04-23T11:33:12.8437526Z to a time.Time` in azure_storage_account. Closes #100

### DIFF
--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -191,7 +191,7 @@ func tableAzureStorageAccount(_ context.Context) *plugin.Table {
 				Name:        "encryption_key_vault_properties_last_rotation_time",
 				Description: "Timestamp of last rotation of the Key Vault Key.",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("Account.AccountProperties.Encryption.KeyVaultProperties.LastKeyRotationTimestamp"),
+				Transform:   transform.FromField("Account.AccountProperties.Encryption.KeyVaultProperties.LastKeyRotationTimestamp").Transform(convertDateToTime),
 			},
 			{
 				Name:        "failover_in_progress",

--- a/azure/utils.go
+++ b/azure/utils.go
@@ -35,6 +35,9 @@ func extractResourceGroupFromID(ctx context.Context, d *transform.TransformData)
 }
 
 func convertDateToTime(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	if d.Value == nil {
+		return nil, nil
+	}
 	dateValue := d.Value.(*date.Time)
 
 	if dateValue != nil {


### PR DESCRIPTION
…e.Time in table azure_storage_account table. Closes #100

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select name, encryption_key_vault_properties_last_rotation_time from azure_storage_account;

+---------+----------------------------------------------------+
| name    | encryption_key_vault_properties_last_rotation_time |
+---------+----------------------------------------------------+
| test007 | 2021-04-23 12:10:50                                |
+---------+----------------------------------------------------+
```
</details>
