### PR TITLE
Add NetworkAcls details in table azure_key_vault.Closes #208

### DIFF
--- a/azure/table_azure_key_vault.go
+++ b/azure/table_azure_key_vault.go
@@ -139,6 +139,13 @@ func tableAzureKeyVault(_ context.Context) *plugin.Table {
 				Hydrate:     listKmsKeyVaultDiagnosticSettings,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "network_acls",
+				Description: "Rules governing the accessibility of the key vault from specific network locations.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getKeyVault,
+				Transform:   transform.FromField("Properties.NetworkAcls"),
+			},
 
 			// Steampipe standard columns
 			{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_key_vault []

PRETEST: tests/azure_key_vault

TEST: tests/azure_key_vault
Running terraform
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 5s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219]
azurerm_key_vault.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Creating...
azurerm_key_vault.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [21s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [31s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [40s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [41s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 45s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.Storage/storageAccounts/turbottest55219]
azurerm_key_vault.named_test_resource: Still creating... [51s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m1s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m11s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m21s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m31s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m41s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m51s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m1s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m11s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m21s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m31s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m41s elapsed]
azurerm_key_vault.named_test_resource: Creation complete after 2m41s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219]
azurerm_key_vault_access_policy.named_test_resource: Creating...
azurerm_monitor_diagnostic_setting.named_test_resource: Creating...
azurerm_key_vault_access_policy.named_test_resource: Still creating... [10s elapsed]
azurerm_monitor_diagnostic_setting.named_test_resource: Still creating... [10s elapsed]
azurerm_monitor_diagnostic_setting.named_test_resource: Creation complete after 13s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219|turbottest55219]
azurerm_key_vault_access_policy.named_test_resource: Creation complete after 15s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219/objectId/959adfaa-3632-4f37-85a2-ef002bd72f9e]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

object_id = "959adfaa-3632-4f37-85a2-ef002bd72f9e"
resource_aka = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219"
resource_aka_lower = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest55219/providers/microsoft.keyvault/vaults/turbottest55219"
resource_id = "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219"
resource_name = "turbottest55219"
storage_account_id = "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.Storage/storageAccounts/turbottest55219"
subscription_id = "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8"
tenant_id = "cdffd708-7da0-4cea-abeb-0a4c334d7f64"

Running SQL query: test-get-query.sql
[
  {
    "enabled_for_deployment": false,
    "enabled_for_disk_encryption": false,
    "enabled_for_template_deployment": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219",
    "name": "turbottest55219",
    "region": "westus",
    "resource_group": "turbottest55219",
    "sku_name": "standard",
    "tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "type": "Microsoft.KeyVault/vaults",
    "vault_uri": "https://turbottest55219.vault.azure.net/"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_policies": [
      {
        "objectId": "959adfaa-3632-4f37-85a2-ef002bd72f9e",
        "permissions": {
          "certificates": [],
          "keys": [
            "get"
          ],
          "secrets": [
            "get"
          ],
          "storage": []
        },
        "tenantId": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
      }
    ],
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest55219/providers/microsoft.keyvault/vaults/turbottest55219"
    ],
    "name": "turbottest55219",
    "tags": {
      "name": "turbottest55219"
    },
    "title": "turbottest55219"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219",
    "name": "turbottest55219"
  }
]
✔ PASSED

Running SQL query: test-logging-query.sql
[
  {
    "category": "AuditEvent",
    "log_retention_days": 30,
    "name": "turbottest55219",
    "storage_account_id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.Storage/storageAccounts/turbottest55219"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest55219/providers/Microsoft.KeyVault/vaults/turbottest55219",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest55219/providers/microsoft.keyvault/vaults/turbottest55219"
    ],
    "name": "turbottest55219",
    "tags": {
      "name": "turbottest55219"
    },
    "title": "turbottest55219"
  }
]
✔ PASSED

POSTTEST: tests/azure_key_vault

TEARDOWN: tests/azure_key_vault

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, network_acls from azure_key_vault
+----------+-----------------------------------------------------------------------------------------+
| name     | network_acls                                                                            |
+----------+-----------------------------------------------------------------------------------------+
| testkv65 | {"bypass":"AzureServices","defaultAction":"Deny","ipRules":[],"virtualNetworkRules":[]} |
+----------+-----------------------------------------------------------------------------------------+
```
</details>
