### PR TITLE
Add server keys details in table azure_postgresql_server closes #287

### DIFF
--- a/azure/table_azure_postgresql_server.go
+++ b/azure/table_azure_postgresql_server.go
@@ -377,9 +377,7 @@ func getPostgreSQLServerKeys(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	var serverKeys []postgresql.ServerKey
-	for _, key := range op.Values() {
-		serverKeys = append(serverKeys, key)
-	}
+	serverKeys = append(serverKeys, op.Values()...)
 	return serverKeys, nil
 }
 

--- a/azure/table_azure_postgresql_server.go
+++ b/azure/table_azure_postgresql_server.go
@@ -369,7 +369,7 @@ func getPostgreSQLServerFirewallRules(ctx context.Context, d *plugin.QueryData, 
 }
 
 func listPostgreSQLServerKeys(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getPostgreSQLServerKeys")
+	plugin.Logger(ctx).Trace("listPostgreSQLServerKeys")
 	server := h.Item.(postgresql.Server)
 
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
@@ -384,6 +384,7 @@ func listPostgreSQLServerKeys(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	op, err := client.List(ctx, resourceGroupName, *server.Name)
 	if err != nil {
+		plugin.Logger(ctx).Trace("listPostgreSQLServerKeys", "List", err)
 		return nil, err
 	}
 
@@ -397,6 +398,7 @@ func listPostgreSQLServerKeys(ctx context.Context, d *plugin.QueryData, h *plugi
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
 		if err != nil {
+			plugin.Logger(ctx).Trace("listPostgreSQLServerKeys", "list_paging", err)
 			return nil, err
 		}
 		for _, key := range op.Values() {

--- a/azure/table_azure_postgresql_server.go
+++ b/azure/table_azure_postgresql_server.go
@@ -384,7 +384,7 @@ func listPostgreSQLServerKeys(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	op, err := client.List(ctx, resourceGroupName, *server.Name)
 	if err != nil {
-		plugin.Logger(ctx).Trace("listPostgreSQLServerKeys", "List", err)
+		plugin.Logger(ctx).Error("listPostgreSQLServerKeys", "List", err)
 		return nil, err
 	}
 
@@ -398,7 +398,7 @@ func listPostgreSQLServerKeys(ctx context.Context, d *plugin.QueryData, h *plugi
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Trace("listPostgreSQLServerKeys", "list_paging", err)
+			plugin.Logger(ctx).Error("listPostgreSQLServerKeys", "list_paging", err)
 			return nil, err
 		}
 		for _, key := range op.Values() {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_postgresql_server []

PRETEST: tests/azure_postgresql_server

TEST: tests/azure_postgresql_server
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 5s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688]
azurerm_postgresql_server.named_test_resource: Creating...
azurerm_postgresql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m30s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m40s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m50s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m0s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m10s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m20s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m30s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m40s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m50s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [3m0s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [3m10s elapsed]
azurerm_postgresql_server.named_test_resource: Creation complete after 3m12s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688]
azurerm_postgresql_active_directory_administrator.named_test_resource: Creating...
azurerm_postgresql_configuration.named_test_resource: Creating...
azurerm_postgresql_firewall_rule.named_test_resource: Creating...
azurerm_postgresql_firewall_rule.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_configuration.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_active_directory_administrator.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_active_directory_administrator.named_test_resource: Creation complete after 18s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688/administrators/activeDirectory]
azurerm_postgresql_configuration.named_test_resource: Creation complete after 20s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688/configurations/log_checkpoints]
azurerm_postgresql_firewall_rule.named_test_resource: Still creating... [20s elapsed]
azurerm_postgresql_firewall_rule.named_test_resource: Creation complete after 21s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688/firewallRules/turbottest62688]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

location = eastus
resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest62688/providers/microsoft.dbforpostgresql/servers/turbottest62688
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688
resource_name = turbottest62688
server_fqdn = turbottest62688.postgres.database.azure.com
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "psqladminun",
    "backup_retention_days": 7,
    "fully_qualified_domain_name": "turbottest62688.postgres.database.azure.com",
    "geo_redundant_backup": "Disabled",
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688",
    "location": "eastus",
    "minimal_tls_version": "TLS1_2",
    "name": "turbottest62688",
    "public_network_access": "Enabled",
    "region": "eastus",
    "resource_group": "turbottest62688",
    "sku_family": "Gen5",
    "sku_name": "B_Gen5_1",
    "sku_size": null,
    "sku_tier": "Basic",
    "ssl_enforcement": "Enabled",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.DBforPostgreSQL/servers",
    "version": "9.5"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "configuration_name": "log_checkpoints",
    "configuration_value": "on",
    "end_ip_address": "40.112.8.12",
    "name": "turbottest62688",
    "rule_name": "turbottest62688",
    "rule_type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
    "server_admin_login_name": "ActiveDirectory",
    "start_ip_address": "40.112.8.12"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688",
    "location": "eastus",
    "name": "turbottest62688"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest62688/providers/Microsoft.DBforPostgreSQL/servers/turbottest62688",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest62688/providers/microsoft.dbforpostgresql/servers/turbottest62688"
    ],
    "name": "turbottest62688",
    "tags": {
      "name": "turbottest62688"
    },
    "title": "turbottest62688"
  }
]
✔ PASSED

POSTTEST: tests/azure_postgresql_server

TEARDOWN: tests/azure_postgresql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, jsonb_pretty(server_keys) as server_keys from azure_postgresql_server;
```

```
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name          | server_keys                                                                                                                                                                               
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| my-service-23 | [                                                                                                                                                                                         
|               |     {                                                                                                                                                                                     
|               |         "Type": "Microsoft.DBforPostgreSQL/servers/keys",                                                                                                                                 
|               |         "ServerKeyId": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.DBforPostgreSQL/servers/my-service-23/keys/test-server-key_test_5
|               |         "ServerKeyUri": "https://test-server-key.vault.azure.net/keys/test/50fd2286c589466b87fec8d89866530d",                                                                             
|               |         "ServerKeyKind": "azurekeyvault",                                                                                                                                                 
|               |         "ServerKeyName": "test-server-key_test_50fd2286c589466b87fec8d89866530d",                                                                                                         
|               |         "ServerKeyType": "AzureKeyVault",                                                                                                                                                 
|               |         "ServerKeyCreationDate": "2021-09-17T09:55:45.8Z"                                                                                                                                 
|               |     }                                                                                                                                                                                     
|               | ]                                                                                                                                                                                         
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

</details>
