### PR TITLE
Add Private Endpoint Connection details in table azure_sql_server closes #289

### DIFF
--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -126,7 +126,7 @@ func tableAzureSQLServer(_ context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
-				Name:        "private_endpoint_connactions",
+				Name:        "private_endpoint_connections",
 				Description: "The server private endpoint connections.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getSQLServerPrivateEndpointConnections,

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -615,6 +615,8 @@ func networkRuleMap(rule sql.VirtualNetworkRule) map[string]interface{} {
 	return objectMap
 }
 
+// If we return the API response directly, the output will not give
+// all the contents of PrivateEndpointConnection
 func privateEndpointConnectionMap(conn sqlv.PrivateEndpointConnection) PrivateConnectionInfo {
 	var connection PrivateConnectionInfo
 	if conn.ID != nil {

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -127,7 +127,7 @@ func tableAzureSQLServer(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "private_endpoint_connections",
-				Description: "The server private endpoint connections.",
+				Description: "The private endpoint connections of the sql server.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listSQLServerPrivateEndpointConnections,
 				Transform:   transform.FromValue(),
@@ -333,7 +333,7 @@ func listSQLServerPrivateEndpointConnections(ctx context.Context, d *plugin.Quer
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("listSQLServerPrivateEndpointConnections", "pagging", err)
+			plugin.Logger(ctx).Error("listSQLServerPrivateEndpointConnections", "ListByServer_pagination", err)
 			return nil, err
 		}
 		for _, conn := range op.Values() {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_sql_server []

PRETEST: tests/azure_sql_server

TEST: tests/azure_sql_server
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 36s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Storage/storageAccounts/turbottest57916]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m21s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916]
azurerm_sql_firewall_rule.named_test_resource: Creating...
azurerm_sql_firewall_rule.named_test_resource: Creation complete after 5s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/firewallRules/turbottest57916]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: "extended_auditing_policy": [DEPRECATED] the `extended_auditing_policy` block has been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.

  on variables.tf line 49, in resource "azurerm_sql_server" "named_test_resource":
  49: resource "azurerm_sql_server" "named_test_resource" {



Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

firewall_rule_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/firewallRules/turbottest57916
location = eastus
resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest57916/providers/microsoft.sql/servers/turbottest57916
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916
resource_name = turbottest57916
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "fully_qualified_domain_name": "turbottest57916.database.windows.net",
    "kind": "v12.0",
    "location": "eastus",
    "name": "turbottest57916",
    "region": "eastus",
    "resource_group": "turbottest57916",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "tags_src": {
      "name": "turbottest57916"
    },
    "type": "Microsoft.Sql/servers",
    "version": "12.0"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "encryption_protector": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/encryptionProtector/current",
        "kind": "servicemanaged",
        "name": "current",
        "properties": {
          "serverKeyName": "ServiceManaged",
          "serverKeyType": "ServiceManaged"
        },
        "type": "Microsoft.Sql/servers/encryptionProtector"
      }
    ],
    "firewall_rules": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/firewallRules/turbottest57916",
        "name": "turbottest57916",
        "properties": {
          "endIpAddress": "10.0.17.62",
          "startIpAddress": "10.0.17.62"
        },
        "type": "Microsoft.Sql/servers/firewallRules"
      }
    ],
    "name": "turbottest57916",
    "server_audit_policy": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/auditingSettings/Default",
        "name": "Default",
        "properties": {
          "auditActionsAndGroups": [
            "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
            "FAILED_DATABASE_AUTHENTICATION_GROUP",
            "BATCH_COMPLETED_GROUP"
          ],
          "isAzureMonitorTargetEnabled": true,
          "isStorageSecondaryKeyInUse": true,
          "retentionDays": 6,
          "state": "Enabled",
          "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
          "storageEndpoint": "https://turbottest57916.blob.core.windows.net/"
        },
        "type": "Microsoft.Sql/servers/auditingSettings"
      }
    ],
    "server_azure_ad_administrator": null,
    "server_security_alert_policy": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/securityAlertPolicies/Default",
        "name": "Default",
        "properties": {
          "disabledAlerts": [
            ""
          ],
          "emailAccountAdmins": false,
          "emailAddresses": [
            ""
          ],
          "retentionDays": 0,
          "state": "Disabled",
          "storageAccountAccessKey": "",
          "storageEndpoint": ""
        },
        "type": "Microsoft.Sql/servers/securityAlertPolicies"
      }
    ],
    "server_vulnerability_assessment": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916/vulnerabilityAssessments/Default",
        "name": "Default",
        "properties": {
          "recurringScans": {
            "emailSubscriptionAdmins": true,
            "isEnabled": false
          }
        },
        "type": "Microsoft.Sql/servers/vulnerabilityAssessments"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916",
    "location": "eastus",
    "name": "turbottest57916"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest57916/providers/Microsoft.Sql/servers/turbottest57916",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest57916/providers/microsoft.sql/servers/turbottest57916"
    ],
    "name": "turbottest57916",
    "title": "turbottest57916"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_server

TEARDOWN: tests/azure_sql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(private_endpoint_connections) as private_endpoint_connections from azure_sql_server;
+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name              | private_endpoint_connections                                                                                                                                                          
+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| test-sql-server23 | [                                                                                                                                                                                     
|                   |     {                                                                                                                                                                                 
|                   |         "PrivateEndpointId": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.Network/privateEndpoints/pec",                         
|                   |         "ProvisioningState": "Ready",                                                                                                                                                 
|                   |         "PrivateEndpointConnectionId": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/test-sql-server23/privateEndpoint
|                   |         "PrivateEndpointConnectionName": "pec-0572ade5-efdd-4999-9291-db1aed3c85ed",                                                                                                  
|                   |         "PrivateEndpointConnectionType": "Microsoft.Sql/servers/privateEndpointConnections",                                                                                          
|                   |         "PrivateLinkServiceConnectionStateStatus": "Approved",                                                                                                                        
|                   |         "PrivateLinkServiceConnectionStateDescription": "Auto-approved",                                                                                                              
|                   |         "PrivateLinkServiceConnectionStateActionsRequired": "None"                                                                                                                    
|                   |     }                                                                                                                                                                                 
|                   | ]                                                                                                                                                                                     
+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

</details>
