### PR TITLE
Add lifecycle_management_policy details for storage account. Closes #146

### DIFF
--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -371,7 +371,7 @@ func tableAzureStorageAccount(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Account.AccountProperties.NetworkRuleSet.VirtualNetworkRules"),
 			},
 
-			// Standard columns
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: ColumnDescriptionTitle,
@@ -390,6 +390,8 @@ func tableAzureStorageAccount(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Account.ID").Transform(idToAkas),
 			},
+
+			// Azure standard columns
 			{
 				Name:        "region",
 				Description: ColumnDescriptionRegion,
@@ -486,19 +488,20 @@ func getAzureStorageAccountLifecycleManagementPolicy(ctx context.Context, d *plu
 		return nil, err
 	}
 
-		objectMap := make(map[string]interface{})
-		if op.ID != nil {
-			objectMap["id"] = op.ID
-		}
-		if op.Name != nil {
-			objectMap["name"] = op.Name
-		}
-		if op.Type != nil {
-			objectMap["type"] = op.Type
-		}
-		if op.ManagementPolicyProperties != nil {
-			objectMap["properties"] = op.ManagementPolicyProperties
-		}
+	// Direct assignment returns ManagementPolicyProperties only
+	objectMap := make(map[string]interface{})
+	if op.ID != nil {
+		objectMap["id"] = op.ID
+	}
+	if op.Name != nil {
+		objectMap["name"] = op.Name
+	}
+	if op.Type != nil {
+		objectMap["type"] = op.Type
+	}
+	if op.ManagementPolicyProperties != nil {
+		objectMap["properties"] = op.ManagementPolicyProperties
+	}
 
 	return objectMap, nil
 }

--- a/docs/tables/azure_storage_account.md
+++ b/docs/tables/azure_storage_account.md
@@ -105,3 +105,16 @@ where
   and queue_logging_read
   and queue_logging_write;
 ```
+
+
+### List storage accounts without lifecycle
+
+```sql
+select
+  name,
+  lifecycle_management_policy -> 'properties' -> 'policy' -> 'rules' as lifecycle_rules
+from
+  azure_storage_account
+where
+  lifecycle_rules is null;
+```

--- a/docs/tables/azure_storage_account.md
+++ b/docs/tables/azure_storage_account.md
@@ -116,5 +116,5 @@ select
 from
   azure_storage_account
 where
-  lifecycle_rules is null;
+  lifecycle_management_policy -> 'properties' -> 'policy' -> 'rules' is null;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/azure_storage_account []

PRETEST: tests/azure_storage_account

TEST: tests/azure_storage_account
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 33s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097
resource_aka_lower = azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest43097/providers/microsoft.storage/storageaccounts/turbottest43097
resource_id = /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097
resource_name = turbottest43097

Running SQL query: test-get-query.sql
[
  {
    "access_tier": "Cool",
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097",
    "kind": "StorageV2",
    "name": "turbottest43097",
    "sku_name": "Standard_LRS",
    "sku_tier": "Standard"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_tier": "Cool",
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097",
    "name": "turbottest43097"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097",
    "name": "turbottest43097"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest43097/providers/Microsoft.Storage/storageAccounts/turbottest43097",
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest43097/providers/microsoft.storage/storageaccounts/turbottest43097"
    ],
    "tags": {
      "name": "turbottest43097"
    },
    "title": "turbottest43097"
  }
]
✔ PASSED

POSTTEST: tests/azure_storage_account

TEARDOWN: tests/azure_storage_account

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List storage accounts without lifecycle

```sql
select
  name,
  lifecycle_management_policy -> 'properties' -> 'policy' -> 'rules' as lifecycle_rules
from
  azure_storage_account
where
  lifecycle_rules is null;
```
```
+--------------------------+-----------------+
| name                     | lifecycle_rules |
+--------------------------+-----------------+
| testsumitstorageaccount1 | <null>          |
| sqlvaskpahgwu6znae       | <null>          |
| testsumitstorageclassic  | <null>          |
+--------------------------+-----------------+
```
</details>
