### PR TITLE
[Fix] Error: hydrate call listKmsKeyVaultDiagnosticSettings failed with panic interface conversion: interface {} is keyvault.Resource, not keyvault.Vault. Closes #103

### DIFF
--- a/azure/table_azure_key_vault.go
+++ b/azure/table_azure_key_vault.go
@@ -249,7 +249,7 @@ func getKeyVault(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 
 func listKmsKeyVaultDiagnosticSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listKmsKeyVaultDiagnosticSettings")
-	data := h.Item.(keyvault.Vault)
+	id := getKeyVaultID(h.Item)
 
 	// Create session
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
@@ -261,7 +261,7 @@ func listKmsKeyVaultDiagnosticSettings(ctx context.Context, d *plugin.QueryData,
 	client := insights.NewDiagnosticSettingsClient(subscriptionID)
 	client.Authorizer = session.Authorizer
 
-	op, err := client.List(ctx, *data.ID)
+	op, err := client.List(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -286,4 +286,14 @@ func listKmsKeyVaultDiagnosticSettings(ctx context.Context, d *plugin.QueryData,
 		diagnosticSettings = append(diagnosticSettings, objectMap)
 	}
 	return diagnosticSettings, nil
+}
+
+func getKeyVaultID(item interface{}) string {
+	switch item.(type) {
+	case keyvault.Vault:
+		return *item.(keyvault.Vault).ID
+	case keyvault.Resource:
+		return *item.(keyvault.Resource).ID
+	}
+	return ""
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
vishalkumar@Vishals-MacBook-Air azure-test % ./tint.js tests/azure_key_vault
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_key_vault []

PRETEST: tests/azure_key_vault

TEST: tests/azure_key_vault
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169]
azurerm_key_vault.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Creating...
azurerm_key_vault.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 37s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.Storage/storageAccounts/turbottest52169]
azurerm_key_vault.named_test_resource: Still creating... [40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m30s elapsed]
azurerm_key_vault.named_test_resource: Creation complete after 2m39s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169]
azurerm_key_vault_access_policy.named_test_resource: Creating...
azurerm_monitor_diagnostic_setting.named_test_resource: Creating...
azurerm_key_vault_access_policy.named_test_resource: Still creating... [10s elapsed]
azurerm_monitor_diagnostic_setting.named_test_resource: Still creating... [10s elapsed]
azurerm_key_vault_access_policy.named_test_resource: Creation complete after 13s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169/objectId/f0c73063-f4c3-4b80-a035-1aaddb4f93a2]
azurerm_monitor_diagnostic_setting.named_test_resource: Creation complete after 13s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169|turbottest52169]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

object_id = f0c73063-f4c3-4b80-a035-1aaddb4f93a2
resource_aka = azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169
resource_aka_lower = azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourcegroups/turbottest52169/providers/microsoft.keyvault/vaults/turbottest52169
resource_id = /subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169
resource_name = turbottest52169
storage_account_id = /subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.Storage/storageAccounts/turbottest52169
subscription_id = 3510ae4d-530b-497d-8f30-53b9616fc6c1
tenant_id = cdffd708-7da0-4cea-abeb-0a4c334d7f64

Running SQL query: test-get-query.sql
[
  {
    "enabled_for_deployment": false,
    "enabled_for_disk_encryption": false,
    "enabled_for_template_deployment": false,
    "id": "/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169",
    "name": "turbottest52169",
    "region": "westus",
    "resource_group": "turbottest52169",
    "sku_name": "standard",
    "tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "type": "Microsoft.KeyVault/vaults",
    "vault_uri": "https://turbottest52169.vault.azure.net/"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_policies": [
      {
        "objectId": "f0c73063-f4c3-4b80-a035-1aaddb4f93a2",
        "permissions": {
          "certificates": [],
          "keys": [
            "get"
          ],
          "secrets": [
            "get"
          ],
          "storage": []
        },
        "tenantId": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
      }
    ],
    "akas": [
      "azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169",
      "azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourcegroups/turbottest52169/providers/microsoft.keyvault/vaults/turbottest52169"
    ],
    "name": "turbottest52169",
    "tags": {
      "name": "turbottest52169"
    },
    "title": "turbottest52169"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169",
    "name": "turbottest52169"
  }
]
✔ PASSED

Running SQL query: test-logging-query.sql
[
  {
    "category": "AuditEvent",
    "log_retention_days": 30,
    "name": "turbottest52169",
    "storage_account_id": "/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.Storage/storageAccounts/turbottest52169"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest52169/providers/Microsoft.KeyVault/vaults/turbottest52169",
      "azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourcegroups/turbottest52169/providers/microsoft.keyvault/vaults/turbottest52169"
    ],
    "name": "turbottest52169",
    "tags": {
      "name": "turbottest52169"
    },
    "title": "turbottest52169"
  }
]
✔ PASSED

POSTTEST: tests/azure_key_vault

TEARDOWN: tests/azure_key_vault

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
