### PR TITLE
Add Private Endpoint Connection details in table azure_servicebus_namespace. Closes #295

### DIFF
--- a/azure/table_azure_servicebus_namespace.go
+++ b/azure/table_azure_servicebus_namespace.go
@@ -116,6 +116,13 @@ func tableAzureServiceBusNamespace(_ context.Context) *plugin.Table {
 				Hydrate:     getServiceBusNamespaceNetworkRuleSet,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "private_endpoint_connections",
+				Description: "The private endpoint connections of the namespace.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listServiceBusNamespacePrivateEndpointConnections,
+				Transform:   transform.FromValue(),
+			},
 
 			// Steampipe standard columns
 			{
@@ -290,4 +297,91 @@ func listServiceBusNamespaceDiagnosticSettings(ctx context.Context, d *plugin.Qu
 		diagnosticSettings = append(diagnosticSettings, objectMap)
 	}
 	return diagnosticSettings, nil
+}
+
+// If we return the API response directly, the output will not provide the properties of PrivateEndpointConnections
+func listServiceBusNamespacePrivateEndpointConnections(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listServiceBusNamespacePrivateEndpointConnections")
+
+	namespace := h.Item.(servicebus.SBNamespace)
+	resourceGroup := strings.Split(string(*namespace.ID), "/")[4]
+	namespaceName := *namespace.Name
+
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	client := servicebus.NewPrivateEndpointConnectionsClient(subscriptionID)
+	client.Authorizer = session.Authorizer
+
+	op, err := client.List(ctx, resourceGroup, namespaceName)
+	if err != nil {
+		plugin.Logger(ctx).Error("listServiceBusNamespacePrivateEndpointConnections", "list", err)
+		return nil, err
+	}
+
+	var serviceBusNamespacePrivateEndpointConnections []map[string]interface{}
+
+	for _, i := range op.Values() {
+		serviceBusNamespacePrivateEndpointConnection := make(map[string]interface{})
+		if i.ID != nil {
+			serviceBusNamespacePrivateEndpointConnection["id"] = *i.ID
+		}
+		if i.Name != nil {
+			serviceBusNamespacePrivateEndpointConnection["name"] = *i.Name
+		}
+		if i.Type != nil {
+			serviceBusNamespacePrivateEndpointConnection["type"] = *i.Type
+		}
+		if i.PrivateEndpointConnectionProperties != nil {
+			if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
+				serviceBusNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
+			}
+			if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
+				serviceBusNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
+			}
+			if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
+				serviceBusNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
+			}
+		}
+
+		serviceBusNamespacePrivateEndpointConnections = append(serviceBusNamespacePrivateEndpointConnections, serviceBusNamespacePrivateEndpointConnection)
+	}
+
+	for op.NotDone() {
+		err = op.NextWithContext(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("listServiceBusNamespacePrivateEndpointConnections", "list_paging", err)
+			return nil, err
+		}
+		for _, i := range op.Values() {
+			serviceBusNamespacePrivateEndpointConnection := make(map[string]interface{})
+			if i.ID != nil {
+				serviceBusNamespacePrivateEndpointConnection["id"] = *i.ID
+			}
+			if i.Name != nil {
+				serviceBusNamespacePrivateEndpointConnection["name"] = *i.Name
+			}
+			if i.Type != nil {
+				serviceBusNamespacePrivateEndpointConnection["type"] = *i.Type
+			}
+			if i.PrivateEndpointConnectionProperties != nil {
+				if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
+					serviceBusNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
+				}
+				if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
+					serviceBusNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
+				}
+				if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
+					serviceBusNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
+				}
+			}
+
+			serviceBusNamespacePrivateEndpointConnections = append(serviceBusNamespacePrivateEndpointConnections, serviceBusNamespacePrivateEndpointConnection)
+		}
+	}
+
+	return serviceBusNamespacePrivateEndpointConnections, nil
 }

--- a/azure/table_azure_servicebus_namespace.go
+++ b/azure/table_azure_servicebus_namespace.go
@@ -299,7 +299,6 @@ func listServiceBusNamespaceDiagnosticSettings(ctx context.Context, d *plugin.Qu
 	return diagnosticSettings, nil
 }
 
-// If we return the API response directly, the output will not provide the properties of PrivateEndpointConnections
 func listServiceBusNamespacePrivateEndpointConnections(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listServiceBusNamespacePrivateEndpointConnections")
 
@@ -325,29 +324,7 @@ func listServiceBusNamespacePrivateEndpointConnections(ctx context.Context, d *p
 	var serviceBusNamespacePrivateEndpointConnections []map[string]interface{}
 
 	for _, i := range op.Values() {
-		serviceBusNamespacePrivateEndpointConnection := make(map[string]interface{})
-		if i.ID != nil {
-			serviceBusNamespacePrivateEndpointConnection["id"] = *i.ID
-		}
-		if i.Name != nil {
-			serviceBusNamespacePrivateEndpointConnection["name"] = *i.Name
-		}
-		if i.Type != nil {
-			serviceBusNamespacePrivateEndpointConnection["type"] = *i.Type
-		}
-		if i.PrivateEndpointConnectionProperties != nil {
-			if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
-				serviceBusNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
-			}
-			if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
-				serviceBusNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
-			}
-			if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
-				serviceBusNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
-			}
-		}
-
-		serviceBusNamespacePrivateEndpointConnections = append(serviceBusNamespacePrivateEndpointConnections, serviceBusNamespacePrivateEndpointConnection)
+		serviceBusNamespacePrivateEndpointConnections = append(serviceBusNamespacePrivateEndpointConnections, extractServiceBusNamespacePrivateEndpointConnection(i))
 	}
 
 	for op.NotDone() {
@@ -357,31 +334,35 @@ func listServiceBusNamespacePrivateEndpointConnections(ctx context.Context, d *p
 			return nil, err
 		}
 		for _, i := range op.Values() {
-			serviceBusNamespacePrivateEndpointConnection := make(map[string]interface{})
-			if i.ID != nil {
-				serviceBusNamespacePrivateEndpointConnection["id"] = *i.ID
-			}
-			if i.Name != nil {
-				serviceBusNamespacePrivateEndpointConnection["name"] = *i.Name
-			}
-			if i.Type != nil {
-				serviceBusNamespacePrivateEndpointConnection["type"] = *i.Type
-			}
-			if i.PrivateEndpointConnectionProperties != nil {
-				if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
-					serviceBusNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
-				}
-				if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
-					serviceBusNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
-				}
-				if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
-					serviceBusNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
-				}
-			}
-
-			serviceBusNamespacePrivateEndpointConnections = append(serviceBusNamespacePrivateEndpointConnections, serviceBusNamespacePrivateEndpointConnection)
+			serviceBusNamespacePrivateEndpointConnections = append(serviceBusNamespacePrivateEndpointConnections, extractServiceBusNamespacePrivateEndpointConnection(i))
 		}
 	}
 
 	return serviceBusNamespacePrivateEndpointConnections, nil
+}
+
+// If we return the API response directly, the output will not provide the properties of PrivateEndpointConnections
+func extractServiceBusNamespacePrivateEndpointConnection(i servicebus.PrivateEndpointConnection) map[string]interface{} {
+	serviceBusNamespacePrivateEndpointConnection := make(map[string]interface{})
+	if i.ID != nil {
+		serviceBusNamespacePrivateEndpointConnection["id"] = *i.ID
+	}
+	if i.Name != nil {
+		serviceBusNamespacePrivateEndpointConnection["name"] = *i.Name
+	}
+	if i.Type != nil {
+		serviceBusNamespacePrivateEndpointConnection["type"] = *i.Type
+	}
+	if i.PrivateEndpointConnectionProperties != nil {
+		if len(i.PrivateEndpointConnectionProperties.ProvisioningState) > 0 {
+			serviceBusNamespacePrivateEndpointConnection["provisioningState"] = i.PrivateEndpointConnectionProperties.ProvisioningState
+		}
+		if i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState != nil {
+			serviceBusNamespacePrivateEndpointConnection["privateLinkServiceConnectionState"] = i.PrivateEndpointConnectionProperties.PrivateLinkServiceConnectionState
+		}
+		if i.PrivateEndpointConnectionProperties.PrivateEndpoint != nil && i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID != nil {
+			serviceBusNamespacePrivateEndpointConnection["privateEndpointPropertyID"] = i.PrivateEndpointConnectionProperties.PrivateEndpoint.ID
+		}
+	}
+	return serviceBusNamespacePrivateEndpointConnection
 }

--- a/docs/tables/azure_servicebus_namespace.md
+++ b/docs/tables/azure_servicebus_namespace.md
@@ -67,3 +67,20 @@ where
     )
   );
 ```
+
+### List private endpoint connection details
+
+```sql
+select
+  name,
+  id,
+  connections ->> 'id' as connection_id,
+  connections ->> 'name' as connection_name,
+  connections ->> 'privateEndpointPropertyID' as property_private_endpoint_id,
+  connections ->> 'provisioningState' as property_provisioning_state,
+  jsonb_pretty(connections -> 'privateLinkServiceConnectionState') as property_private_link_service_connection_state,
+  connections ->> 'type' as connection_type
+from
+  azure_servicebus_namespace,
+  jsonb_array_elements(private_endpoint_connections) as connections;
+```


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_servicebus_namespace                                                                                      
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_servicebus_namespace []

PRETEST: tests/azure_servicebus_namespace

TEST: tests/azure_servicebus_namespace
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest49027"
    }

  # azurerm_servicebus_namespace.named_test_resource will be created
  + resource "azurerm_servicebus_namespace" "named_test_resource" {
      + capacity                            = 0
      + default_primary_connection_string   = (sensitive value)
      + default_primary_key                 = (sensitive value)
      + default_secondary_connection_string = (sensitive value)
      + default_secondary_key               = (sensitive value)
      + id                                  = (known after apply)
      + location                            = "eastus"
      + name                                = "turbottest49027"
      + resource_group_name                 = "turbottest49027"
      + sku                                 = "Basic"
      + tags                                = {
          + "name" = "turbottest49027"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "eastus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest49027"
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027]
azurerm_servicebus_namespace.named_test_resource: Creating...
azurerm_servicebus_namespace.named_test_resource: Still creating... [10s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [20s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [30s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [40s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [50s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [1m0s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [1m10s elapsed]
azurerm_servicebus_namespace.named_test_resource: Creation complete after 1m10s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version = "=2.41.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest49027/providers/microsoft.servicebus/namespaces/turbottest49027"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027"
resource_name = "turbottest49027"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "encryption": null,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027",
    "name": "turbottest49027",
    "network_rule_set": {
      "properties": {
        "defaultAction": "Deny",
        "ipRules": [],
        "virtualNetworkRules": []
      }
    },
    "provisioning_state": "Succeeded",
    "servicebus_endpoint": "https://turbottest49027.servicebus.windows.net:443/",
    "sku_name": "Basic",
    "sku_tier": "Basic",
    "type": "Microsoft.ServiceBus/Namespaces",
    "zone_redundant": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027",
    "name": "turbottest49027"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest49027/providers/microsoft.servicebus/namespaces/turbottest49027"
    ],
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest49027/providers/Microsoft.ServiceBus/namespaces/turbottest49027",
    "name": "turbottest49027",
    "region": "eastus",
    "resource_group": "turbottest49027",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "tags": {
      "name": "turbottest49027"
    },
    "title": "turbottest49027"
  }
]
✔ PASSED

POSTTEST: tests/azure_servicebus_namespace

TEARDOWN: tests/azure_servicebus_namespace

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  sku_tier,
  provisioning_state,
  created_at
from
  azure_servicebus_namespace;
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-------------------
| name             | id                                                                                                                                                      | sku_tier | provisioning_state
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-------------------
| test-premium-bus | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-premium-bus | Premium  | Succeeded         
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-------------------
> select
  name,
  sku_tier,
  region
from
  azure_servicebus_namespace
where
  sku_tier = 'Premium';
+------------------+----------+-----------+
| name             | sku_tier | region    |
+------------------+----------+-----------+
| test-premium-bus | Premium  | centralus |
+------------------+----------+-----------+
> select
  name,
  sku_tier,
  encryption
from
  azure_servicebus_namespace
where
  sku_tier = 'Premium'
  and encryption is null;
+------------------+----------+------------+
| name             | sku_tier | encryption |
+------------------+----------+------------+
| test-premium-bus | Premium  | <null>     |
+------------------+----------+------------+
> select
  name,
  region,
  network_rule_set -> 'properties' -> 'virtualNetworkRules' as virtual_network_rules
from
  azure_servicebus_namespace
where
  sku_tier = 'Premium'
  and (
    jsonb_array_length(network_rule_set -> 'properties' -> 'virtualNetworkRules') = 0
    or exists (
      select
        * 
      from
        jsonb_array_elements(network_rule_set -> 'properties' -> 'virtualNetworkRules') as t
      where
        t -> 'subnet' ->> 'id' is null
    )
  );
+------------------+-----------+-----------------------+
| name             | region    | virtual_network_rules |
+------------------+-----------+-----------------------+
| test-premium-bus | centralus | []                    |
+------------------+-----------+-----------------------+
> select
  name,
  id,
  connections ->> 'id' as connection_id,
  connections ->> 'name' as connection_name,
  connections ->> 'privateEndpointPropertyID' as property_private_endpoint_id,
  connections ->> 'provisioningState' as property_provisioning_state,
  jsonb_pretty(connections -> 'privateLinkServiceConnectionState') as property_private_link_service_connection_state,
  connections ->> 'type' as connection_type
from
  azure_servicebus_namespace,
  jsonb_array_elements(private_endpoint_connections) as connections;
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------
| name             | id                                                                                                                                                      | connection_id                
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------
| test-premium-bus | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-premium-bus | /subscriptions/d46d7416-f95f-
|                  |                                                                                                                                                         |                              
|                  |                                                                                                                                                         |                              
|                  |                                                                                                                                                         |                              
+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------
> 
```
</details>
