### PR TITLE
Add type details of extensions for table azure_compute_virtual_machine closes #216

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -548,6 +548,7 @@ func getAzureComputeVirtualMachineExtensions(ctx context.Context, d *plugin.Quer
 		extensionMap["Type"] = extension.Type
 		extensionMap["Location"] = extension.Location
 		extensionMap["Publisher"] = extension.VirtualMachineExtensionProperties.Publisher
+		extensionMap["ExtensionType"] = extension.VirtualMachineExtensionProperties.Type
 		extensionMap["TypeHandlerVersion"] = extension.VirtualMachineExtensionProperties.TypeHandlerVersion
 		extensionMap["AutoUpgradeMinorVersion"] = extension.VirtualMachineExtensionProperties.AutoUpgradeMinorVersion
 		extensionMap["EnableAutomaticUpgrade"] = extension.VirtualMachineExtensionProperties.EnableAutomaticUpgrade


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_virtual_machine []

PRETEST: tests/azure_compute_virtual_machine

TEST: tests/azure_compute_virtual_machine
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Creation complete after 7s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Network/virtualNetworks/turbottest32867]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 4s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Network/virtualNetworks/turbottest32867/subnets/turbottest32867]
azurerm_network_interface.named_test_resource: Creating...
azurerm_network_interface.named_test_resource: Still creating... [10s elapsed]
azurerm_network_interface.named_test_resource: Creation complete after 11s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Network/networkInterfaces/turbottest32867]
azurerm_virtual_machine.named_test_resource: Creating...
azurerm_virtual_machine.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [20s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [30s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [40s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [50s elapsed]
azurerm_virtual_machine.named_test_resource: Creation complete after 51s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Compute/virtualMachines/turbottest32867]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Compute/virtualMachines/turbottest32867
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest32867/providers/microsoft.compute/virtualmachines/turbottest32867
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Compute/virtualMachines/turbottest32867
resource_name = turbottest32867
resource_name_upper = TURBOTTEST32867
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Compute/virtualMachines/turbottest32867",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest32867",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest32867",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest32867",
    "size": "Standard_DS1_v2",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Compute/virtualMachines/turbottest32867",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest32867",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest32867",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest32867",
    "size": "Standard_DS1_v2",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/TURBOTTEST32867/providers/Microsoft.Compute/virtualMachines/turbottest32867",
    "name": "turbottest32867",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest32867/providers/Microsoft.Compute/virtualMachines/turbottest32867",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest32867/providers/microsoft.compute/virtualmachines/turbottest32867"
    ],
    "name": "turbottest32867",
    "tags": {
      "name": "turbottest32867"
    },
    "title": "turbottest32867"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_virtual_machine

TEARDOWN: tests/azure_compute_virtual_machine

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, extensions from azure_compute_virtual_machine;
```

```
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name  | extensions                                                                                                                                                                                        
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| my-vm | [{"AutoUpgradeMinorVersion":true,"EnableAutomaticUpgrade":null,"ExtensionType":"Site24x7LinuxServerExtn","ForceUpdateTag":null,"Id":"/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceG
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>

Note: The property added in `extentions` column with name `ExtensionType` because there was a property `Type` already available.