### PR TITLE
Getting an error as column 'id' requires hydrate data from getKeyVaultSecret but none is available on azure_key_vault_secret table. Closes #104

### DIFF
--- a/azure/table_azure_key_vault_secret.go
+++ b/azure/table_azure_key_vault_secret.go
@@ -201,6 +201,10 @@ func getKeyVaultSecret(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		splitID := strings.Split(*data.ID, "/")
 		vaultName = strings.Split(splitID[2], ".")[0]
 		name = splitID[4]
+		// Operation get is not allowed on a disabled secret
+		if  !*data.Attributes.Enabled{
+			return nil,nil
+		}
 	} else {
 		vaultName = d.KeyColumnQuals["vault_name"].GetStringValue()
 		name = d.KeyColumnQuals["name"].GetStringValue()


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_key_vault_secret []

PRETEST: tests/azure_key_vault_secret

TEST: tests/azure_key_vault_secret
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest12044]
azurerm_key_vault.named_test_resource: Creating...
azurerm_key_vault.named_test_resource: Still creating... [10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m30s elapsed]
azurerm_key_vault.named_test_resource: Creation complete after 2m33s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest12044/providers/Microsoft.KeyVault/vaults/turbottest12044]
azurerm_key_vault_secret.named_test_resource: Creating...
azurerm_key_vault_secret.named_test_resource: Creation complete after 5s [id=https://turbottest12044.vault.azure.net/secrets/turbottest12044/4aa5a2cbec2e4cc3a3122e70b34d1bec]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

location = westus
resource_aka = azure://https://turbottest12044.vault.azure.net/secrets/turbottest12044/4aa5a2cbec2e4cc3a3122e70b34d1bec
resource_aka_lower = azure://https://turbottest12044.vault.azure.net/secrets/turbottest12044/4aa5a2cbec2e4cc3a3122e70b34d1bec
resource_id = https://turbottest12044.vault.azure.net/secrets/turbottest12044/4aa5a2cbec2e4cc3a3122e70b34d1bec
resource_name = turbottest12044
secret_uri_without_version = https://turbottest12044.vault.azure.net/secrets/turbottest12044
secret_version = 4aa5a2cbec2e4cc3a3122e70b34d1bec
subscription_id = 3510ae4d-530b-497d-8f30-53b9616fc6c1

Running SQL query: test-get-query.sql
[
  {
    "content_type": "text",
    "enabled": true,
    "id": "https://turbottest12044.vault.azure.net/secrets/turbottest12044/4aa5a2cbec2e4cc3a3122e70b34d1bec",
    "name": "turbottest12044",
    "recoverable_days": 7,
    "recovery_level": "CustomizedRecoverable+Purgeable",
    "region": "westus",
    "resource_group": "turbottest12044",
    "subscription_id": "3510ae4d-530b-497d-8f30-53b9616fc6c1",
    "value": "steampipe",
    "vault_name": "turbottest12044"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "https://turbottest12044.vault.azure.net/secrets/turbottest12044/4aa5a2cbec2e4cc3a3122e70b34d1bec",
    "name": "turbottest12044"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourceGroups/turbottest12044/providers/Microsoft.KeyVault/vaults/turbottest12044/secrets/turbottest12044",
      "azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/resourcegroups/turbottest12044/providers/microsoft.keyvault/vaults/turbottest12044/secrets/turbottest12044"
    ],
    "name": "turbottest12044",
    "tags": {
      "name": "turbottest12044"
    },
    "title": "turbottest12044"
  }
]
✔ PASSED

POSTTEST: tests/azure_key_vault_secret

TEARDOWN: tests/azure_key_vault_secret

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
