### PR TITLE
Add table azure_policy_definition. closes #18

### DIFF
--- a/azure-test/tests/azure_policy_definition/test-list-expected.json
+++ b/azure-test/tests/azure_policy_definition/test-list-expected.json
@@ -1,0 +1,7 @@
+[
+  {
+    "display_name": "{{ output.resource_name.value }}",
+    "id": "{{ output.resource_id.value }}",
+    "name": "{{ output.resource_name.value }}"
+  }
+]

--- a/azure-test/tests/azure_policy_definition/test-list-query.sql
+++ b/azure-test/tests/azure_policy_definition/test-list-query.sql
@@ -1,0 +1,3 @@
+select id, name, display_name
+from azure.azure_policy_definition
+where display_name = '{{ output.resource_name.value }}';

--- a/azure-test/tests/azure_policy_definition/variables.tf
+++ b/azure-test/tests/azure_policy_definition/variables.tf
@@ -1,0 +1,86 @@
+
+variable "resource_name" {
+  type        = string
+  default     = "turbot-test-20200125-create-update"
+  description = "Name of the resource used throughout the test."
+}
+
+variable "azure_environment" {
+  type        = string
+  default     = "public"
+  description = "Azure environment used for the test."
+}
+
+variable "azure_subscription" {
+  type        = string
+  default     = "3510ae4d-530b-497d-8f30-53b9616fc6c1"
+  description = "Azure subscription used for the test."
+}
+
+provider "azurerm" {
+  # Cannot be passed as a variable
+  version = "=2.43.0"
+  features {}
+  environment     = var.azure_environment
+  subscription_id = var.azure_subscription
+}
+
+data "azurerm_client_config" "current" {}
+
+data "null_data_source" "resource" {
+  inputs = {
+    scope = "azure:///subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  }
+}
+
+resource "azurerm_policy_definition" "named_test_resource" {
+  name         = "TestSecurityCenterBuiltIn"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "TestSecurityCenterBuiltIn"
+  policy_rule  = <<POLICY_RULE
+    {
+    "if": {
+      "not": {
+        "field": "location",
+        "in": "[parameters('allowedLocations')]"
+      }
+    },
+    "then": {
+      "effect": "audit"
+    }
+  }
+POLICY_RULE
+  parameters   = <<PARAMETERS
+    {
+    "allowedLocations": {
+      "type": "Array",
+      "metadata": {
+        "description": "The list of allowed locations for resources.",
+        "displayName": "Allowed locations",
+        "strongType": "location"
+      }
+    }
+  }
+PARAMETERS
+}
+
+output "resource_aka" {
+  value = "azure://${azurerm_policy_definition.named_test_resource.id}"
+}
+
+output "resource_aka_lower" {
+  value = "azure://${lower(azurerm_policy_definition.named_test_resource.id)}"
+}
+
+output "resource_id" {
+  value = azurerm_policy_definition.named_test_resource.id
+}
+
+output "resource_name" {
+  value = "TestSecurityCenterBuiltIn"
+}
+
+output "subscription_id" {
+  value = var.azure_subscription
+}

--- a/azure/plugin.go
+++ b/azure/plugin.go
@@ -57,6 +57,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"azure_network_watcher":                      tableAzureNetworkWatcher(ctx),
 			"azure_network_watcher_flow_log":             tableAzureNetworkWatcherFlowLog(ctx),
 			"azure_policy_assignment":                    tableAzurePolicyAssignment(ctx),
+			"azure_policy_definition":                    tableAzurePolicyDefinition(ctx),
 			"azure_postgresql_server":                    tableAzurePostgreSqlServer(ctx),
 			"azure_provider":                             tableAzureProvider(ctx),
 			"azure_public_ip":                            tableAzurePublicIP(ctx),

--- a/azure/table_azure_policy_definition.go
+++ b/azure/table_azure_policy_definition.go
@@ -45,16 +45,46 @@ func tableAzurePolicyDefinition(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DefinitionProperties.DisplayName"),
 			},
 			{
+				Name:        "description",
+				Description: "The policy definition description.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DefinitionProperties.Description"),
+			},
+			{
+				Name:        "mode",
+				Description: "The policy definition mode. Some examples are All, Indexed, Microsoft.KeyVault.Data.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DefinitionProperties.Mode"),
+			},
+			{
+				Name:        "policy_type",
+				Description: "The type of policy definition. Possible values are NotSpecified, BuiltIn, Custom, and Static. Possible values include: 'NotSpecified', 'BuiltIn', 'Custom', 'Static'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DefinitionProperties.PolicyType"),
+			},
+			{
 				Name:        "type",
 				Description: "The type of the resource (Microsoft.Authorization/policyDefinitions).",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Type"),
 			},
 			{
-				Name:        "definition_properties",
-				Description: "The policy definition properties.",
+				Name:        "metadata",
+				Description: "The policy definition metadata.  Metadata is an open ended object and is typically a collection of key value pairs.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("DefinitionProperties"),
+				Transform:   transform.FromField("DefinitionProperties.Metadata"),
+			},
+			{
+				Name:        "parameters",
+				Description: "The parameter definitions for parameters used in the policy rule. The keys are the parameter names.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("DefinitionProperties.Parameters"),
+			},
+			{
+				Name:        "policy_rule",
+				Description: "The policy rule.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("DefinitionProperties.PolicyRule"),
 			},
 			// Steampipe standard columns
 			{

--- a/azure/table_azure_policy_definition.go
+++ b/azure/table_azure_policy_definition.go
@@ -1,0 +1,129 @@
+package azure
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-09-01/policy"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+)
+
+//// TABLE DEFINITION
+
+func tableAzurePolicyDefinition(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "azure_policy_definition",
+		Description: "Azure Policy Definition",
+		// Get API operation is not working as expected, skipping for now
+		// Get: &plugin.GetConfig{
+		// 	KeyColumns: plugin.SingleColumn("name"),
+		// 	Hydrate:    getPolicyDefinition,
+		// },
+		List: &plugin.ListConfig{
+			Hydrate: listPolicyDefintions,
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "id",
+				Type:        proto.ColumnType_STRING,
+				Description: "The ID of the policy definition.",
+				Transform:   transform.FromField("ID"),
+			},
+			{
+				Name:        "name",
+				Description: "The name of the policy definition.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "display_name",
+				Description: "The user-friendly display name of the policy definition.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DefinitionProperties.DisplayName"),
+			},
+			{
+				Name:        "type",
+				Description: "The type of the resource (Microsoft.Authorization/policyDefinitions).",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Type"),
+			},
+			{
+				Name:        "definition_properties",
+				Description: "The policy definition properties.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("DefinitionProperties"),
+			},
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DefinitionProperties.DisplayName"),
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getPolicyDefinitionTurbotData,
+			},
+
+			// Azure standard columns
+			{
+				Name:        "subscription_id",
+				Description: ColumnDescriptionSubscription,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getPolicyDefinitionTurbotData,
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listPolicyDefintions(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptionID := session.SubscriptionID
+	PolicyClient := policy.NewDefinitionsClient(subscriptionID)
+	PolicyClient.Authorizer = session.Authorizer
+
+	policyList, err := PolicyClient.List(ctx)
+	if err != nil {
+		return err, nil
+	}
+
+	for _, policy := range policyList.Values() {
+		d.StreamListItem(ctx, policy)
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getPolicyDefinitionTurbotData(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getPolicyDefinitionTurbotData")
+	data := h.Item.(policy.Definition)
+
+	// Create session
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptionID := session.SubscriptionID
+	akas := []string{"azure:///subscriptions/" + subscriptionID + *data.ID, "azure:///subscriptions/" + subscriptionID + strings.ToLower(*data.ID)}
+
+	turbotData := map[string]interface{}{
+		"SubscriptionId": subscriptionID,
+		"Akas":           akas,
+	}
+
+	return turbotData, nil
+}

--- a/docs/tables/azure_policy_definition.md
+++ b/docs/tables/azure_policy_definition.md
@@ -15,11 +15,9 @@ select
   jsonb_pretty(policy_rule) as policy_rule
 from
   azure_policy_definition
-where
-  display_name = 'Private endpoint connections on Batch accounts should be enabled';
 ```
 
-### Get the policy definitions for a particular subscription
+### Get the policy definition by display name
 
 ```sql
 select
@@ -31,6 +29,5 @@ select
 from
   azure_policy_definition
 where
-  subscription_id = '3510ae4d-530b-497d-8f30-53b9616fc6c1';
+  display_name = 'Private endpoint connections on Batch accounts should be enabled';
 ```
-

--- a/docs/tables/azure_policy_definition.md
+++ b/docs/tables/azure_policy_definition.md
@@ -1,0 +1,34 @@
+# Table: azure_policy_definition
+
+Azure Policy establishes conventions for resources. Policy definitions describe resource compliance conditions and the effect to take if a condition is met. A condition compares a resource property field or a value to a required value.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  name,
+  display_name,
+  type
+from
+  azure_policy_definition
+where
+  display_name = 'Private endpoint connections on Batch accounts should be enabled';
+```
+
+### Get the policy definitions for a particular subscription
+
+```sql
+select
+  id,
+  name,
+  display_name,
+  type
+from
+  azure_policy_definition
+where
+  subscription_id = '3510ae4d-530b-497d-8f30-53b9616fc6c1';
+```
+

--- a/docs/tables/azure_policy_definition.md
+++ b/docs/tables/azure_policy_definition.md
@@ -11,7 +11,8 @@ select
   id,
   name,
   display_name,
-  type
+  type,
+  jsonb_pretty(policy_rule) as policy_rule
 from
   azure_policy_definition
 where
@@ -25,7 +26,8 @@ select
   id,
   name,
   display_name,
-  type
+  type,
+  jsonb_pretty(policy_rule) as policy_rule
 from
   azure_policy_definition
 where


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
pskrbasu@Puskars-MacBook-Pro azure-test (main) $ ./tint.js tests/azure_policy_definition
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_policy_definition []

PRETEST: tests/azure_policy_definition

TEST: tests/azure_policy_definition
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_policy_definition.named_test_resource: Creating...
azurerm_policy_definition.named_test_resource: Still creating... [10s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [20s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [30s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [40s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [50s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [1m0s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [1m10s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [1m20s elapsed]
azurerm_policy_definition.named_test_resource: Still creating... [1m30s elapsed]
azurerm_policy_definition.named_test_resource: Creation complete after 1m32s [id=/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/providers/Microsoft.Authorization/policyDefinitions/TestSecurityCenterBuiltIn]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/providers/Microsoft.Authorization/policyDefinitions/TestSecurityCenterBuiltIn
resource_aka_lower = azure:///subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/providers/microsoft.authorization/policydefinitions/testsecuritycenterbuiltin
resource_id = /subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/providers/Microsoft.Authorization/policyDefinitions/TestSecurityCenterBuiltIn
resource_name = TestSecurityCenterBuiltIn
subscription_id = 3510ae4d-530b-497d-8f30-53b9616fc6c1

Running SQL query: test-list-query.sql
[
  {
    "display_name": "TestSecurityCenterBuiltIn",
    "id": "/subscriptions/3510ae4d-530b-497d-8f30-53b9616fc6c1/providers/Microsoft.Authorization/policyDefinitions/TestSecurityCenterBuiltIn",
    "name": "TestSecurityCenterBuiltIn"
  }
]
✔ PASSED

POSTTEST: tests/azure_policy_definition

TEARDOWN: tests/azure_policy_definition

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id,
  name,
  display_name,
  type
from
  azure_policy_definition
where
  display_name = 'Private endpoint connections on Batch accounts should be enabled';
+-------------------------------------------------------------------------------------------+--------------------------------------+-----------------------------------
| id                                                                                        | name                                 | display_name                      
+-------------------------------------------------------------------------------------------+--------------------------------------+-----------------------------------
| /providers/Microsoft.Authorization/policyDefinitions/009a0c92-f5b4-4776-9b66-4ed2b4775563 | 009a0c92-f5b4-4776-9b66-4ed2b4775563 | Private endpoint connections on Ba
+-------------------------------------------------------------------------------------------+--------------------------------------+-----------------------------------
>
> select
  id,
  name,
  display_name,
  type
from
  azure_policy_definition
where
  subscription_id = '3510ae4d-530b-497d-8f30-53b9616fc6c1';
+-------------------------------------------------------------------------------------------+--------------------------------------+-----------------------------------
| id                                                                                        | name                                 | display_name                      
+-------------------------------------------------------------------------------------------+--------------------------------------+-----------------------------------
| /providers/Microsoft.Authorization/policyDefinitions/013e242c-8828-4970-87b3-ab247555486d | 013e242c-8828-4970-87b3-ab247555486d | Azure Backup should be enabled for
| /providers/Microsoft.Authorization/policyDefinitions/009a0c92-f5b4-4776-9b66-4ed2b4775563 | 009a0c92-f5b4-4776-9b66-4ed2b4775563 | Private endpoint connections on Ba
| /providers/Microsoft.Authorization/policyDefinitions/0049a6b3-a662-4f3e-8635-39cf44ace45a | 0049a6b3-a662-4f3e-8635-39cf44ace45a | Vulnerability assessment should be
| /providers/Microsoft.Authorization/policyDefinitions/00379355-8932-4b52-b63a-3bc6daf3451a | 00379355-8932-4b52-b63a-3bc6daf3451a | Microsoft Managed Control 1375 - I
| /providers/Microsoft.Authorization/policyDefinitions/0062eb8b-dc75-4718-8ea5-9bb4a9606655 | 0062eb8b-dc75-4718-8ea5-9bb4a9606655 | Microsoft Managed Control 1605 - D
| /providers/Microsoft.Authorization/policyDefinitions/0015ea4d-51ff-4ce3-8d8c-f3f8f0179a56 | 0015ea4d-51ff-4ce3-8d8c-f3f8f0179a56 | Audit virtual machines without dis
| /providers/Microsoft.Authorization/policyDefinitions/0088bc63-6dee-4a9c-9d29-91cfdc848952 | 0088bc63-6dee-4a9c-9d29-91cfdc848952 | SQL Server Integration Services in
| /providers/Microsoft.Authorization/policyDefinitions/0004bbf0-5099-4179-869e-e9ffe5fb0945 | 0004bbf0-5099-4179-869e-e9ffe5fb0945 | Microsoft Managed Control 1599 - D
| /providers/Microsoft.Authorization/policyDefinitions/01910bab-8639-4bd0-84ef-cc53b24d79ba | 01910bab-8639-4bd0-84ef-cc53b24d79ba | Microsoft Managed Control 1099 - S
| /providers/Microsoft.Authorization/policyDefinitions/027cae1c-ec3e-4492-9036-4168d540c42a | 027cae1c-ec3e-4492-9036-4168d540c42a | Microsoft Managed Control 1052 - S
| /providers/Microsoft.Authorization/policyDefinitions/001802d1-4969-4c82-a700-c29c6c6f9bbd | 001802d1-4969-4c82-a700-c29c6c6f9bbd | [Deprecated]: Audit Web Sockets st
| /providers/Microsoft.Authorization/policyDefinitions/01524fa8-4555-48ce-ba5f-c3b8dcef5147 | 01524fa8-4555-48ce-ba5f-c3b8dcef5147 | Microsoft Managed Control 1142 - S
| /providers/Microsoft.Authorization/policyDefinitions/01f7726b-db54-45c2-bcb5-9bd7a43796ee | 01f7726b-db54-45c2-bcb5-9bd7a43796ee | Microsoft Managed Control 1285 - T
| /providers/Microsoft.Authorization/policyDefinitions/025992d6-7fee-4137-9bbf-2ffc39c0686c | 025992d6-7fee-4137-9bbf-2ffc39c0686c | Microsoft Managed Control 1709 - S
| /providers/Microsoft.Authorization/policyDefinitions/0b60c0b2-2dc2-4e1c-b5c9-abbed971de53 | 0b60c0b2-2dc2-4e1c-b5c9-abbed971de53 | Key vaults should have purge prote
| /providers/Microsoft.Authorization/policyDefinitions/0a9991e6-21be-49f9-8916-a06d934bcf29 | 0a9991e6-21be-49f9-8916-a06d934bcf29 | [Deprecated]: Deploy prerequisites
| /providers/Microsoft.Authorization/policyDefinitions/0abbac52-57cf-450d-8408-1208d0dd9e90 | 0abbac52-57cf-450d-8408-1208d0dd9e90 | Microsoft Managed Control 1044 - U
| /providers/Microsoft.Authorization/policyDefinitions/0aa61e00-0a01-4a3c-9945-e93cffedf0e6 | 0aa61e00-0a01-4a3c-9945-e93cffedf0e6 | Azure Container Instance container

```
</details>
