### PR TITLE
Add Virtual Network Rules details in table azure_sql_server. Closes #210

### DIFF
--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -515,7 +515,7 @@ func listSQLServerVirtualNetworkRules(ctx context.Context, d *plugin.QueryData, 
 	client.Authorizer = session.Authorizer
 
 	// If we return the API response directly, the output only gives
-	// the contents of FirewallRuleProperties
+	// the contents of VirtualNetworkRuleProperties
 	var NetworkRules []map[string]interface{}
 
 	pagesLeft := true


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_sql_server []

PRETEST: tests/azure_sql_server

TEST: tests/azure_sql_server
Running terraform
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 37s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Storage/storageAccounts/turbottest93390]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m22s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version = "=2.50.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.


Warning: "extended_auditing_policy": [DEPRECATED] the `extended_auditing_policy` block has been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.

  on variables.tf line 48, in resource "azurerm_sql_server" "named_test_resource":
  48: resource "azurerm_sql_server" "named_test_resource" {



Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390"
resource_aka_lower = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest93390/providers/microsoft.sql/servers/turbottest93390"
resource_id = "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390"
resource_name = "turbottest93390"
subscription_id = "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8"

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "fully_qualified_domain_name": "turbottest93390.database.windows.net",
    "kind": "v12.0",
    "location": "eastus",
    "name": "turbottest93390",
    "region": "eastus",
    "resource_group": "turbottest93390",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "tags_src": {
      "name": "turbottest93390"
    },
    "type": "Microsoft.Sql/servers",
    "version": "12.0"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "encryption_protector": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390/encryptionProtector/current",
        "kind": "servicemanaged",
        "name": "current",
        "properties": {
          "serverKeyName": "ServiceManaged",
          "serverKeyType": "ServiceManaged"
        },
        "type": "Microsoft.Sql/servers/encryptionProtector"
      }
    ],
    "firewall_rules": [],
    "name": "turbottest93390",
    "server_audit_policy": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390/auditingSettings/Default",
        "name": "Default",
        "properties": {
          "auditActionsAndGroups": [
            "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
            "FAILED_DATABASE_AUTHENTICATION_GROUP",
            "BATCH_COMPLETED_GROUP"
          ],
          "isAzureMonitorTargetEnabled": true,
          "isStorageSecondaryKeyInUse": true,
          "retentionDays": 6,
          "state": "Enabled",
          "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
          "storageEndpoint": "https://turbottest93390.blob.core.windows.net/"
        },
        "type": "Microsoft.Sql/servers/auditingSettings"
      }
    ],
    "server_azure_ad_administrator": null,
    "server_security_alert_policy": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390/securityAlertPolicies/Default",
        "name": "Default",
        "properties": {
          "disabledAlerts": [
            ""
          ],
          "emailAccountAdmins": false,
          "emailAddresses": [
            ""
          ],
          "retentionDays": 0,
          "state": "Disabled",
          "storageAccountAccessKey": "",
          "storageEndpoint": ""
        },
        "type": "Microsoft.Sql/servers/securityAlertPolicies"
      }
    ],
    "server_vulnerability_assessment": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390/vulnerabilityAssessments/Default",
        "name": "Default",
        "properties": {
          "recurringScans": {
            "emailSubscriptionAdmins": true,
            "isEnabled": false
          }
        },
        "type": "Microsoft.Sql/servers/vulnerabilityAssessments"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390",
    "location": "eastus",
    "name": "turbottest93390"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest93390/providers/Microsoft.Sql/servers/turbottest93390",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest93390/providers/microsoft.sql/servers/turbottest93390"
    ],
    "name": "turbottest93390",
    "title": "turbottest93390"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_server

TEARDOWN: tests/azure_sql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,virtual_network_rules from azure_sql_server
+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name      | virtual_network_rules                                                                                                                                                                         
+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| turbot-db | [{"id":"/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/turbot-db/virtualNetworkRules/newVnetRule1","name":"newVnetRule1","proper
+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
