### PR TITLE
Add VirtualMachineIdentity details in table azure_compute_virtual_machine. Closes #321

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -308,6 +308,11 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
+				Name:        "identity",
+				Description: "The identity of the virtual machine, if configured.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "win_rm",
 				Description: "Specifies the windows remote management listeners. This enables remote windows powershell.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/azure_compute_virtual_machine.md
+++ b/docs/tables/azure_compute_virtual_machine.md
@@ -119,3 +119,22 @@ where
   lower(vm_nic ->> 'id') = lower(nsg_int ->> 'id')
   and vm.name = 'warehouse-01';
 ```
+
+### List virtual machines with user assigned identities
+
+```sql
+select
+  name,
+  identity -> 'type' as identity_type,
+  jsonb_pretty(identity -> 'userAssignedIdentities') as identity_user_assignedidentities
+from
+  azure_compute_virtual_machine
+where
+    exists (
+      select
+      from
+        unnest(regexp_split_to_array(identity ->> 'type', ',')) elem
+      where
+        trim(elem) = 'UserAssigned'
+  );
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_compute_virtual_machine
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_virtual_machine []

PRETEST: tests/azure_compute_virtual_machine

TEST: tests/azure_compute_virtual_machine
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_network_interface.named_test_resource will be created
  + resource "azurerm_network_interface" "named_test_resource" {
      + applied_dns_servers           = (known after apply)
      + dns_servers                   = (known after apply)
      + enable_accelerated_networking = false
      + enable_ip_forwarding          = false
      + id                            = (known after apply)
      + internal_dns_name_label       = (known after apply)
      + internal_fqdn                 = (known after apply)
      + location                      = "eastus"
      + mac_address                   = (known after apply)
      + name                          = "turbottest7932"
      + private_ip_address            = (known after apply)
      + private_ip_addresses          = (known after apply)
      + resource_group_name           = "turbottest7932"
      + tags                          = (known after apply)
      + virtual_machine_id            = (known after apply)

      + ip_configuration {
          + application_gateway_backend_address_pools_ids = (known after apply)
          + application_security_group_ids                = (known after apply)
          + load_balancer_backend_address_pools_ids       = (known after apply)
          + load_balancer_inbound_nat_rules_ids           = (known after apply)
          + name                                          = "turbottest7932"
          + primary                                       = (known after apply)
          + private_ip_address_allocation                 = "dynamic"
          + private_ip_address_version                    = "IPv4"
          + subnet_id                                     = (known after apply)
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest7932"
      + tags     = (known after apply)
    }

  # azurerm_subnet.named_test_resource will be created
  + resource "azurerm_subnet" "named_test_resource" {
      + address_prefix       = "10.0.2.0/24"
      + id                   = (known after apply)
      + ip_configurations    = (known after apply)
      + name                 = "turbottest7932"
      + resource_group_name  = "turbottest7932"
      + virtual_network_name = "turbottest7932"
    }

  # azurerm_virtual_machine.named_test_resource will be created
  + resource "azurerm_virtual_machine" "named_test_resource" {
      + availability_set_id              = (known after apply)
      + delete_data_disks_on_termination = false
      + delete_os_disk_on_termination    = false
      + id                               = (known after apply)
      + license_type                     = (known after apply)
      + location                         = "eastus"
      + name                             = "turbottest7932"
      + network_interface_ids            = (known after apply)
      + resource_group_name              = "turbottest7932"
      + tags                             = {
          + "name" = "turbottest7932"
        }
      + vm_size                          = "Standard_DS1_v2"

      + identity {
          + identity_ids = (known after apply)
          + principal_id = (known after apply)
          + type         = (known after apply)
        }

      + os_profile {
          + admin_password = (sensitive value)
          + admin_username = "testadmin"
          + computer_name  = "hostname"
          + custom_data    = (known after apply)
        }

      + os_profile_linux_config {
          + disable_password_authentication = false
        }

      + storage_data_disk {
          + caching                   = (known after apply)
          + create_option             = (known after apply)
          + disk_size_gb              = (known after apply)
          + lun                       = (known after apply)
          + managed_disk_id           = (known after apply)
          + managed_disk_type         = (known after apply)
          + name                      = (known after apply)
          + vhd_uri                   = (known after apply)
          + write_accelerator_enabled = (known after apply)
        }

      + storage_image_reference {
          + offer     = "UbuntuServer"
          + publisher = "Canonical"
          + sku       = "16.04-LTS"
          + version   = "latest"
        }

      + storage_os_disk {
          + caching                   = "ReadWrite"
          + create_option             = "FromImage"
          + disk_size_gb              = (known after apply)
          + managed_disk_id           = (known after apply)
          + managed_disk_type         = "Standard_LRS"
          + name                      = "turbottest7932"
          + os_type                   = (known after apply)
          + write_accelerator_enabled = false
        }
    }

  # azurerm_virtual_network.named_test_resource will be created
  + resource "azurerm_virtual_network" "named_test_resource" {
      + address_space       = [
          + "10.0.0.0/16",
        ]
      + id                  = (known after apply)
      + location            = "eastus"
      + name                = "turbottest7932"
      + resource_group_name = "turbottest7932"
      + tags                = (known after apply)

      + subnet {
          + address_prefix = (known after apply)
          + id             = (known after apply)
          + name           = (known after apply)
          + security_group = (known after apply)
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka        = (known after apply)
  + resource_aka_lower  = (known after apply)
  + resource_id         = (known after apply)
  + resource_name       = "turbottest7932"
  + resource_name_upper = "TURBOTTEST7932"
  + subscription_id     = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_network.named_test_resource: Creation complete after 17s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Network/virtualNetworks/turbottest7932]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 4s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Network/virtualNetworks/turbottest7932/subnets/turbottest7932]
azurerm_network_interface.named_test_resource: Creating...
azurerm_network_interface.named_test_resource: Creation complete after 6s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Network/networkInterfaces/turbottest7932]
azurerm_virtual_machine.named_test_resource: Creating...
azurerm_virtual_machine.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [20s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [30s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [40s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [50s elapsed]
azurerm_virtual_machine.named_test_resource: Creation complete after 52s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Compute/virtualMachines/turbottest7932]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 22, in provider "azurerm":
  22:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Compute/virtualMachines/turbottest7932"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest7932/providers/microsoft.compute/virtualmachines/turbottest7932"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Compute/virtualMachines/turbottest7932"
resource_name = "turbottest7932"
resource_name_upper = "TURBOTTEST7932"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Compute/virtualMachines/turbottest7932",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest7932",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest7932",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest7932",
    "size": "Standard_DS1_v2",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Compute/virtualMachines/turbottest7932",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest7932",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest7932",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest7932",
    "size": "Standard_DS1_v2",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/TURBOTTEST7932/providers/Microsoft.Compute/virtualMachines/turbottest7932",
    "name": "turbottest7932",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest7932/providers/Microsoft.Compute/virtualMachines/turbottest7932",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest7932/providers/microsoft.compute/virtualmachines/turbottest7932"
    ],
    "name": "turbottest7932",
    "tags": {
      "name": "turbottest7932"
    },
    "title": "turbottest7932"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_virtual_machine

TEARDOWN: tests/azure_compute_virtual_machine

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  power_state,
  private_ips,
  public_ips,
  vm_id,
  size,
  os_type,
  image_offer,
  image_sku
from
  azure_compute_virtual_machine;
+-----------------+-------------+--------------+--------------------+--------------------------------------+-----------------+---------+------------------------------+-----------------+
| name            | power_state | private_ips  | public_ips         | vm_id                                | size            | os_type | image_offer                  | image_sku       |
+-----------------+-------------+--------------+--------------------+--------------------------------------+-----------------+---------+------------------------------+-----------------+
| turbottest7932  | starting    | ["10.0.2.4"] | <null>             | a3e5885e-7e87-4f3e-995d-a034af42403d | Standard_DS1_v2 | Linux   | UbuntuServer                 | 16.04-LTS       |
| ubuntu-test-oci | running     | ["10.0.0.4"] | ["20.44.49.4"]     | 69eace2d-ba71-41ea-9e44-798d0bea0afb | Standard_DS1_v2 | Linux   | 0001-com-ubuntu-server-focal | 20_04-lts-gen2  |
| testingg        | running     | ["10.1.0.4"] | <null>             | 2ab8b8a7-cce2-491a-9314-79353bc7b546 | Standard_B1s    | Windows | WindowsServer                | 2019-Datacenter |
| test-vm         | running     | ["10.3.0.4"] | ["40.122.147.116"] | a18eb9bf-7a34-440d-bc15-09e634ce5af1 | Standard_B2s    | Windows | sql2019-ws2019               | sqldev          |
+-----------------+-------------+--------------+--------------------+--------------------------------------+-----------------+---------+------------------------------+-----------------+
> select
  region,
  count(name)
from
  azure_compute_virtual_machine
group by
  region;
+------------+-------+
| region     | count |
+------------+-------+
| centralus  | 2     |
| eastus     | 1     |
| southindia | 1     |
+------------+-------+
> select
  vm.name,
  disk.encryption_type
from
  azure_compute_disk as disk
  join azure_compute_virtual_machine as vm on disk.name = vm.os_disk_name
where
  not disk.encryption_type = 'EncryptionAtRestWithCustomerKey';
+-----------------+---------------------------------+
| name            | encryption_type                 |
+-----------------+---------------------------------+
| test-vm         | EncryptionAtRestWithPlatformKey |
| testingg        | EncryptionAtRestWithPlatformKey |
| ubuntu-test-oci | EncryptionAtRestWithPlatformKey |
+-----------------+---------------------------------+
> select
  size,
  count(*) as count
from
  azure_compute_virtual_machine
where
  size not in ('Standard_D8s_v3', 'Standard_DS3_v3')
group by
  size;
+-----------------+-------+
| size            | count |
+-----------------+-------+
| Standard_B1s    | 1     |
| Standard_B2s    | 1     |
| Standard_DS1_v2 | 2     |
+-----------------+-------+
> select
  vm.name vm_name,
  aset.name availability_set_name,
  aset.platform_fault_domain_count,
  aset.platform_update_domain_count,
  aset.sku_name
from
  azure_compute_availability_set as aset
  join azure_compute_virtual_machine as vm on lower(aset.id) = lower(vm.availability_set_id);
+---------+-----------------------+-----------------------------+------------------------------+----------+
| vm_name | availability_set_name | platform_fault_domain_count | platform_update_domain_count | sku_name |
+---------+-----------------------+-----------------------------+------------------------------+----------+
+---------+-----------------------+-----------------------------+------------------------------+----------+
> select
  name,
  vm_id,
  eviction_policy
from
  azure_compute_virtual_machine
where
  priority = 'Spot';
+------+-------+-----------------+
| name | vm_id | eviction_policy |
+------+-------+-----------------+
+------+-------+-----------------+
> select
  vm.name,
  count(d) as num_disks,
  sum(d.disk_size_gb) as total_disk_size_gb
from
  azure.azure_compute_virtual_machine as vm
  left join azure_compute_disk as d on lower(vm.id) = lower(d.managed_by)
group by
  vm.name
order by
  vm.name;
+-----------------+-----------+--------------------+
| name            | num_disks | total_disk_size_gb |
+-----------------+-----------+--------------------+
| test-vm         | 3         | 2175               |
| testingg        | 1         | 127                |
| turbottest7932  | 0         | <null>             |
| ubuntu-test-oci | 1         | 30                 |
+-----------------+-----------+--------------------+
> select
  vm.name,
  nsg.name,
  jsonb_pretty(security_rules)
from
  azure.azure_compute_virtual_machine as vm,
  jsonb_array_elements(vm.network_interfaces) as vm_nic,
  azure_network_security_group as nsg,
  jsonb_array_elements(nsg.network_interfaces) as nsg_int
where
  lower(vm_nic ->> 'id') = lower(nsg_int ->> 'id')
  and vm.name = 'warehouse-01';
+------+------+--------------+
| name | name | jsonb_pretty |
+------+------+--------------+
+------+------+--------------+
> select
  name,
  identity -> 'type' as identity_type,
  jsonb_pretty(identity -> 'userAssignedIdentities') as identity_user_assignedidentities
from
  azure_compute_virtual_machine
where
    exists (
      select
      from
        unnest(regexp_split_to_array(identity ->> 'type', ',')) elem
      where
        trim(elem) = 'UserAssigned'
  );
+---------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| name    | identity_type                  | identity_user_assignedidentities                                                                                                                          |
+---------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| test-vm | "SystemAssigned, UserAssigned" | {                                                                                                                                                         |
|         |                                |     "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/hipaa-hitrust/providers/microsoft.managedidentity/userassignedidentities/test": { |
|         |                                |     }                                                                                                                                                     |
|         |                                | }                                                                                                                                                         |
+---------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
> 
```
</details>
