### PR TITLE
Add Diagnostic settings details in table azure_servicebus_namespace. Closes #215

### DIFF
--- a/azure/table_azure_servicebus_namespace.go
+++ b/azure/table_azure_servicebus_namespace.go
@@ -98,7 +98,7 @@ func tableAzureServiceBusNamespace(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "diagnostic_settings",
-				Description: "A list of active diagnostic settings for the resource.",
+				Description: "A list of active diagnostic settings for the servicebus namespace.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listServiceBusNamespaceDiagnosticSettings,
 				Transform:   transform.FromValue(),

--- a/azure/table_azure_servicebus_namespace.go
+++ b/azure/table_azure_servicebus_namespace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
 	"github.com/Azure/azure-sdk-for-go/services/preview/servicebus/mgmt/2018-01-01-preview/servicebus"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -94,6 +95,13 @@ func tableAzureServiceBusNamespace(_ context.Context) *plugin.Table {
 				Description: "The time the namespace was updated.",
 				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("SBNamespaceProperties.UpdatedAt").Transform(convertDateToTime),
+			},
+			{
+				Name:        "diagnostic_settings",
+				Description: "A list of active diagnostic settings for the resource.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listServiceBusNamespaceDiagnosticSettings,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "encryption",
@@ -235,4 +243,45 @@ func getServiceBusNamespaceNetworkRuleSet(ctx context.Context, d *plugin.QueryDa
 	}
 
 	return op, nil
+}
+
+func listServiceBusNamespaceDiagnosticSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listServiceBusNamespaceDiagnosticSettings")
+	id := *h.Item.(servicebus.SBNamespace).ID
+
+	// Create session
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	client := insights.NewDiagnosticSettingsClient(subscriptionID)
+	client.Authorizer = session.Authorizer
+
+	op, err := client.List(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we return the API response directly, the output only gives
+	// the contents of DiagnosticSettings
+	var diagnosticSettings []map[string]interface{}
+	for _, i := range *op.Value {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.DiagnosticSettings != nil {
+			objectMap["properties"] = i.DiagnosticSettings
+		}
+		diagnosticSettings = append(diagnosticSettings, objectMap)
+	}
+	return diagnosticSettings, nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_servicebus_namespace []

PRETEST: tests/azure_servicebus_namespace

TEST: tests/azure_servicebus_namespace
Running terraform
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 5s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576]
azurerm_servicebus_namespace.named_test_resource: Creating...
azurerm_servicebus_namespace.named_test_resource: Still creating... [10s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [20s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [30s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [40s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [50s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [1m0s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [1m10s elapsed]
azurerm_servicebus_namespace.named_test_resource: Creation complete after 1m15s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version = "=2.41.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576"
resource_aka_lower = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest35576/providers/microsoft.servicebus/namespaces/turbottest35576"
resource_id = "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576"
resource_name = "turbottest35576"
subscription_id = "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8"

Running SQL query: test-get-query.sql
[
  {
    "encryption": null,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576",
    "name": "turbottest35576",
    "network_rule_set": {
      "properties": {
        "defaultAction": "Deny",
        "ipRules": [],
        "virtualNetworkRules": []
      }
    },
    "provisioning_state": "Succeeded",
    "servicebus_endpoint": "https://turbottest35576.servicebus.windows.net:443/",
    "sku_name": "Basic",
    "sku_tier": "Basic",
    "type": "Microsoft.ServiceBus/Namespaces",
    "zone_redundant": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576",
    "name": "turbottest35576"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest35576/providers/microsoft.servicebus/namespaces/turbottest35576"
    ],
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest35576/providers/Microsoft.ServiceBus/namespaces/turbottest35576",
    "name": "turbottest35576",
    "region": "eastus",
    "resource_group": "turbottest35576",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "tags": {
      "name": "turbottest35576"
    },
    "title": "turbottest35576"
  }
]
✔ PASSED

POSTTEST: tests/azure_servicebus_namespace

TEARDOWN: tests/azure_servicebus_namespace

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,diagnostic_settings from azure_servicebus_namespace
+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name   | diagnostic_settings                                                                                                                                                                              
+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| terteq | [{"id":"/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbot_rg/providers/microsoft.servicebus/namespaces/terteq/providers/microsoft.insights/diagnosticSettings/test","name
+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
