### PR TITLE
Fix private_endpoint_connections column for table azure_postgresql_server. Closes #309

### DIFF
--- a/docs/tables/azure_postgresql_server.md
+++ b/docs/tables/azure_postgresql_server.md
@@ -104,3 +104,20 @@ from
 where
   geo_redundant_backup = 'Disabled';
 ```
+
+### List private endpoint connection details
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  connections ->> 'id' as connection_id,
+  connections ->> 'privateEndpointPropertyId' as connection_private_endpoint_property_id,
+  connections ->> 'privateLinkServiceConnectionStateActionsRequired' as connection_actions_required,
+  connections ->> 'privateLinkServiceConnectionStateDescription' as connection_description,
+  connections ->> 'privateLinkServiceConnectionStateStatus' as connection_status,
+  connections ->> 'provisioningState' as connection_provisioning_state
+from
+  azure_postgresql_server,
+  jsonb_array_elements(private_endpoint_connections) as connections;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_postgresql_server
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_postgresql_server []

PRETEST: tests/azure_postgresql_server

TEST: tests/azure_postgresql_server
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_postgresql_active_directory_administrator.named_test_resource will be created
  + resource "azurerm_postgresql_active_directory_administrator" "named_test_resource" {
      + id                  = (known after apply)
      + login               = "sqladmin"
      + object_id           = "bc3de371-eae8-4a42-a172-84bb6ce25bfb"
      + resource_group_name = "turbottest46070"
      + server_name         = "turbottest46070"
      + tenant_id           = "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
    }

  # azurerm_postgresql_configuration.named_test_resource will be created
  + resource "azurerm_postgresql_configuration" "named_test_resource" {
      + id                  = (known after apply)
      + name                = "log_checkpoints"
      + resource_group_name = "turbottest46070"
      + server_name         = "turbottest46070"
      + value               = "on"
    }

  # azurerm_postgresql_firewall_rule.named_test_resource will be created
  + resource "azurerm_postgresql_firewall_rule" "named_test_resource" {
      + end_ip_address      = "40.112.8.12"
      + id                  = (known after apply)
      + name                = "turbottest46070"
      + resource_group_name = "turbottest46070"
      + server_name         = "turbottest46070"
      + start_ip_address    = "40.112.8.12"
    }

  # azurerm_postgresql_server.named_test_resource will be created
  + resource "azurerm_postgresql_server" "named_test_resource" {
      + administrator_login               = "psqladminun"
      + administrator_login_password      = (sensitive value)
      + auto_grow_enabled                 = false
      + backup_retention_days             = 7
      + create_mode                       = "Default"
      + fqdn                              = (known after apply)
      + geo_redundant_backup_enabled      = false
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + location                          = "eastus"
      + name                              = "turbottest46070"
      + public_network_access_enabled     = true
      + resource_group_name               = "turbottest46070"
      + sku_name                          = "B_Gen5_1"
      + ssl_enforcement                   = (known after apply)
      + ssl_enforcement_enabled           = true
      + ssl_minimal_tls_version_enforced  = "TLS1_2"
      + storage_mb                        = 5120
      + tags                              = {
          + "name" = "turbottest46070"
        }
      + version                           = "9.5"

      + storage_profile {
          + auto_grow             = (known after apply)
          + backup_retention_days = (known after apply)
          + geo_redundant_backup  = (known after apply)
          + storage_mb            = (known after apply)
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest46070"
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "eastus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest46070"
  + server_fqdn        = (known after apply)
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070]
azurerm_postgresql_server.named_test_resource: Creating...
azurerm_postgresql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m30s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m40s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [1m50s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m0s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m10s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m20s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m30s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m40s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [2m50s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [3m0s elapsed]
azurerm_postgresql_server.named_test_resource: Still creating... [3m10s elapsed]
azurerm_postgresql_server.named_test_resource: Creation complete after 3m12s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070]
azurerm_postgresql_firewall_rule.named_test_resource: Creating...
azurerm_postgresql_configuration.named_test_resource: Creating...
azurerm_postgresql_active_directory_administrator.named_test_resource: Creating...
azurerm_postgresql_active_directory_administrator.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_configuration.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_firewall_rule.named_test_resource: Still creating... [10s elapsed]
azurerm_postgresql_configuration.named_test_resource: Creation complete after 18s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070/configurations/log_checkpoints]
azurerm_postgresql_active_directory_administrator.named_test_resource: Creation complete after 19s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070/administrators/activeDirectory]
azurerm_postgresql_firewall_rule.named_test_resource: Creation complete after 19s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070/firewallRules/turbottest46070]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 28, in data "null_data_source" "resource":
  28: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest46070/providers/microsoft.dbforpostgresql/servers/turbottest46070"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070"
resource_name = "turbottest46070"
server_fqdn = "turbottest46070.postgres.database.azure.com"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "psqladminun",
    "backup_retention_days": 7,
    "fully_qualified_domain_name": "turbottest46070.postgres.database.azure.com",
    "geo_redundant_backup": "Disabled",
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070",
    "location": "eastus",
    "minimal_tls_version": "TLS1_2",
    "name": "turbottest46070",
    "public_network_access": "Enabled",
    "region": "eastus",
    "resource_group": "turbottest46070",
    "sku_family": "Gen5",
    "sku_name": "B_Gen5_1",
    "sku_size": null,
    "sku_tier": "Basic",
    "ssl_enforcement": "Enabled",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.DBforPostgreSQL/servers",
    "version": "9.5"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "configuration_name": "log_checkpoints",
    "configuration_value": "on",
    "end_ip_address": "40.112.8.12",
    "name": "turbottest46070",
    "rule_name": "turbottest46070",
    "rule_type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
    "server_admin_login_name": "ActiveDirectory",
    "start_ip_address": "40.112.8.12"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070",
    "location": "eastus",
    "name": "turbottest46070"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest46070/providers/microsoft.dbforpostgresql/servers/turbottest46070"
    ],
    "name": "turbottest46070",
    "tags": {
      "name": "turbottest46070"
    },
    "title": "turbottest46070"
  }
]
✔ PASSED

POSTTEST: tests/azure_postgresql_server

TEARDOWN: tests/azure_postgresql_server

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  location
from
  azure_postgresql_server;
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| name             | id                                                                                                                                                        | location  |
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| turbottest46070  | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070            | eastus    |
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforPostgreSQL/servers/test-gen5-server | centralus |
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
> select
  name,
  id,
  location,
  ssl_enforcement
from
  azure_postgresql_server
where
  ssl_enforcement = 'Disabled';
+------+----+----------+-----------------+
| name | id | location | ssl_enforcement |
+------+----+----------+-----------------+
+------+----+----------+-----------------+
> select
  name,
  id,
  rule ->> 'Name' as rule_name,
  rule ->> 'Type' as rule_type,
  rule -> 'FirewallRuleProperties' ->> 'endIpAddress' as end_ip_address,
  rule -> 'FirewallRuleProperties' ->> 'startIpAddress' as start_ip_address
from
  azure_postgresql_server,
  jsonb_array_elements(firewall_rules) as rule
where
  rule ->> 'Name' = 'AllowAllWindowsAzureIps'
  and rule -> 'FirewallRuleProperties' ->> 'startIpAddress' = '0.0.0.0'
  and rule -> 'FirewallRuleProperties' ->> 'endIpAddress' = '0.0.0.0';
+------+----+-----------+-----------+----------------+------------------+
| name | id | rule_name | rule_type | end_ip_address | start_ip_address |
+------+----+-----------+-----------+----------------+------------------+
+------+----+-----------+-----------+----------------+------------------+
> select
  name,
  id,
  location
from
  azure_postgresql_server
where
  server_administrators is null;
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| name             | id                                                                                                                                                        | location  |
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforPostgreSQL/servers/test-gen5-server | centralus |
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
> select
  name,
  configurations ->> 'Name' as configuration_name,
  configurations -> 'ConfigurationProperties' ->> 'value' as configuration_value
from
  azure_postgresql_server,
  jsonb_array_elements(server_configurations) as configurations
where
  configurations ->> 'Name' = 'log_checkpoints'
  and configurations -> 'ConfigurationProperties' ->> 'value' = 'OFF';
+------+--------------------+---------------------+
| name | configuration_name | configuration_value |
+------+--------------------+---------------------+
+------+--------------------+---------------------+
> select
  name,
  configurations ->> 'Name' as configuration_name,
  configurations -> 'ConfigurationProperties' ->> 'value' as configuration_value
from
  azure_postgresql_server,
  jsonb_array_elements(server_configurations) as configurations
where
  configurations ->> 'Name' = 'log_retention_days'
  and (configurations -> 'ConfigurationProperties' ->> 'value')::INTEGER > 3;
+------+--------------------+---------------------+
| name | configuration_name | configuration_value |
+------+--------------------+---------------------+
+------+--------------------+---------------------+
> select
  name,
  id,
  location,
  geo_redundant_backup
from
  azure_postgresql_server
where
  geo_redundant_backup = 'Disabled';
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+----------------
| name             | id                                                                                                                                                        | location  | geo_redundant_b
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+----------------
| turbottest46070  | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest46070/providers/Microsoft.DBforPostgreSQL/servers/turbottest46070            | eastus    | Disabled       
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforPostgreSQL/servers/test-gen5-server | centralus | Disabled       
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+----------------
> select
  name as server_name,
  id as server_id,
  connections ->> 'id' as connection_id,
  connections ->> 'privateEndpointPropertyId' as connection_private_endpoint_property_id,
  connections ->> 'privateLinkServiceConnectionStateActionsRequired' as connection_actions_required,
  connections ->> 'privateLinkServiceConnectionStateDescription' as connection_description,
  connections ->> 'privateLinkServiceConnectionStateStatus' as connection_status,
  connections ->> 'provisioningState' as connection_provisioning_state
from
  azure_postgresql_server,
  jsonb_array_elements(private_endpoint_connections) as connections;
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------
| server_name      | server_id                                                                                                                                                 | connection_id              
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------
| test-gen5-server | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.DBforPostgreSQL/servers/test-gen5-server | /subscriptions/d46d7416-f95
+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------
>
```
</details>
