### PR TITLE
Fix Integration test failed for resources. Closes #258

### DIFF
--- a/azure-test/tests/azure_api_management/variables.tf
+++ b/azure-test/tests/azure_api_management/variables.tf
@@ -23,8 +23,9 @@ variable "azure_resource_group" {
   description = "Name of the resource group used throughout the test."
 }
 
-data "azurerm_resource_group" "data_resource_group" {
-  name = var.azure_resource_group
+resource "azurerm_resource_group" "named_test_resource" {
+  name     = var.resource_name
+  location = "West US"
 }
 
 provider "azurerm" {
@@ -44,8 +45,8 @@ data "null_data_source" "resource" {
 
 resource "azurerm_api_management" "named_test_resource" {
   name                = var.resource_name
-  location            = data.azurerm_resource_group.data_resource_group.location
-  resource_group_name = var.azure_resource_group
+  location            = azurerm_resource_group.named_test_resource.location
+  resource_group_name = azurerm_resource_group.named_test_resource.name
   publisher_name      = "TurbotHQ"
   publisher_email     = "test@turbot.com"
 
@@ -83,7 +84,7 @@ output "resource_id" {
 }
 
 output "location" {
-  value = data.azurerm_resource_group.data_resource_group.location
+  value = azurerm_resource_group.named_test_resource.location
 }
 
 output "subscription_id" {

--- a/azure-test/tests/azure_app_service_function_app/test-hydrate-expected.json
+++ b/azure-test/tests/azure_app_service_function_app/test-hydrate-expected.json
@@ -6,7 +6,7 @@
     "id": "{{ output.resource_id.value }}",
     "kind": "functionapp",
     "name": "{{resourceName}}",
-    "region": "East US",
+    "region": "east us",
     "resource_group": "{{resourceName}}"
   }
 ]

--- a/azure-test/tests/azure_app_service_plan/test-hydrate-expected.json
+++ b/azure-test/tests/azure_app_service_plan/test-hydrate-expected.json
@@ -7,7 +7,7 @@
     "kind": "Windows",
     "name": "{{resourceName}}",
     "per_site_scaling": false,
-    "region": "East US",
+    "region": "east us",
     "reserved": false,
     "resource_group": "{{resourceName}}",
     "type": "Microsoft.Web/serverfarms"

--- a/azure-test/tests/azure_app_service_web_app/test-get-expected.json
+++ b/azure-test/tests/azure_app_service_web_app/test-get-expected.json
@@ -9,9 +9,9 @@
       "TenantID": "{{ output.tenant_id.value }}"
     },
     "kind": "app",
-    "name": "{{resourceName}}",
+    "name": "{{ resourceName }}",
     "region": "east us",
     "reserved": false,
-    "resource_group": "{{resourceName}}"
+    "resource_group": "{{ resourceName }}"
   }
 ]

--- a/azure-test/tests/azure_app_service_web_app/test-get-expected.json
+++ b/azure-test/tests/azure_app_service_web_app/test-get-expected.json
@@ -6,8 +6,7 @@
     "id": "{{ output.resource_id.value }}",
     "identity": {
       "PrincipalID": "{{ output.principal_id.value }}",
-      "TenantID": "{{ output.tenant_id.value }}",
-      "Type": "SystemAssigned"
+      "TenantID": "{{ output.tenant_id.value }}"
     },
     "kind": "app",
     "name": "{{resourceName}}",

--- a/azure-test/tests/azure_app_service_web_app/test-hydrate-expected.json
+++ b/azure-test/tests/azure_app_service_web_app/test-hydrate-expected.json
@@ -5,8 +5,8 @@
     "https_only": false,
     "id": "{{ output.resource_id.value }}",
     "kind": "app",
-    "name": "{{resourceName}}",
+    "name": "{{ resourceName }}",
     "region": "east us",
-    "resource_group": "{{resourceName}}"
+    "resource_group": "{{ resourceName }}"
   }
 ]

--- a/azure-test/tests/azure_app_service_web_app/test-list-expected.json
+++ b/azure-test/tests/azure_app_service_web_app/test-list-expected.json
@@ -3,8 +3,7 @@
     "id": "{{ output.resource_id.value }}",
     "identity": {
       "PrincipalID": "{{ output.principal_id.value }}",
-      "TenantID": "{{ output.tenant_id.value }}",
-      "Type": "SystemAssigned"
+      "TenantID": "{{ output.tenant_id.value }}"
     },
     "name": "{{resourceName}}"
   }

--- a/azure-test/tests/azure_app_service_web_app/test-list-expected.json
+++ b/azure-test/tests/azure_app_service_web_app/test-list-expected.json
@@ -5,6 +5,6 @@
       "PrincipalID": "{{ output.principal_id.value }}",
       "TenantID": "{{ output.tenant_id.value }}"
     },
-    "name": "{{resourceName}}"
+    "name": "{{ resourceName }}"
   }
 ]

--- a/azure-test/tests/azure_app_service_web_app/test-turbot-expected.json
+++ b/azure-test/tests/azure_app_service_web_app/test-turbot-expected.json
@@ -4,10 +4,10 @@
       "{{ output.resource_aka.value }}",
       "{{ output.resource_aka_lower.value }}"
     ],
-    "name": "{{resourceName}}",
+    "name": "{{ resourceName }}",
     "tags": {
-      "name": "{{resourceName}}"
+      "name": "{{ resourceName }}"
     },
-    "title": "{{resourceName}}"
+    "title": "{{ resourceName }}"
   }
 ]

--- a/azure-test/tests/azure_compute_disk_encryption_set/test-get-expected.json
+++ b/azure-test/tests/azure_compute_disk_encryption_set/test-get-expected.json
@@ -2,7 +2,7 @@
   {
     "active_key_source_vault_id": "{{ output.vault_id.value }}",
     "active_key_url": "{{ output.key_id.value }}",
-    "encryption_tpe": "EncryptionAtRestWithCustomerKey",
+    "encryption_type": "EncryptionAtRestWithCustomerKey",
     "id": "{{ output.resource_id.value }}",
     "identity_tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
     "identity_type": "SystemAssigned",

--- a/azure-test/tests/azure_compute_disk_encryption_set/test-get-expected.json
+++ b/azure-test/tests/azure_compute_disk_encryption_set/test-get-expected.json
@@ -6,9 +6,9 @@
     "id": "{{ output.resource_id.value }}",
     "identity_tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
     "identity_type": "SystemAssigned",
-    "name": "{{resourceName}}",
+    "name": "{{ resourceName }}",
     "region": "eastus",
-    "resource_group": "{{resourceName}}",
+    "resource_group": "{{ resourceName }}",
     "subscription_id": "{{ output.subscription_id.value }}",
     "type": "Microsoft.Compute/diskEncryptionSets"
   }

--- a/azure-test/tests/azure_compute_disk_encryption_set/test-get-query.sql
+++ b/azure-test/tests/azure_compute_disk_encryption_set/test-get-query.sql
@@ -1,3 +1,3 @@
-select name, id, type, active_key_source_vault_id, active_key_url, encryption_tpe, identity_tenant_id, identity_type, region, resource_group, subscription_id
+select name, id, type, active_key_source_vault_id, active_key_url, encryption_type, identity_tenant_id, identity_type, region, resource_group, subscription_id
 from azure.azure_compute_disk_encryption_set
 where name = '{{resourceName}}' and resource_group = '{{resourceName}}'

--- a/azure-test/tests/azure_compute_disk_encryption_set/test-hydrate-expected.json
+++ b/azure-test/tests/azure_compute_disk_encryption_set/test-hydrate-expected.json
@@ -2,7 +2,7 @@
   {
     "active_key_source_vault_id": "{{ output.vault_id.value }}",
     "active_key_url": "{{ output.key_id.value }}",
-    "encryption_tpe": "EncryptionAtRestWithCustomerKey",
+    "encryption_type": "EncryptionAtRestWithCustomerKey",
     "id": "{{ output.resource_id.value }}",
     "identity_tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
     "identity_type": "SystemAssigned",

--- a/azure-test/tests/azure_compute_disk_encryption_set/test-hydrate-expected.json
+++ b/azure-test/tests/azure_compute_disk_encryption_set/test-hydrate-expected.json
@@ -6,9 +6,9 @@
     "id": "{{ output.resource_id.value }}",
     "identity_tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
     "identity_type": "SystemAssigned",
-    "name": "{{resourceName}}",
+    "name": "{{ resourceName }}",
     "region": "eastus",
-    "resource_group": "{{resourceName}}",
+    "resource_group": "{{ resourceName }}",
     "subscription_id": "{{ output.subscription_id.value }}",
     "type": "Microsoft.Compute/diskEncryptionSets"
   }

--- a/azure-test/tests/azure_compute_disk_encryption_set/test-hydrate-query.sql
+++ b/azure-test/tests/azure_compute_disk_encryption_set/test-hydrate-query.sql
@@ -1,3 +1,3 @@
-select name, id, type, active_key_source_vault_id, active_key_url, encryption_tpe, identity_tenant_id, identity_type, region, resource_group, subscription_id
+select name, id, type, active_key_source_vault_id, active_key_url, encryption_type, identity_tenant_id, identity_type, region, resource_group, subscription_id
 from azure.azure_compute_disk_encryption_set
 where name = '{{resourceName}}' and resource_group = '{{resourceName}}'

--- a/azure-test/tests/azure_compute_disk_encryption_set/variables.tf
+++ b/azure-test/tests/azure_compute_disk_encryption_set/variables.tf
@@ -46,7 +46,7 @@ resource "azurerm_key_vault" "named_test_resource" {
   enabled_for_disk_encryption = true
   soft_delete_enabled         = true
   soft_delete_retention_days  = 7
-  purge_protection_enabled    = false
+  purge_protection_enabled    = true
   sku_name                    = "standard"
 }
 

--- a/azure-test/tests/azure_virtual_network/test-get-expected.json
+++ b/azure-test/tests/azure_virtual_network/test-get-expected.json
@@ -4,7 +4,7 @@
       "10.1.2.0/24"
     ],
     "enable_ddos_protection": false,
-    "enable_vm_protection": false,
+    "enable_vm_protection": null,
     "id": "{{ output.resource_id.value }}",
     "name": "{{resourceName}}",
     "region": "eastus",

--- a/azure/table_azure_data_factory_dataset.go
+++ b/azure/table_azure_data_factory_dataset.go
@@ -155,7 +155,7 @@ func getDataFactoryDataset(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		return nil, nil
 	}
 
-	op, err := datasetClient.Get(ctx, resourceGroup, factoryName, datasetName, "*")
+	op, err := datasetClient.Get(ctx, resourceGroup, factoryName, datasetName, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```  
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_data_factory_dataset []

PRETEST: tests/azure_data_factory_dataset

TEST: tests/azure_data_factory_dataset
Running terraform
data.azurerm_client_config.current: Refreshing state...
azurerm_resource_group.named_test_resource: Refreshing state... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840]
azurerm_data_factory.named_test_resource: Refreshing state... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840/providers/Microsoft.DataFactory/factories/turbottest48840]
azurerm_data_factory_linked_service_mysql.named_test_resource: Refreshing state... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840/providers/Microsoft.DataFactory/factories/turbottest48840/linkedservices/turbottest48840]
data.null_data_source.resource: Refreshing state...
azurerm_data_factory_dataset_mysql.named_test_resource: Refreshing state... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840/providers/Microsoft.DataFactory/factories/turbottest48840/datasets/turbottest48840]
azurerm_data_factory_dataset_mysql.named_test_resource: Destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840/providers/Microsoft.DataFactory/factories/turbottest48840/datasets/turbottest48840]
azurerm_data_factory_dataset_mysql.named_test_resource: Destruction complete after 2s
azurerm_data_factory_linked_service_mysql.named_test_resource: Destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840/providers/Microsoft.DataFactory/factories/turbottest48840/linkedservices/turbottest48840]
azurerm_data_factory_linked_service_mysql.named_test_resource: Destruction complete after 1s
azurerm_data_factory.named_test_resource: Destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840/providers/Microsoft.DataFactory/factories/turbottest48840]
azurerm_data_factory.named_test_resource: Destruction complete after 9s
azurerm_resource_group.named_test_resource: Destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest48840]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-...3dae6c8/resourceGroups/turbottest48840, 10s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-...3dae6c8/resourceGroups/turbottest48840, 20s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-...3dae6c8/resourceGroups/turbottest48840, 30s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-...3dae6c8/resourceGroups/turbottest48840, 40s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-...3dae6c8/resourceGroups/turbottest48840, 50s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-...3dae6c8/resourceGroups/turbottest48840, 1m0s elapsed]
azurerm_resource_group.named_test_resource: Destruction complete after 1m7s
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004]
azurerm_data_factory.named_test_resource: Creating...
azurerm_data_factory.named_test_resource: Still creating... [10s elapsed]
azurerm_data_factory.named_test_resource: Creation complete after 19s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004]
azurerm_data_factory_linked_service_mysql.named_test_resource: Creating...
azurerm_data_factory_linked_service_mysql.named_test_resource: Creation complete after 4s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/linkedservices/turbottest58004]
azurerm_data_factory_dataset_mysql.named_test_resource: Creating...
azurerm_data_factory_dataset_mysql.named_test_resource: Creation complete after 3s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/datasets/turbottest58004]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 4 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/datasets/turbottest58004
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest58004/providers/microsoft.datafactory/factories/turbottest58004/datasets/turbottest58004
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/datasets/turbottest58004
resource_name = turbottest58004
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/datasets/turbottest58004",
    "name": "turbottest58004",
    "resource_group": "turbottest58004",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.DataFactory/factories/datasets"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/datasets/turbottest58004",
    "name": "turbottest58004",
    "type": "Microsoft.DataFactory/factories/datasets"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest58004/providers/Microsoft.DataFactory/factories/turbottest58004/datasets/turbottest58004",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest58004/providers/microsoft.datafactory/factories/turbottest58004/datasets/turbottest58004"
    ],
    "name": "turbottest58004",
    "title": "turbottest58004"
  }
]
✔ PASSED

POSTTEST: tests/azure_data_factory_dataset

TEARDOWN: tests/azure_data_factory_dataset

SUMMARY:

1/1 passed.
```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_disk_encryption_set []

PRETEST: tests/azure_compute_disk_encryption_set

TEST: tests/azure_compute_disk_encryption_set
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436]
azurerm_key_vault.named_test_resource: Creating...
azurerm_key_vault.named_test_resource: Still creating... [10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m30s elapsed]
azurerm_key_vault.named_test_resource: Creation complete after 2m32s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.KeyVault/vaults/turbottest50436]
azurerm_key_vault_access_policy.local_user: Creating...
azurerm_key_vault_access_policy.local_user: Still creating... [10s elapsed]
azurerm_key_vault_access_policy.local_user: Creation complete after 12s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.KeyVault/vaults/turbottest50436/objectId/06fd46b0-a867-49a1-a4f1-f7768465caba]
azurerm_key_vault_key.named_test_resource: Creating...
azurerm_key_vault_key.named_test_resource: Creation complete after 10s [id=https://turbottest50436.vault.azure.net/keys/turbottest50436/727552bb7566487f9c07f32cc1045bda]
azurerm_disk_encryption_set.named_test_resource: Creating...
azurerm_disk_encryption_set.named_test_resource: Still creating... [10s elapsed]
azurerm_disk_encryption_set.named_test_resource: Creation complete after 17s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

key_id = https://turbottest50436.vault.azure.net/keys/turbottest50436/727552bb7566487f9c07f32cc1045bda
object_id = 06fd46b0-a867-49a1-a4f1-f7768465caba
resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest50436/providers/microsoft.compute/diskencryptionsets/turbottest50436
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436
resource_name = turbottest50436
resource_name_upper = TURBOTTEST50436
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8
tenant_id = cdffd708-7da0-4cea-abeb-0a4c334d7f64
vault_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.KeyVault/vaults/turbottest50436

Running SQL query: test-get-query.sql
[
  {
    "active_key_source_vault_id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.KeyVault/vaults/turbottest50436",
    "active_key_url": "https://turbottest50436.vault.azure.net/keys/turbottest50436/727552bb7566487f9c07f32cc1045bda",
    "encryption_type": "EncryptionAtRestWithCustomerKey",
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436",
    "identity_tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "identity_type": "SystemAssigned",
    "name": "turbottest50436",
    "region": "eastus",
    "resource_group": "turbottest50436",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.Compute/diskEncryptionSets"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "active_key_source_vault_id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.KeyVault/vaults/turbottest50436",
    "active_key_url": "https://turbottest50436.vault.azure.net/keys/turbottest50436/727552bb7566487f9c07f32cc1045bda",
    "encryption_type": "EncryptionAtRestWithCustomerKey",
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436",
    "identity_tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "identity_type": "SystemAssigned",
    "name": "turbottest50436",
    "region": "eastus",
    "resource_group": "turbottest50436",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.Compute/diskEncryptionSets"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/TURBOTTEST50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436",
    "name": "turbottest50436",
    "type": "Microsoft.Compute/diskEncryptionSets"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest50436/providers/Microsoft.Compute/diskEncryptionSets/turbottest50436",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest50436/providers/microsoft.compute/diskencryptionsets/turbottest50436"
    ],
    "name": "turbottest50436",
    "tags": {
      "name": "turbottest50436"
    },
    "title": "turbottest50436"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_disk_encryption_set

TEARDOWN: tests/azure_compute_disk_encryption_set

SUMMARY:

1/1 passed.
```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_app_service_plan []

PRETEST: tests/azure_app_service_plan

TEST: tests/azure_app_service_plan
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825]
azurerm_app_service_plan.named_test_resource: Creating...
azurerm_app_service_plan.named_test_resource: Still creating... [10s elapsed]
azurerm_app_service_plan.named_test_resource: Creation complete after 13s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest36825/providers/microsoft.web/serverfarms/turbottest36825
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825
resource_name = turbottest36825
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "hyper_v": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825",
    "is_spot": false,
    "is_xenon": false,
    "kind": "Windows",
    "name": "turbottest36825",
    "per_site_scaling": false,
    "region": "east us",
    "reserved": false,
    "resource_group": "turbottest36825",
    "sku_capacity": 1,
    "sku_size": "S1",
    "sku_tier": "Standard",
    "type": "Microsoft.Web/serverfarms"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "hyper_v": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825",
    "is_spot": false,
    "is_xenon": false,
    "kind": "Windows",
    "name": "turbottest36825",
    "per_site_scaling": false,
    "region": "east us",
    "reserved": false,
    "resource_group": "turbottest36825",
    "type": "Microsoft.Web/serverfarms"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825",
    "name": "turbottest36825"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest36825/providers/Microsoft.Web/serverfarms/turbottest36825",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest36825/providers/microsoft.web/serverfarms/turbottest36825"
    ],
    "name": "turbottest36825",
    "tags": {
      "name": "turbottest36825"
    },
    "title": "turbottest36825"
  }
]
✔ PASSED

POSTTEST: tests/azure_app_service_plan

TEARDOWN: tests/azure_app_service_plan

SUMMARY:

1/1 passed.


```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_availability_set []

PRETEST: tests/azure_compute_availability_set

TEST: tests/azure_compute_availability_set
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993]
azurerm_availability_set.named_test_resource: Creating...
azurerm_availability_set.named_test_resource: Creation complete after 7s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993/providers/Microsoft.Compute/availabilitySets/turbottest88993]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993/providers/Microsoft.Compute/availabilitySets/turbottest88993
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest88993/providers/microsoft.compute/availabilitysets/turbottest88993
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993/providers/Microsoft.Compute/availabilitySets/turbottest88993
resource_name = turbottest88993
resource_name_upper = TURBOTTEST88993
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993/providers/Microsoft.Compute/availabilitySets/turbottest88993",
    "name": "turbottest88993",
    "platform_fault_domain_count": 3,
    "platform_update_domain_count": 5,
    "region": "eastus",
    "resource_group": "turbottest88993",
    "sku_name": "Classic",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.Compute/availabilitySets"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993/providers/Microsoft.Compute/availabilitySets/turbottest88993",
    "name": "turbottest88993",
    "platform_fault_domain_count": 3,
    "platform_update_domain_count": 5,
    "region": "eastus",
    "resource_group": "turbottest88993",
    "sku_name": "Classic",
    "subscription_id": "d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8",
    "type": "Microsoft.Compute/availabilitySets"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/TURBOTTEST88993/providers/Microsoft.Compute/availabilitySets/turbottest88993",
    "name": "turbottest88993",
    "type": "Microsoft.Compute/availabilitySets"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest88993/providers/Microsoft.Compute/availabilitySets/turbottest88993",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest88993/providers/microsoft.compute/availabilitysets/turbottest88993"
    ],
    "name": "turbottest88993",
    "tags": {
      "name": "turbottest88993"
    },
    "title": "turbottest88993"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_availability_set

TEARDOWN: tests/azure_compute_availability_set

SUMMARY:

1/1 passed.
```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_app_service_web_app []

PRETEST: tests/azure_app_service_web_app

TEST: tests/azure_app_service_web_app
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724]
azurerm_app_service_plan.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Creating...
azurerm_app_service_plan.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_app_service_plan.named_test_resource: Creation complete after 13s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/serverfarms/turbottest84724]
azurerm_app_service.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_app_service.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 31s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Storage/storageAccounts/turbottest84724]
azurerm_app_service.named_test_resource: Still creating... [20s elapsed]
azurerm_app_service.named_test_resource: Still creating... [30s elapsed]
azurerm_app_service.named_test_resource: Still creating... [40s elapsed]
azurerm_app_service.named_test_resource: Still creating... [50s elapsed]
azurerm_app_service.named_test_resource: Still creating... [1m0s elapsed]
azurerm_app_service.named_test_resource: Creation complete after 1m1s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

principal_id = c28f10f6-ecef-42e9-86cc-45f8936da722
resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest84724/providers/microsoft.web/sites/turbottest84724
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724
resource_name = turbottest84724
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8
tenant_id = cdffd708-7da0-4cea-abeb-0a4c334d7f64

Running SQL query: test-get-query.sql
[
  {
    "client_affinity_enabled": false,
    "enabled": true,
    "https_only": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724",
    "identity": {
      "PrincipalID": "c28f10f6-ecef-42e9-86cc-45f8936da722",
      "TenantID": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
    },
    "kind": "app",
    "name": "turbottest84724",
    "region": "east us",
    "reserved": false,
    "resource_group": "turbottest84724"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "client_affinity_enabled": false,
    "enabled": true,
    "https_only": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724",
    "kind": "app",
    "name": "turbottest84724",
    "region": "east us",
    "resource_group": "turbottest84724"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724",
    "identity": {
      "PrincipalID": "c28f10f6-ecef-42e9-86cc-45f8936da722",
      "TenantID": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
    },
    "name": "turbottest84724"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest84724/providers/Microsoft.Web/sites/turbottest84724",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest84724/providers/microsoft.web/sites/turbottest84724"
    ],
    "name": "turbottest84724",
    "tags": {
      "name": "turbottest84724"
    },
    "title": "turbottest84724"
  }
]
✔ PASSED

POSTTEST: tests/azure_app_service_web_app

TEARDOWN: tests/azure_app_service_web_app

SUMMARY:

1/1 passed.

@ ~/steam-pipe/azure/azure-test (intg-test-1) ⏩  ./tint.js azure_tenant
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_tenant []

PRETEST: tests/azure_tenant

TEST: tests/azure_tenant
Running terraform
data.azurerm_client_config.current: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

current_tenant_display_name = cdffd708-7da0-4cea-abeb-0a4c334d7f64
tenant_id = cdffd708-7da0-4cea-abeb-0a4c334d7f64

Running SQL query: test-list-query.sql
[
  {
    "display_name": null,
    "name": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "name": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "title": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
  }
]
✔ PASSED

POSTTEST: tests/azure_tenant

TEARDOWN: tests/azure_tenant

SUMMARY:

1/1 passed.
```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_virtual_network []

PRETEST: tests/azure_virtual_network

TEST: tests/azure_virtual_network
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Creation complete after 8s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest56235/providers/microsoft.network/virtualnetworks/turbottest56235
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235
resource_name = turbottest56235
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "address_prefixes": [
      "10.1.2.0/24"
    ],
    "enable_ddos_protection": false,
    "enable_vm_protection": null,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235",
    "name": "turbottest56235",
    "region": "eastus",
    "resource_group": "turbottest56235",
    "type": "Microsoft.Network/virtualNetworks"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest56235/providers/microsoft.network/virtualnetworks/turbottest56235"
    ],
    "name": "turbottest56235",
    "tags": {
      "name": "turbottest56235"
    },
    "title": "turbottest56235"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235",
    "name": "turbottest56235"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest56235/providers/Microsoft.Network/virtualNetworks/turbottest56235",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest56235/providers/microsoft.network/virtualnetworks/turbottest56235"
    ],
    "name": "turbottest56235",
    "tags": {
      "name": "turbottest56235"
    },
    "title": "turbottest56235"
  }
]
✔ PASSED

POSTTEST: tests/azure_virtual_network

TEARDOWN: tests/azure_virtual_network

SUMMARY:

1/1 passed.

```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_app_service_function_app []

PRETEST: tests/azure_app_service_function_app

TEST: tests/azure_app_service_function_app
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766]
azurerm_app_service_plan.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Creating...
azurerm_app_service_plan.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_app_service_plan.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_app_service_plan.named_test_resource: Creation complete after 23s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/serverfarms/turbottest4766]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 33s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Storage/storageAccounts/turbottest4766]
azurerm_function_app.named_test_resource: Creating...
azurerm_function_app.named_test_resource: Still creating... [10s elapsed]
azurerm_function_app.named_test_resource: Still creating... [20s elapsed]
azurerm_function_app.named_test_resource: Still creating... [30s elapsed]
azurerm_function_app.named_test_resource: Still creating... [40s elapsed]
azurerm_function_app.named_test_resource: Creation complete after 47s [id=/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766
resource_aka_lower = azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest4766/providers/microsoft.web/sites/turbottest4766
resource_id = /subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766
resource_name = turbottest4766
subscription_id = d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8

Running SQL query: test-get-query.sql
[
  {
    "client_affinity_enabled": false,
    "enabled": true,
    "https_only": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766",
    "kind": "functionapp",
    "name": "turbottest4766",
    "region": "east us",
    "resource_group": "turbottest4766"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "client_affinity_enabled": false,
    "enabled": true,
    "https_only": false,
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766",
    "kind": "functionapp",
    "name": "turbottest4766",
    "region": "east us",
    "resource_group": "turbottest4766"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766",
    "name": "turbottest4766"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourceGroups/turbottest4766/providers/Microsoft.Web/sites/turbottest4766",
      "azure:///subscriptions/d7245080-b4ae-4fe5-b6fa-2e71b3dae6c8/resourcegroups/turbottest4766/providers/microsoft.web/sites/turbottest4766"
    ],
    "name": "turbottest4766",
    "tags": {
      "name": "turbottest4766"
    },
    "title": "turbottest4766"
  }
]
✔ PASSED

POSTTEST: tests/azure_app_service_function_app

TEARDOWN: tests/azure_app_service_function_app

SUMMARY:

1/1 passed.
```

</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
