### PR TITLE
Add Long Term Retention Policies details in table azure_sql_database closes #219

### DIFF
--- a/azure-test/tests/azure_sql_database/test-get-query.sql
+++ b/azure-test/tests/azure_sql_database/test-get-query.sql
@@ -1,6 +1,4 @@
 select name, id, server_name, status, type, containment_state, default_secondary_location, earliest_restore_date, edition, elastic_pool_name, location,max_size_bytes, zone_redundant, requested_service_objective_name, service_level_objective,transparent_data_encryption, title, tags, akas, region, resource_group, subscription_id
 from
   azure.azure_sql_database
-where
-  name = '{{ resourceName }}'
-  and resource_group = '{{ resourceName }}';
+where name = '{{ resourceName }}' and resource_group = '{{ resourceName }}';

--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -548,6 +548,7 @@ func getAzureComputeVirtualMachineExtensions(ctx context.Context, d *plugin.Quer
 		extensionMap["Type"] = extension.Type
 		extensionMap["Location"] = extension.Location
 		extensionMap["Publisher"] = extension.VirtualMachineExtensionProperties.Publisher
+		extensionMap["ExtensionType"] = extension.VirtualMachineExtensionProperties.Type
 		extensionMap["TypeHandlerVersion"] = extension.VirtualMachineExtensionProperties.TypeHandlerVersion
 		extensionMap["AutoUpgradeMinorVersion"] = extension.VirtualMachineExtensionProperties.AutoUpgradeMinorVersion
 		extensionMap["EnableAutomaticUpgrade"] = extension.VirtualMachineExtensionProperties.EnableAutomaticUpgrade

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -150,24 +150,6 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DatabaseProperties.RestorePointInTime").Transform(convertDateToTime),
 			},
 			{
-				Name:        "source_database_deletion_date",
-				Description: "Specifies the time that the database was deleted when createMode is Restore and sourceDatabaseId is the deleted database's original resource id.",
-				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("DatabaseProperties.SourceDatabaseDeletionDate").Transform(convertDateToTime),
-			},
-			{
-				Name:        "source_database_id",
-				Description: "Specifies the resource ID of the source database if createMode is Copy, NonReadableSecondary, OnlineSecondary, PointInTimeRestore, Recovery, or Restore.",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("DatabaseProperties.SourceDatabaseID"),
-			},
-			{
-				Name:        "zone_redundant",
-				Description: "Indicates if the database is zone redundant or not.",
-				Type:        proto.ColumnType_BOOL,
-				Transform:   transform.FromField("DatabaseProperties.ZoneRedundant"),
-			},
-			{
 				Name:        "retention_policy_id",
 				Description: "Retention policy ID.",
 				Type:        proto.ColumnType_STRING,
@@ -194,6 +176,24 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getSqlDatabaseLongTermRetentionPolicies,
 				Transform:   transform.FromField("BaseLongTermRetentionPolicyProperties"),
+			},
+			{
+				Name:        "source_database_deletion_date",
+				Description: "Specifies the time that the database was deleted when createMode is Restore and sourceDatabaseId is the deleted database's original resource id.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("DatabaseProperties.SourceDatabaseDeletionDate").Transform(convertDateToTime),
+			},
+			{
+				Name:        "source_database_id",
+				Description: "Specifies the resource ID of the source database if createMode is Copy, NonReadableSecondary, OnlineSecondary, PointInTimeRestore, Recovery, or Restore.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DatabaseProperties.SourceDatabaseID"),
+			},
+			{
+				Name:        "zone_redundant",
+				Description: "Indicates if the database is zone redundant or not.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("DatabaseProperties.ZoneRedundant"),
 			},
 			{
 				Name:        "create_mode",

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -245,7 +245,7 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("TransparentDataEncryptionProperties"),
 			},
 
-			// Azure Standard columns
+			// Azure standard columns
 			{
 				Name:        "title",
 				Description: ColumnDescriptionTitle,

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -150,6 +150,12 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DatabaseProperties.RestorePointInTime").Transform(convertDateToTime),
 			},
 			{
+				Name:        "requested_service_objective_name",
+				Description: "The name of the configured service level objective of the database.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DatabaseProperties.RequestedServiceObjectiveName"),
+			},
+			{
 				Name:        "retention_policy_id",
 				Description: "Retention policy ID.",
 				Type:        proto.ColumnType_STRING,
@@ -212,12 +218,6 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Description: "The recommended indices for this database.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("DatabaseProperties.RecommendedIndex"),
-			},
-			{
-				Name:        "requested_service_objective_name",
-				Description: "The name of the configured service level objective of the database.",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("DatabaseProperties.RequestedServiceObjectiveName"),
 			},
 			{
 				Name:        "sample_name",

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -398,7 +398,6 @@ func getSqlDatabaseLongTermRetentionPolicies(ctx context.Context, d *plugin.Quer
 		database := h.Item.(sql.Database)
 		serverName = strings.Split(*database.ID, "/")[8]
 		databaseName = *database.Name
-		plugin.Logger(ctx).Trace("Hydrate Database Id", *database.ID)
 		resourceGroupName = strings.Split(string(*database.ID), "/")[4]
 	} else {
 		serverName = d.KeyColumnQuals["server_name"].GetStringValue()

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -177,13 +177,6 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Type"),
 			},
 			{
-				Name:        "retention_policy_property",
-				Description: "Long term Retention policy Property.",
-				Type:        proto.ColumnType_JSON,
-				Hydrate:     getSqlDatabaseLongTermRetentionPolicies,
-				Transform:   transform.FromField("BaseLongTermRetentionPolicyProperties"),
-			},
-			{
 				Name:        "source_database_deletion_date",
 				Description: "Specifies the time that the database was deleted when createMode is Restore and sourceDatabaseId is the deleted database's original resource id.",
 				Type:        proto.ColumnType_TIMESTAMP,
@@ -218,6 +211,13 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Description: "The recommended indices for this database.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("DatabaseProperties.RecommendedIndex"),
+			},
+			{
+				Name:        "retention_policy_property",
+				Description: "Long term Retention policy Property.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSqlDatabaseLongTermRetentionPolicies,
+				Transform:   transform.FromField("BaseLongTermRetentionPolicyProperties"),
 			},
 			{
 				Name:        "sample_name",

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -245,7 +245,7 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("TransparentDataEncryptionProperties"),
 			},
 
-			// Standard columns
+			// Azure Standard columns
 			{
 				Name:        "title",
 				Description: ColumnDescriptionTitle,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_sql_database []

PRETEST: tests/azure_sql_database

TEST: tests/azure_sql_database
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m17s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097]
azurerm_sql_database.named_test_resource: Creating...
azurerm_sql_database.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_database.named_test_resource: Creation complete after 1m12s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest33097/providers/microsoft.sql/servers/turbottest33097/databases/turbottest33097
resource_creation_date = 2021-08-11T11:11:27.893Z
resource_default_secondary_location = West US
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097
resource_location = East US
resource_name = turbottest33097
resource_region = east us
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest33097/providers/microsoft.sql/servers/turbottest33097/databases/turbottest33097"
    ],
    "containment_state": 2,
    "default_secondary_location": "West US",
    "earliest_restore_date": null,
    "edition": "GeneralPurpose",
    "elastic_pool_name": null,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097",
    "location": "East US",
    "max_size_bytes": "34359738368",
    "name": "turbottest33097",
    "region": "east us",
    "requested_service_objective_name": "GP_Gen5_2",
    "resource_group": "turbottest33097",
    "server_name": "turbottest33097",
    "service_level_objective": "GP_Gen5_2",
    "status": "Online",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest33097",
    "transparent_data_encryption": {
      "status": "Enabled"
    },
    "type": "Microsoft.Sql/servers/databases",
    "zone_redundant": false
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097",
    "name": "turbottest33097",
    "server_name": "turbottest33097",
    "transparent_data_encryption": {
      "status": "Enabled"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097",
    "location": "East US",
    "name": "turbottest33097",
    "resource_group": "turbottest33097",
    "server_name": "turbottest33097"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest33097/providers/Microsoft.Sql/servers/turbottest33097/databases/turbottest33097",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest33097/providers/microsoft.sql/servers/turbottest33097/databases/turbottest33097"
    ],
    "name": "turbottest33097",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest33097"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_database

TEARDOWN: tests/azure_sql_database

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, server_name, retention_policy_id, retention_policy_name, retention_policy_type, retention_policy_property from azure_sql_database;
```

```
+--------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+
| name   | server_name | retention_policy_id                                                                                                                                                            | retention_policy_name | retention_policy_type                                           | retention_policy_property                                                                    |
+--------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+
| master | turbot-db   | <null>                                                                                                                                                                         | <null>                | <null>                                                          | <null>                                                                                       |
| my-db  | turbot-db   | /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/turbot-db/databases/my-db/backupLongTermRetentionPolicies/default | default               | Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies | {"monthlyRetention":"PT0S","weekOfYear":0,"weeklyRetention":"PT0S","yearlyRetention":"PT0S"} |
+--------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+

```
</details>
