### PR TITLE
Fix private_endpoint_connections column for table azure_mysql_server. Closes #304

### DIFF
--- a/azure-test/tests/azure_mysql_server/test-get-expected.json
+++ b/azure-test/tests/azure_mysql_server/test-get-expected.json
@@ -11,15 +11,15 @@
 		"public_network_access": "Enabled",
 		"region": "eastus",
 		"resource_group": "{{ resourceName }}",
-		"sku_capacity": 1,
+		"sku_capacity": 2,
 		"sku_family": "Gen5",
-		"sku_name": "B_Gen5_1",
+		"sku_name": "B_Gen5_2",
 		"sku_tier": "Basic",
 		"ssl_enforcement": "Enabled",
 		"storage_auto_grow": "Disabled",
 		"storage_mb": 5120,
 		"subscription_id": "{{ output.subscription_id.value }}",
 		"type": "Microsoft.DBforMySQL/servers",
-		"version": "5.6"
+		"version": "5.7"
 	}
 ]

--- a/azure-test/tests/azure_mysql_server/variables.tf
+++ b/azure-test/tests/azure_mysql_server/variables.tf
@@ -17,18 +17,20 @@ variable "azure_subscription" {
   description = "Azure subscription used for the test."
 }
 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.73.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
   features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
-}
-
-data "azurerm_client_config" "current" {}
-
-data "null_data_source" "resource" {
-  inputs = {
-    scope = "azure:///subscriptions/${data.azurerm_client_config.current.subscription_id}"
-  }
 }
 
 resource "azurerm_resource_group" "named_test_resource" {
@@ -44,9 +46,9 @@ resource "azurerm_mysql_server" "named_test_resource" {
   administrator_login          = "mradministrator"
   administrator_login_password = "H@Sh1CoR3!"
 
-  sku_name   = "B_Gen5_1"
+  sku_name   = "B_Gen5_2"
   storage_mb = 5120
-  version    = "5.6"
+  version    = "5.7"
 
   auto_grow_enabled                 = false
   backup_retention_days             = 7

--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -311,12 +311,27 @@ func extractMySQLServerPrivateEndpointConnections(ctx context.Context, d *transf
 				objectMap["id"] = i.ID
 			}
 			if i.Properties != nil {
-				objectMap["properties"] = i.Properties
-				objectMap["provisioningState"] = i.Properties.ProvisioningState
+				if i.Properties.PrivateEndpoint != nil {
+					objectMap["privateEndpointPropertyId"] = i.Properties.PrivateEndpoint.ID
+				}
+				if i.Properties.PrivateLinkServiceConnectionState != nil {
+					if len(i.Properties.PrivateLinkServiceConnectionState.ActionsRequired) > 0 {
+						objectMap["privateLinkServiceConnectionStateActionsRequired"] = i.Properties.PrivateLinkServiceConnectionState.ActionsRequired
+					}
+					if len(i.Properties.PrivateLinkServiceConnectionState.Status) > 0 {
+						objectMap["privateLinkServiceConnectionStateStatus"] = i.Properties.PrivateLinkServiceConnectionState.Status
+					}
+					if i.Properties.PrivateLinkServiceConnectionState.Description != nil {
+						objectMap["privateLinkServiceConnectionStateDescription"] = i.Properties.PrivateLinkServiceConnectionState.Description
+					}
+				}
+				if len(i.Properties.ProvisioningState) > 0 {
+					objectMap["provisioningState"] = i.Properties.ProvisioningState
+				}
 			}
 			properties = append(properties, objectMap)
 		}
 	}
-	
+
 	return properties, nil
 }

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -91,7 +91,10 @@ select
   name as server_name,
   id as server_id,
   connections ->> 'id' as connection_id,
-  jsonb_pretty(connections -> 'properties') as connection_property,
+  connections ->> 'privateEndpointPropertyId' as connection_private_endpoint_property_id,
+  connections ->> 'privateLinkServiceConnectionStateActionsRequired' as connection_actions_required,
+  connections ->> 'privateLinkServiceConnectionStateDescription' as connection_description,
+  connections ->> 'privateLinkServiceConnectionStateStatus' as connection_status,
   connections ->> 'provisioningState' as connection_provisioning_state
 from
   azure_mysql_server,

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -83,3 +83,17 @@ where
   minimal_tls_version = 'TLS1_0'
   or minimal_tls_version = 'TLS1_1';
 ```
+
+### List private endpoint connection details
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  connections ->> 'id' as connection_id,
+  jsonb_pretty(connections -> 'properties') as connection_property,
+  connections ->> 'provisioningState' as connection_provisioning_state
+from
+  azure_mysql_server,
+  jsonb_array_elements(private_endpoint_connections) as connections;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_mysql_server
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_mysql_server []

PRETEST: tests/azure_mysql_server

TEST: tests/azure_mysql_server
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_mysql_server.named_test_resource will be created
  + resource "azurerm_mysql_server" "named_test_resource" {
      + administrator_login               = "mradministrator"
      + administrator_login_password      = (sensitive value)
      + auto_grow_enabled                 = false
      + backup_retention_days             = 7
      + create_mode                       = "Default"
      + fqdn                              = (known after apply)
      + geo_redundant_backup_enabled      = false
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + location                          = "eastus"
      + name                              = "turbottest75018"
      + public_network_access_enabled     = true
      + resource_group_name               = "turbottest75018"
      + sku_name                          = "B_Gen5_2"
      + ssl_enforcement                   = (known after apply)
      + ssl_enforcement_enabled           = true
      + ssl_minimal_tls_version_enforced  = "TLS1_2"
      + storage_mb                        = 5120
      + tags                              = {
          + "name" = "turbottest75018"
        }
      + version                           = "5.7"

      + storage_profile {
          + auto_grow             = (known after apply)
          + backup_retention_days = (known after apply)
          + geo_redundant_backup  = (known after apply)
          + storage_mb            = (known after apply)
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest75018"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "eastus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest75018"
  + server_fqdn        = (known after apply)
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest75018]
azurerm_mysql_server.named_test_resource: Creating...
azurerm_mysql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m30s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m40s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m50s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m0s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m20s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m30s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m40s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m50s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [3m0s elapsed]
azurerm_mysql_server.named_test_resource: Creation complete after 3m8s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest75018/providers/Microsoft.DBforMySQL/servers/turbottest75018]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest75018/providers/Microsoft.DBforMySQL/servers/turbottest75018"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest75018/providers/microsoft.dbformysql/servers/turbottest75018"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest75018/providers/Microsoft.DBforMySQL/servers/turbottest75018"
resource_name = "turbottest75018"
server_fqdn = "turbottest75018.mysql.database.azure.com"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "backup_retention_days": 7,
    "fully_qualified_domain_name": "turbottest75018.mysql.database.azure.com",
    "geo_redundant_backup": "Disabled",
    "infrastructure_encryption": "Disabled",
    "location": "eastus",
    "minimal_tls_version": "TLS1_2",
    "name": "turbottest75018",
    "public_network_access": "Enabled",
    "region": "eastus",
    "resource_group": "turbottest75018",
    "sku_capacity": 2,
    "sku_family": "Gen5",
    "sku_name": "B_Gen5_2",
    "sku_tier": "Basic",
    "ssl_enforcement": "Enabled",
    "storage_auto_grow": "Disabled",
    "storage_mb": 5120,
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.DBforMySQL/servers",
    "version": "5.7"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest75018/providers/Microsoft.DBforMySQL/servers/turbottest75018",
    "location": "eastus",
    "name": "turbottest75018"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest75018/providers/Microsoft.DBforMySQL/servers/turbottest75018",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest75018/providers/microsoft.dbformysql/servers/turbottest75018"
    ],
    "name": "turbottest75018",
    "tags": {
      "name": "turbottest75018"
    },
    "title": "turbottest75018"
  }
]
✔ PASSED

POSTTEST: tests/azure_mysql_server

TEARDOWN: tests/azure_mysql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  location,
  ssl_enforcement,
  minimal_tls_version
from
  azure_mysql_server;
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-----------------+---
| name             | id                                                                                                                                                   | location  | ssl_enforcement | mi
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-----------------+---
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforMySQL/servers/test-gen5-server | centralus | Enabled         | TL
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-----------------+---
> select
  name,
  id,
  location,
  ssl_enforcement
from
  azure_mysql_server
where
  ssl_enforcement = 'Enabled';
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-----------------+
| name             | id                                                                                                                                                   | location  | ssl_enforcement |
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-----------------+
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforMySQL/servers/test-gen5-server | centralus | Enabled         |
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-----------------+
> select
  name,
  id,
  public_network_access
from
  azure_mysql_server
where
  public_network_access = 'Disabled';
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+
| name             | id                                                                                                                                                   | public_network_access |
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforMySQL/servers/test-gen5-server | Disabled              |
+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+
> select
  name,
  id,
  storage_auto_grow
from
  azure_mysql_server
where
  storage_auto_grow = 'Disabled';
+------+----+-------------------+
| name | id | storage_auto_grow |
+------+----+-------------------+
+------+----+-------------------+
> select
  name,
  id,
  backup_retention_days
from
  azure_mysql_server
where
  backup_retention_days > 90;
+------+----+-----------------------+
| name | id | backup_retention_days |
+------+----+-----------------------+
+------+----+-----------------------+
> select
  name,
  id,
  minimal_tls_version
from
  azure_mysql_server
where
  minimal_tls_version = 'TLS1_0'
  or minimal_tls_version = 'TLS1_1';
+------+----+---------------------+
| name | id | minimal_tls_version |
+------+----+---------------------+
+------+----+---------------------+
> select
  name as server_name,
  id as server_id,
  connections ->> 'id' as connection_id,
  connections ->> 'privateEndpointPropertyId' as connection_private_endpoint_property_id,
  connections ->> 'privateLinkServiceConnectionStateActionsRequired' as connection_actions_required,
  connections ->> 'privateLinkServiceConnectionStateDescription' as connection_description,
  connections ->> 'privateLinkServiceConnectionStateStatus' as connection_status,
  connections ->> 'provisioningState' as connection_provisioning_state
from
  azure_mysql_server,
  jsonb_array_elements(private_endpoint_connections) as connections;
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------
| server_name        | server_id                                                                                                                                              | connection_id               
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------
| test-gen5-server-1 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforMySQL/servers/test-gen5-server-1 | /subscriptions/d46d7416-f95f
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------
>
```
</details>
