### PR TITLE
Add `diagnostic_settings` column in `azure_network_security_group` table. Closes #244

### DIFF
--- a/azure/table_azure_network_security_group.go
+++ b/azure/table_azure_network_security_group.go
@@ -11,7 +11,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
-//// TABLE DEFINITION ////
+//// TABLE DEFINITION
 
 func tableAzureNetworkSecurityGroup(_ context.Context) *plugin.Table {
 	return &plugin.Table{
@@ -97,7 +97,7 @@ func tableAzureNetworkSecurityGroup(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("SecurityGroupPropertiesFormat.Subnets"),
 			},
 
-			// Standard columns
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: ColumnDescriptionTitle,
@@ -115,6 +115,8 @@ func tableAzureNetworkSecurityGroup(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("ID").Transform(idToAkas),
 			},
+
+			// Azure standard columns
 			{
 				Name:        "region",
 				Description: ColumnDescriptionRegion,
@@ -137,7 +139,7 @@ func tableAzureNetworkSecurityGroup(_ context.Context) *plugin.Table {
 	}
 }
 
-//// FETCH FUNCTIONS ////
+//// LIST FUNCTION
 
 func listNetworkSecurityGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
@@ -165,7 +167,7 @@ func listNetworkSecurityGroups(ctx context.Context, d *plugin.QueryData, _ *plug
 	return nil, err
 }
 
-//// HYDRATE FUNCTIONS ////
+//// HYDRATE FUNCTIONS
 
 func getNetworkSecurityGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getNetworkSecurityGroup")


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/azure_network_security_group []

PRETEST: tests/azure_network_security_group

TEST: tests/azure_network_security_group
Running terraform
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666]
azurerm_network_security_group.named_test_resource: Creating...
azurerm_network_security_group.named_test_resource: Still creating... [10s elapsed]
azurerm_network_security_group.named_test_resource: Creation complete after 11s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666"
resource_aka_lower = "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest14666/providers/microsoft.network/networksecuritygroups/turbottest14666"
resource_id = "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666"
resource_name = "turbottest14666"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666",
    "name": "turbottest14666",
    "region": "westus",
    "resource_group": "turbottest14666",
    "security_rules": [
      {
        "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666/securityRules/turbottest14666",
        "name": "turbottest14666",
        "properties": {
          "access": "Allow",
          "destinationAddressPrefix": "*",
          "destinationAddressPrefixes": [],
          "destinationPortRange": "*",
          "destinationPortRanges": [],
          "direction": "Inbound",
          "priority": 100,
          "protocol": "Tcp",
          "sourceAddressPrefix": "*",
          "sourceAddressPrefixes": [],
          "sourcePortRange": "*",
          "sourcePortRanges": []
        }
      }
    ],
    "type": "Microsoft.Network/networkSecurityGroups"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest14666/providers/microsoft.network/networksecuritygroups/turbottest14666"
    ],
    "name": "turbottest14666"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666",
    "name": "turbottest14666"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest14666/providers/Microsoft.Network/networkSecurityGroups/turbottest14666",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest14666/providers/microsoft.network/networksecuritygroups/turbottest14666"
    ],
    "name": "turbottest14666",
    "tags": {
      "name": "turbottest14666"
    },
    "title": "turbottest14666"
  }
]
✔ PASSED

POSTTEST: tests/azure_network_security_group

TEARDOWN: tests/azure_network_security_group

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,diagnostic_settings from azure_network_security_group where name ='basicNsgdemo-vnet-nic01'
+-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name                    | diagnostic_settings                                                                                                                                                             
+-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| basicNsgdemo-vnet-nic01 | [{"id":"/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/demo/providers/microsoft.network/networksecuritygroups/basicnsgdemo-vnet-nic01/providers/microsoft.in
+-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
