### PR TITLE
Changing parent to resourceGroup to remove duplicate network gateway entry. Closes #180

### DIFF
--- a/azure/table_azure_virtual_network_gateway.go
+++ b/azure/table_azure_virtual_network_gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -22,7 +23,7 @@ func tableAzureVirtualNetworkGateway(_ context.Context) *plugin.Table {
 			ShouldIgnoreError: isNotFoundError([]string{"ResourceGroupNotFound", "ResourceNotFound", "404"}),
 		},
 		List: &plugin.ListConfig{
-			ParentHydrate: listVirtualNetworks,
+			ParentHydrate: listResourceGroups,
 			Hydrate:       listVirtualNetworkGateways,
 		},
 		Columns: []*plugin.Column{
@@ -217,8 +218,8 @@ func listVirtualNetworkGateways(ctx context.Context, d *plugin.QueryData, h *plu
 	networkClient := network.NewVirtualNetworkGatewaysClient(subscriptionID)
 	networkClient.Authorizer = session.Authorizer
 
-	virtualNetwork := h.Item.(network.VirtualNetwork)
-	resourceGroupName := strings.Split(*virtualNetwork.ID, "/")[4]
+	data := h.Item.(resources.Group)
+	resourceGroupName := *data.Name
 
 	pagesLeft := true
 	for pagesLeft {


### PR DESCRIPTION
**_Bug Fixes_**
- Earlier network gateway resource has dependency on `virtual network` resource, hence table stores duplicate resources, whenever more than one `virtual network` resource is present in a resourceGroup.
Currently, the dependency has been updated, to list the resource based on available `resource group`.

`Earlier Response`
```
> select name, id from azure_virtual_network_gateway;
+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
| name               | id                                                                                                                                                  |
+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
| test               | /subscriptions/********-****-****-****-************/resourceGroups/abcd-test1/providers/Microsoft.Network/virtualNetworkGateways/test               |
| express-route-test | /subscriptions/********-****-****-****-************/resourceGroups/abcd-test1/providers/Microsoft.Network/virtualNetworkGateways/express-route-test |
| test               | /subscriptions/********-****-****-****-************/resourceGroups/abcd-test1/providers/Microsoft.Network/virtualNetworkGateways/test               |
| express-route-test | /subscriptions/********-****-****-****-************/resourceGroups/abcd-test1/providers/Microsoft.Network/virtualNetworkGateways/express-route-test |
+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
```

`Current Response`
```
> select name, id from azure_virtual_network_gateway;
+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
| name               | id                                                                                                                                                  |
+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
| express-route-test | /subscriptions/********-****-****-****-************/resourceGroups/abcd-test1/providers/Microsoft.Network/virtualNetworkGateways/express-route-test |
| test               | /subscriptions/********-****-****-****-************/resourceGroups/abcd-test1/providers/Microsoft.Network/virtualNetworkGateways/test               |
+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+
```

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
