### PR TITLE
Not getting firewall_rules for table azure_sql_server. closes #228

### DIFF
--- a/azure-test/tests/azure_sql_server/test-hydrate-expected.json
+++ b/azure-test/tests/azure_sql_server/test-hydrate-expected.json
@@ -12,7 +12,17 @@
 				"type": "Microsoft.Sql/servers/encryptionProtector"
 			}
 		],
-		"firewall_rules": [],
+		"firewall_rules": [
+			{
+				"id": "{{ output.firewall_rule_id.value }}",
+				"name": "{{ resourceName }}",
+				"properties":{
+					"endIpAddress":"10.0.17.62",
+					"startIpAddress":"10.0.17.62"
+				},
+				"type": "Microsoft.Sql/servers/firewallRules"
+			}
+		],
 		"name": "{{ resourceName }}",
 		"server_audit_policy": [
 			{

--- a/azure-test/tests/azure_sql_server/variables.tf
+++ b/azure-test/tests/azure_sql_server/variables.tf
@@ -66,6 +66,14 @@ resource "azurerm_sql_server" "named_test_resource" {
   }
 }
 
+resource "azurerm_sql_firewall_rule" "named_test_resource" {
+  name                = var.resource_name
+  resource_group_name = azurerm_resource_group.named_test_resource.name
+  server_name         = azurerm_sql_server.named_test_resource.name
+  start_ip_address    = "10.0.17.62"
+  end_ip_address      = "10.0.17.62"
+}
+
 output "resource_aka" {
   value = "azure://${azurerm_sql_server.named_test_resource.id}"
 }
@@ -76,6 +84,10 @@ output "resource_aka_lower" {
 
 output "resource_name" {
   value = var.resource_name
+}
+
+output "firewall_rule_id" {
+  value = azurerm_sql_firewall_rule.named_test_resource.id
 }
 
 output "resource_id" {

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -473,10 +473,6 @@ func listSQLServerFirewallRules(ctx context.Context, d *plugin.QueryData, h *plu
 		return nil, err
 	}
 
-	if op.Value != nil {
-		return op.Value, nil
-	}
-
 	// If we return the API response directly, the output only gives
 	// the contents of FirewallRuleProperties
 	var firewallRules []map[string]interface{}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_sql_server []

PRETEST: tests/azure_sql_server

TEST: tests/azure_sql_server
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 34s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Storage/storageAccounts/turbottest72057]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m20s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057]
azurerm_sql_firewall_rule.named_test_resource: Creating...
azurerm_sql_firewall_rule.named_test_resource: Creation complete after 5s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/firewallRules/turbottest72057]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: "extended_auditing_policy": [DEPRECATED] the `extended_auditing_policy` block has been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.

  on variables.tf line 49, in resource "azurerm_sql_server" "named_test_resource":
  49: resource "azurerm_sql_server" "named_test_resource" {



Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

firewall_rule_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/firewallRules/turbottest72057
location = eastus
resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest72057/providers/microsoft.sql/servers/turbottest72057
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057
resource_name = turbottest72057
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "fully_qualified_domain_name": "turbottest72057.database.windows.net",
    "kind": "v12.0",
    "location": "eastus",
    "name": "turbottest72057",
    "region": "eastus",
    "resource_group": "turbottest72057",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "tags_src": {
      "name": "turbottest72057"
    },
    "type": "Microsoft.Sql/servers",
    "version": "12.0"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "encryption_protector": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/encryptionProtector/current",
        "kind": "servicemanaged",
        "name": "current",
        "properties": {
          "serverKeyName": "ServiceManaged",
          "serverKeyType": "ServiceManaged"
        },
        "type": "Microsoft.Sql/servers/encryptionProtector"
      }
    ],
    "firewall_rules": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/firewallRules/turbottest72057",
        "name": "turbottest72057",
        "properties": {
          "endIpAddress": "10.0.17.62",
          "startIpAddress": "10.0.17.62"
        },
        "type": "Microsoft.Sql/servers/firewallRules"
      }
    ],
    "name": "turbottest72057",
    "server_audit_policy": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/auditingSettings/Default",
        "name": "Default",
        "properties": {
          "auditActionsAndGroups": [
            "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
            "FAILED_DATABASE_AUTHENTICATION_GROUP",
            "BATCH_COMPLETED_GROUP"
          ],
          "isAzureMonitorTargetEnabled": true,
          "isStorageSecondaryKeyInUse": true,
          "retentionDays": 6,
          "state": "Enabled",
          "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
          "storageEndpoint": "https://turbottest72057.blob.core.windows.net/"
        },
        "type": "Microsoft.Sql/servers/auditingSettings"
      }
    ],
    "server_azure_ad_administrator": null,
    "server_security_alert_policy": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/securityAlertPolicies/Default",
        "name": "Default",
        "properties": {
          "disabledAlerts": [
            ""
          ],
          "emailAccountAdmins": false,
          "emailAddresses": [
            ""
          ],
          "retentionDays": 0,
          "state": "Disabled",
          "storageAccountAccessKey": "",
          "storageEndpoint": ""
        },
        "type": "Microsoft.Sql/servers/securityAlertPolicies"
      }
    ],
    "server_vulnerability_assessment": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057/vulnerabilityAssessments/Default",
        "name": "Default",
        "properties": {
          "recurringScans": {
            "emailSubscriptionAdmins": true,
            "isEnabled": false
          }
        },
        "type": "Microsoft.Sql/servers/vulnerabilityAssessments"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057",
    "location": "eastus",
    "name": "turbottest72057"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest72057/providers/Microsoft.Sql/servers/turbottest72057",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest72057/providers/microsoft.sql/servers/turbottest72057"
    ],
    "name": "turbottest72057",
    "title": "turbottest72057"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_server

TEARDOWN: tests/azure_sql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, id, firewall_rules from azure_sql_server;
```

```
+-----------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name      | id                                                                                                                     | firewall_rules                                                                                                                                                                                                                                                                                       |
+-----------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| turbot-db | /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/turbot-db | [{"id":"/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/turbot-db/firewallRules/publicaccess","name":"publicaccess","properties":{"endIpAddress":"10.0.3.0","startIpAddress":"10.0.0.0"},"type":"Microsoft.Sql/servers/firewallRules"}] |
+-----------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

</details>
