### PR TITLE
Add Private Endpoint Connection details in table azure_data_factory closes #285

### DIFF
--- a/azure/table_azure_data_factory.go
+++ b/azure/table_azure_data_factory.go
@@ -104,7 +104,7 @@ func tableAzureDataFactory(_ context.Context) *plugin.Table {
 				Name:        "private_endpoint_connections",
 				Description: "List of private connections for factory.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getDataFactoryPrivateConnections,
+				Hydrate:     getDataFactoryPrivateEndpointConnections,
 				Transform:   transform.FromValue(),
 			},
 
@@ -214,7 +214,7 @@ func getDataFactory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 	return op, nil
 }
 
-func getDataFactoryPrivateConnections(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getDataFactoryPrivateEndpointConnections(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getDataFactoryPrivateConnections")
 	factory := h.Item.(datafactory.Factory)
 	factoryName := factory.Name

--- a/azure/table_azure_data_factory.go
+++ b/azure/table_azure_data_factory.go
@@ -101,7 +101,7 @@ func tableAzureDataFactory(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("FactoryProperties.GlobalParameters"),
 			},
 			{
-				Name:        "private_connections",
+				Name:        "private_endpoint_connections",
 				Description: "List of private connections for factory.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getDataFactoryPrivateConnections,
@@ -223,7 +223,7 @@ func getDataFactoryPrivateConnections(ctx context.Context, d *plugin.QueryData, 
 	// Create session
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
 	if err != nil {
-		plugin.Logger(ctx).Trace("getDataFactoryPrivateConnections", "connection", err)
+		plugin.Logger(ctx).Error("getDataFactoryPrivateConnections", "connection", err)
 		return nil, err
 	}
 	subscriptionID := session.SubscriptionID

--- a/azure/table_azure_data_factory.go
+++ b/azure/table_azure_data_factory.go
@@ -248,7 +248,7 @@ func listDataFactoryPrivateEndpointConnections(ctx context.Context, d *plugin.Qu
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("listDataFactoryPrivateEndpointConnections", "ListByFactory pagging", err)
+			plugin.Logger(ctx).Error("listDataFactoryPrivateEndpointConnections", "ListByFactory_pagination", err)
 			return nil, err
 		}
 		for _, conn := range op.Values() {

--- a/azure/table_azure_data_factory.go
+++ b/azure/table_azure_data_factory.go
@@ -238,7 +238,6 @@ func getDataFactoryPrivateConnections(ctx context.Context, d *plugin.QueryData, 
 
 	var connections []PrivateConnection
 	for _, connection := range op.Values() {
-		plugin.Logger(ctx).Trace("Private Connections =>", connection)
 		connections = append(connections, PrivateConnection{
 			Properties: connection.Properties,
 			Id:         connection.ID,

--- a/azure/table_azure_data_factory.go
+++ b/azure/table_azure_data_factory.go
@@ -102,7 +102,7 @@ func tableAzureDataFactory(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "private_endpoint_connections",
-				Description: "List of private connections for factory.",
+				Description: "List of private endpoint connections for data factory.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listDataFactoryPrivateEndpointConnections,
 				Transform:   transform.FromValue(),
@@ -260,6 +260,8 @@ func listDataFactoryPrivateEndpointConnections(ctx context.Context, d *plugin.Qu
 	return connections, nil
 }
 
+// If we return the API response directly, the output will not give
+// all the properties of PrivateEndpointConnection
 func factoryPrivateEndpointConnectionMap(conn datafactory.PrivateEndpointConnectionResource) PrivateConnection {
 	var connection PrivateConnection
 	if conn.ID != nil {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_data_factory []

PRETEST: tests/azure_data_factory

TEST: tests/azure_data_factory
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505]
azurerm_data_factory.named_test_resource: Creating...
azurerm_data_factory.named_test_resource: Still creating... [10s elapsed]
azurerm_data_factory.named_test_resource: Creation complete after 12s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505/providers/Microsoft.DataFactory/factories/turbottest45505]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = eastus
resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505/providers/Microsoft.DataFactory/factories/turbottest45505
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest45505/providers/microsoft.datafactory/factories/turbottest45505
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505/providers/Microsoft.DataFactory/factories/turbottest45505
resource_name = turbottest45505
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
2021-09-07T13:03:27.001+0530 [TRACE] steampipe: db.EnsureDbAndStartService start
2021-09-07T13:03:27.001+0530 [TRACE] steampipe: ensure installed
2021-09-07T13:03:27.003+0530 [TRACE] steampipe: ensured installed
2021-09-07T13:03:27.026+0530 [TRACE] steampipe: GetRunStatus - pid 10614 does not exist
2021-09-07T13:03:27.027+0530 [TRACE] steampipe: start implicit service
2021-09-07T13:03:27.027+0530 [TRACE] steampipe: GetRunStatus - loadRunningInstanceInfo returned nil
2021-09-07T13:03:27.032+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:27.057+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:27.057+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=postgres sslmode=require
2021-09-07T13:03:27.144+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:27.170+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:27.170+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:27.231+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:27.258+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:27.258+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:27.281+0530 [TRACE] steampipe: getQueryInitDataAsync
2021-09-07T13:03:27.296+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:27.322+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:27.322+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:29.487+0530 [TRACE] steampipe: RefreshConnections, updates: &{Update:map[] Delete:map[] MissingPlugins:[] RequiredConnections:map[alicloud:0xc000031270 aws:0xc000031310 azure:0xc000031360 gcp:0xc0000313b0 oci:0xc000031540 okta:0xc0000315e0 zendesk:0xc000031220]}
2021-09-07T13:03:29.487+0530 [TRACE] steampipe: no connections to update
2021-09-07T13:03:29.487+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:29.512+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:29.512+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:29.550+0530 [TRACE] steampipe: setting service search path to ["public" "alicloud" "aws" "azure" "gcp" "oci" "okta" "zendesk" "internal"]
2021-09-07T13:03:29.551+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:29.581+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:29.581+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:30.646+0530 [TRACE] steampipe: getQueryInitDataAsync complete
2021-09-07T13:03:33.788+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:33.814+0530 [TRACE] steampipe: status:  &{12893 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:33.814+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:33.847+0530 [TRACE] steampipe: StopDB false
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505/providers/Microsoft.DataFactory/factories/turbottest45505",
    "name": "turbottest45505",
    "region": "eastus",
    "resource_group": "turbottest45505",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "tags": {
      "name": "turbottest45505"
    },
    "type": "Microsoft.DataFactory/factories"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
2021-09-07T13:03:34.009+0530 [TRACE] steampipe: db.EnsureDbAndStartService start
2021-09-07T13:03:34.009+0530 [TRACE] steampipe: ensure installed
2021-09-07T13:03:34.009+0530 [TRACE] steampipe: ensured installed
2021-09-07T13:03:34.030+0530 [TRACE] steampipe: GetRunStatus - pid 12893 does not exist
2021-09-07T13:03:34.030+0530 [TRACE] steampipe: start implicit service
2021-09-07T13:03:34.030+0530 [TRACE] steampipe: GetRunStatus - loadRunningInstanceInfo returned nil
2021-09-07T13:03:34.034+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:34.064+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:34.064+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=postgres sslmode=require
2021-09-07T13:03:34.094+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:34.119+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:34.119+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:34.142+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:34.167+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:34.167+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:34.188+0530 [TRACE] steampipe: getQueryInitDataAsync
2021-09-07T13:03:34.196+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:34.222+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:34.222+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:35.813+0530 [TRACE] steampipe: RefreshConnections, updates: &{Update:map[] Delete:map[] MissingPlugins:[] RequiredConnections:map[alicloud:0xc0000303c0 aws:0xc000030460 azure:0xc0000304b0 gcp:0xc000030500 oci:0xc0000302d0 okta:0xc000030320 zendesk:0xc000030370]}
2021-09-07T13:03:35.813+0530 [TRACE] steampipe: no connections to update
2021-09-07T13:03:35.813+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:35.839+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:35.839+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:35.866+0530 [TRACE] steampipe: setting service search path to ["public" "alicloud" "aws" "azure" "gcp" "oci" "okta" "zendesk" "internal"]
2021-09-07T13:03:35.867+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:35.895+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:35.895+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:36.815+0530 [TRACE] steampipe: getQueryInitDataAsync complete
2021-09-07T13:03:39.422+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:39.449+0530 [TRACE] steampipe: status:  &{12954 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:39.449+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:39.476+0530 [TRACE] steampipe: StopDB false
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505/providers/Microsoft.DataFactory/factories/turbottest45505",
    "name": "turbottest45505",
    "type": "Microsoft.DataFactory/factories"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
2021-09-07T13:03:39.641+0530 [TRACE] steampipe: db.EnsureDbAndStartService start
2021-09-07T13:03:39.641+0530 [TRACE] steampipe: ensure installed
2021-09-07T13:03:39.641+0530 [TRACE] steampipe: ensured installed
2021-09-07T13:03:39.674+0530 [TRACE] steampipe: GetRunStatus - pid 12954 does not exist
2021-09-07T13:03:39.675+0530 [TRACE] steampipe: start implicit service
2021-09-07T13:03:39.675+0530 [TRACE] steampipe: GetRunStatus - loadRunningInstanceInfo returned nil
2021-09-07T13:03:39.678+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:39.706+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:39.706+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=postgres sslmode=require
2021-09-07T13:03:39.742+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:39.766+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:39.766+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:39.793+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:39.819+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:39.819+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:39.838+0530 [TRACE] steampipe: getQueryInitDataAsync
2021-09-07T13:03:39.843+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:39.870+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:39.870+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:41.415+0530 [TRACE] steampipe: RefreshConnections, updates: &{Update:map[] Delete:map[] MissingPlugins:[] RequiredConnections:map[alicloud:0xc00058a3c0 aws:0xc00058a410 azure:0xc00058a460 gcp:0xc00058a4b0 oci:0xc00058a2d0 okta:0xc00058a320 zendesk:0xc00058a370]}
2021-09-07T13:03:41.415+0530 [TRACE] steampipe: no connections to update
2021-09-07T13:03:41.415+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:41.444+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:41.444+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:41.471+0530 [TRACE] steampipe: setting service search path to ["public" "alicloud" "aws" "azure" "gcp" "oci" "okta" "zendesk" "internal"]
2021-09-07T13:03:41.472+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:41.499+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:41.499+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:42.411+0530 [TRACE] steampipe: getQueryInitDataAsync complete
2021-09-07T13:03:44.310+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:44.344+0530 [TRACE] steampipe: status:  &{13014 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:44.344+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:44.372+0530 [TRACE] steampipe: StopDB false
null
✔ PASSED

Running SQL query: test-turbot-query.sql
2021-09-07T13:03:44.535+0530 [TRACE] steampipe: db.EnsureDbAndStartService start
2021-09-07T13:03:44.535+0530 [TRACE] steampipe: ensure installed
2021-09-07T13:03:44.536+0530 [TRACE] steampipe: ensured installed
2021-09-07T13:03:44.557+0530 [TRACE] steampipe: GetRunStatus - pid 13014 does not exist
2021-09-07T13:03:44.558+0530 [TRACE] steampipe: start implicit service
2021-09-07T13:03:44.558+0530 [TRACE] steampipe: GetRunStatus - loadRunningInstanceInfo returned nil
2021-09-07T13:03:44.561+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:44.588+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:44.588+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=postgres sslmode=require
2021-09-07T13:03:44.618+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:44.645+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:44.645+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:44.672+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:44.698+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:44.698+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:44.721+0530 [TRACE] steampipe: getQueryInitDataAsync
2021-09-07T13:03:44.729+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:44.754+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:44.754+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:46.305+0530 [TRACE] steampipe: RefreshConnections, updates: &{Update:map[] Delete:map[] MissingPlugins:[] RequiredConnections:map[alicloud:0xc0000a9310 aws:0xc0000a9360 azure:0xc0000a8d70 gcp:0xc0000a8dc0 oci:0xc0000a91d0 okta:0xc0000a9270 zendesk:0xc0000a92c0]}
2021-09-07T13:03:46.305+0530 [TRACE] steampipe: no connections to update
2021-09-07T13:03:46.305+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:46.331+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:46.331+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:46.356+0530 [TRACE] steampipe: setting service search path to ["public" "alicloud" "aws" "azure" "gcp" "oci" "okta" "zendesk" "internal"]
2021-09-07T13:03:46.357+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:46.384+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:46.384+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=steampipe dbname=steampipe sslmode=require
2021-09-07T13:03:47.297+0530 [TRACE] steampipe: getQueryInitDataAsync complete
2021-09-07T13:03:50.050+0530 [TRACE] steampipe: createDbClient
2021-09-07T13:03:50.077+0530 [TRACE] steampipe: status:  &{13075 9193 [localhost 127.0.0.1] local query 0b16-4900-92e3 steampipe steampipe}
2021-09-07T13:03:50.077+0530 [TRACE] steampipe: Connection string:  host=localhost port=9193 user=root dbname=steampipe sslmode=require
2021-09-07T13:03:50.106+0530 [TRACE] steampipe: StopDB false
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest45505/providers/Microsoft.DataFactory/factories/turbottest45505",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest45505/providers/microsoft.datafactory/factories/turbottest45505"
    ],
    "name": "turbottest45505",
    "tags": {
      "name": "turbottest45505"
    },
    "title": "turbottest45505"
  }
]
✔ PASSED

POSTTEST: tests/azure_data_factory

TEARDOWN: tests/azure_data_factory

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select jsonb_pretty(private_endpoint_connections) as private_endpoint_connections from azure_data_factory
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| private_endpoint_connections                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| [                                                                                                                                                                                                         
|     {                                                                                                                                                                                                     
|         "Etag": "24006308-0000-0100-0000-614332e70000",                                                                                                                                                   
|         "PrivateEndpointId": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.Network/privateEndpoints/test-pvc",                                        
|         "ProvisioningState": "Succeeded",                                                                                                                                                                 
|         "PrivateEndpointConnectionId": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.DataFactory/factories/test-datafactory54/privateendpointconnectio
|         "PrivateEndpointConnectionName": "test-datafactory54.77bc046b-1c02-472d-aa0a-234c6c3092ef",                                                                                                       
|         "PrivateEndpointConnectionType": "Microsoft.DataFactory/factories/privateendpointconnections",                                                                                                    
|         "PrivateLinkServiceConnectionStateStatus": "Approved",                                                                                                                                            
|         "PrivateLinkServiceConnectionStateDescription": "Auto-Approved",                                                                                                                                  
|         "PrivateLinkServiceConnectionStateActionsRequired": "None"                                                                                                                                        
|     }                                                                                                                                                                                                     
| ]                                                                                                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

</details>
