### PR TITLE
Add Private Endpoint Connection details in table azure_eventhub_namespace. Closes #303

### DIFF
--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -328,6 +328,7 @@ func listEventHubNamespaceDiagnosticSettings(ctx context.Context, d *plugin.Quer
 	return diagnosticSettings, nil
 }
 
+// If we return the API response directly, the output will not provide the properties of PrivateEndpointConnections
 func listEventHubNamespacePrivateEndpointConnections(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listEventHubNamespacePrivateEndpointConnections")
 

--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -148,7 +148,7 @@ func tableAzureEventHubNamespace(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "private_endpoint_connections",
-				Description: "Private endpoint connections to the instance.",
+				Description: "The private endpoint connections of the namespace.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listEventHubNamespacePrivateEndpointConnections,
 				Transform:   transform.FromValue(),

--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -328,7 +328,6 @@ func listEventHubNamespaceDiagnosticSettings(ctx context.Context, d *plugin.Quer
 	return diagnosticSettings, nil
 }
 
-// If we return the API response directly, the output will not provide the properties of PrivateEndpointConnections
 func listEventHubNamespacePrivateEndpointConnections(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listEventHubNamespacePrivateEndpointConnections")
 
@@ -354,29 +353,7 @@ func listEventHubNamespacePrivateEndpointConnections(ctx context.Context, d *plu
 	var eventHubNamespacePrivateEndpointConnections []map[string]interface{}
 
 	for _, i := range op.Values() {
-		eventHubNamespacePrivateEndpointConnection := make(map[string]interface{})
-		if i.ID != nil {
-			eventHubNamespacePrivateEndpointConnection["id"] = *i.ID
-		}
-		if i.Name != nil {
-			eventHubNamespacePrivateEndpointConnection["name"] = *i.Name
-		}
-		if i.Type != nil {
-			eventHubNamespacePrivateEndpointConnection["type"] = *i.Type
-		}
-		if i.PrivateEndpointConnectionProperties != nil {
-			if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
-				eventHubNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
-			}
-			if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
-				eventHubNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
-			}
-			if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
-				eventHubNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
-			}
-		}
-
-		eventHubNamespacePrivateEndpointConnections = append(eventHubNamespacePrivateEndpointConnections, eventHubNamespacePrivateEndpointConnection)
+		eventHubNamespacePrivateEndpointConnections = append(eventHubNamespacePrivateEndpointConnections, extractEventHubNamespacePrivateEndpointConnections(i))
 	}
 
 	for op.NotDone() {
@@ -386,31 +363,37 @@ func listEventHubNamespacePrivateEndpointConnections(ctx context.Context, d *plu
 			return nil, err
 		}
 		for _, i := range op.Values() {
-			eventHubNamespacePrivateEndpointConnection := make(map[string]interface{})
-			if i.ID != nil {
-				eventHubNamespacePrivateEndpointConnection["id"] = *i.ID
-			}
-			if i.Name != nil {
-				eventHubNamespacePrivateEndpointConnection["name"] = *i.Name
-			}
-			if i.Type != nil {
-				eventHubNamespacePrivateEndpointConnection["type"] = *i.Type
-			}
-			if i.PrivateEndpointConnectionProperties != nil {
-				if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
-					eventHubNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
-				}
-				if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
-					eventHubNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
-				}
-				if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
-					eventHubNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
-				}
-			}
 
-			eventHubNamespacePrivateEndpointConnections = append(eventHubNamespacePrivateEndpointConnections, eventHubNamespacePrivateEndpointConnection)
+			eventHubNamespacePrivateEndpointConnections = append(eventHubNamespacePrivateEndpointConnections, extractEventHubNamespacePrivateEndpointConnections(i))
 		}
 	}
 
 	return eventHubNamespacePrivateEndpointConnections, nil
+}
+
+// If we return the API response directly, the output will not provide the properties of PrivateEndpointConnections
+
+func extractEventHubNamespacePrivateEndpointConnections(i eventhub.PrivateEndpointConnection) map[string]interface{} {
+	eventHubNamespacePrivateEndpointConnection := make(map[string]interface{})
+	if i.ID != nil {
+		eventHubNamespacePrivateEndpointConnection["id"] = *i.ID
+	}
+	if i.Name != nil {
+		eventHubNamespacePrivateEndpointConnection["name"] = *i.Name
+	}
+	if i.Type != nil {
+		eventHubNamespacePrivateEndpointConnection["type"] = *i.Type
+	}
+	if i.PrivateEndpointConnectionProperties != nil {
+		if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
+			eventHubNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
+		}
+		if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
+			eventHubNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
+		}
+		if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
+			eventHubNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
+		}
+	}
+	return eventHubNamespacePrivateEndpointConnection
 }

--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -363,7 +363,6 @@ func listEventHubNamespacePrivateEndpointConnections(ctx context.Context, d *plu
 			return nil, err
 		}
 		for _, i := range op.Values() {
-
 			eventHubNamespacePrivateEndpointConnections = append(eventHubNamespacePrivateEndpointConnections, extractEventHubNamespacePrivateEndpointConnections(i))
 		}
 	}

--- a/docs/tables/azure_eventhub_namespace.md
+++ b/docs/tables/azure_eventhub_namespace.md
@@ -58,3 +58,20 @@ from
 where
   not is_auto_inflate_enabled;
 ```
+
+### List private endpoint connection details
+
+```sql
+select
+  name,
+  id,
+  connections ->> 'id' as connection_id,
+  connections ->> 'name' as connection_name,
+  connections ->> 'privateEndpointPropertyID' as property_private_endpoint_id,
+  connections ->> 'provisioningState' as property_provisioning_state,
+  jsonb_pretty(connections -> 'privateLinkServiceConnectionState') as property_private_link_service_connection_state,
+  connections ->> 'type' as connection_type
+from
+  azure_eventhub_namespace,
+  jsonb_array_elements(private_endpoint_connections) as connections;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_eventhub_namespace
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_eventhub_namespace []

PRETEST: tests/azure_eventhub_namespace

TEST: tests/azure_eventhub_namespace
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_eventhub_namespace.named_test_resource will be created
  + resource "azurerm_eventhub_namespace" "named_test_resource" {
      + auto_inflate_enabled                = false
      + capacity                            = 1
      + default_primary_connection_string   = (sensitive value)
      + default_primary_key                 = (sensitive value)
      + default_secondary_connection_string = (sensitive value)
      + default_secondary_key               = (sensitive value)
      + id                                  = (known after apply)
      + kafka_enabled                       = false
      + location                            = "westus"
      + maximum_throughput_units            = (known after apply)
      + name                                = "turbottest99342"
      + network_rulesets                    = (known after apply)
      + resource_group_name                 = "turbottest99342"
      + sku                                 = "Standard"
      + tags                                = {
          + "name" = "turbottest99342"
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westus"
      + name     = "turbottest99342"
      + tags     = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "westus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest99342"
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342]
azurerm_eventhub_namespace.named_test_resource: Creating...
azurerm_eventhub_namespace.named_test_resource: Still creating... [10s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [20s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [30s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [40s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [50s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [1m0s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [1m10s elapsed]
azurerm_eventhub_namespace.named_test_resource: Creation complete after 1m19s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 28, in data "null_data_source" "resource":
  28: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "westus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest99342/providers/microsoft.eventhub/namespaces/turbottest99342"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342"
resource_name = "turbottest99342"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342",
    "is_auto_inflate_enabled": false,
    "kafka_enabled": true,
    "name": "turbottest99342",
    "region": "westus",
    "resource_group": "turbottest99342",
    "type": "Microsoft.EventHub/Namespaces"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest99342/providers/microsoft.eventhub/namespaces/turbottest99342"
    ],
    "name": "turbottest99342",
    "tags": {
      "name": "turbottest99342"
    },
    "title": "turbottest99342"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342",
    "name": "turbottest99342"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest99342/providers/Microsoft.EventHub/namespaces/turbottest99342",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest99342/providers/microsoft.eventhub/namespaces/turbottest99342"
    ],
    "name": "turbottest99342",
    "tags": {
      "name": "turbottest99342"
    },
    "title": "turbottest99342"
  }
]
✔ PASSED

POSTTEST: tests/azure_eventhub_namespace

TEARDOWN: tests/azure_eventhub_namespace

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  type,
  provisioning_state,
  created_at
from
  azure_eventhub_namespace;
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| name                    | id                                                                                                                                                           | type             
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| test-standard-namespace | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-standard-namespace | Microsoft.EventHu
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
> select
  name,
  id,
  type,
  network_rule_set -> 'properties' -> 'virtualNetworkRules' as virtual_network_rules
from
  azure_eventhub_namespace
where
  network_rule_set -> 'properties' -> 'virtualNetworkRules' = '[]';
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| name                    | id                                                                                                                                                           | type             
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| test-standard-namespace | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-standard-namespace | Microsoft.EventHu
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
> select
  name,
  id,
  type,
  encryption
from
  azure_eventhub_namespace
where
  encryption is null;
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| name                    | id                                                                                                                                                           | type             
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| test-standard-namespace | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-standard-namespace | Microsoft.EventHu
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
> select
  name,
  id,
  type,
  is_auto_inflate_enabled
from
  azure_eventhub_namespace
where
  not is_auto_inflate_enabled;
+------+----+------+-------------------------+
| name | id | type | is_auto_inflate_enabled |
+------+----+------+-------------------------+
+------+----+------+-------------------------+
> select
  name,
  id,
  connections ->> 'id' as connection_id,
  connections ->> 'name' as connection_name,
  connections ->> 'privateEndpointPropertyID' as property_private_endpoint_id,
  connections ->> 'provisioningState' as property_provisioning_state,
  jsonb_pretty(connections -> 'privateLinkServiceConnectionState') as property_private_link_service_connection_state,
  connections ->> 'type' as connection_type
from
  azure_eventhub_namespace,
  jsonb_array_elements(private_endpoint_connections) as connections;
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| name                    | id                                                                                                                                                           | connection_id    
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
| test-standard-namespace | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-standard-namespace | /subscriptions/d4
|                         |                                                                                                                                                              |                  
|                         |                                                                                                                                                              |                  
|                         |                                                                                                                                                              |                  
+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
> 
```
</details>
