### PR TITLE
Add Diagnostic settings details in table azure_eventhub_namespace. Closes #212

### DIFF
--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -118,6 +119,13 @@ func tableAzureEventHubNamespace(_ context.Context) *plugin.Table {
 				Description: "Enabling this property creates a standard event hubs namespace in regions supported availability zones.",
 				Type:        proto.ColumnType_BOOL,
 				Transform:   transform.FromField("EHNamespaceProperties.ZoneRedundant"),
+			},
+			{
+				Name:        "diagnostic_settings",
+				Description: "A list of active diagnostic settings for the resource.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listEventHubNamespaceDiagnosticSettings,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "encryption",
@@ -264,4 +272,45 @@ func getNetworkRuleSet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	}
 
 	return op, nil
+}
+
+func listEventHubNamespaceDiagnosticSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listEventHubNamespaceDiagnosticSettings")
+	id := *h.Item.(eventhub.EHNamespace).ID
+
+	// Create session
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	client := insights.NewDiagnosticSettingsClient(subscriptionID)
+	client.Authorizer = session.Authorizer
+
+	op, err := client.List(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we return the API response directly, the output only gives
+	// the contents of DiagnosticSettings
+	var diagnosticSettings []map[string]interface{}
+	for _, i := range *op.Value {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.DiagnosticSettings != nil {
+			objectMap["properties"] = i.DiagnosticSettings
+		}
+		diagnosticSettings = append(diagnosticSettings, objectMap)
+	}
+	return diagnosticSettings, nil
 }

--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -122,7 +122,7 @@ func tableAzureEventHubNamespace(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "diagnostic_settings",
-				Description: "A list of active diagnostic settings for the resource.",
+				Description: "A list of active diagnostic settings for the eventhub namespace.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listEventHubNamespaceDiagnosticSettings,
 				Transform:   transform.FromValue(),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_eventhub_namespace []

PRETEST: tests/azure_eventhub_namespace

TEST: tests/azure_eventhub_namespace
Running terraform
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299]
azurerm_eventhub_namespace.named_test_resource: Creating...
azurerm_eventhub_namespace.named_test_resource: Still creating... [10s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [20s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [30s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [40s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [50s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [1m0s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [1m10s elapsed]
azurerm_eventhub_namespace.named_test_resource: Creation complete after 1m17s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "westus"
resource_aka = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299"
resource_aka_lower = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest24299/providers/microsoft.eventhub/namespaces/turbottest24299"
resource_id = "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299"
resource_name = "turbottest24299"
subscription_id = "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299",
    "is_auto_inflate_enabled": false,
    "kafka_enabled": true,
    "name": "turbottest24299",
    "region": "westus",
    "resource_group": "turbottest24299",
    "type": "Microsoft.EventHub/Namespaces"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest24299/providers/microsoft.eventhub/namespaces/turbottest24299"
    ],
    "name": "turbottest24299",
    "tags": {
      "name": "turbottest24299"
    },
    "title": "turbottest24299"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299",
    "name": "turbottest24299"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest24299/providers/Microsoft.EventHub/namespaces/turbottest24299",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest24299/providers/microsoft.eventhub/namespaces/turbottest24299"
    ],
    "name": "turbottest24299",
    "tags": {
      "name": "turbottest24299"
    },
    "title": "turbottest24299"
  }
]
✔ PASSED

POSTTEST: tests/azure_eventhub_namespace

TEARDOWN: tests/azure_eventhub_namespace

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,diagnostic_settings from azure_eventhub_namespace
+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name   | diagnostic_settings                                                                                                                                                                              
+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| wqerer | [{"id":"/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbot_rg/providers/microsoft.eventhub/namespaces/wqerer/providers/microsoft.insights/diagnosticSettings/rewr","name":
|        | /d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbot_rg/providers/Microsoft.Storage/storageAccounts/tertq"},"type":"Microsoft.Insights/diagnosticSettings"}]                              
+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
