### PR TITLE
Error message is not clear enough to state what goes wrong with the command. Closes #109

### DIFF
--- a/azure/service.go
+++ b/azure/service.go
@@ -241,7 +241,7 @@ func getSubscriptionFromCLI(resource string) (*subscription, error) {
 
 	output, err := cliCmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %v", stderr)
+		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %v", err)
 	}
 
 	var tokenResponse map[string]interface{}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
