### PR TITLE
Fix table azure_key_vault failed to populate column private_endpoint_connections issue. Closes #340

### DIFF
--- a/azure-test/tests/azure_key_vault/test-hydrate-expected.json
+++ b/azure-test/tests/azure_key_vault/test-hydrate-expected.json
@@ -3,16 +3,14 @@
     "access_policies": [
       {
         "objectId": "{{ output.object_id.value }}",
-        "permissions": {
-          "certificates": [],
-          "keys": [
-            "get"
-          ],
-          "secrets": [
-            "get"
-          ],
-          "storage": []
-        },
+        "permissionsCertificates": [],
+        "permissionsKeys": [
+          "get"
+        ],
+        "permissionsSecrets": [
+          "get"
+        ],
+        "permissionsStorage": [],
         "tenantId": "{{ output.tenant_id.value }}"
       }
     ],

--- a/docs/tables/azure_key_vault.md
+++ b/docs/tables/azure_key_vault.md
@@ -68,9 +68,9 @@ where
 ```sql
 select
   name,
-  policy #> '{permissions, certificates}'  certificates_permissions,
-  policy #> '{permissions, keys}'  keys_permissions,
-  policy #> '{permissions, secrets}'  secrets_permissions
+  policy -> 'permissionsCertificates' as certificates_permissions,
+  policy -> 'permissionsKeys' as keys_permissions,
+  policy -> 'permissionsSecrets' as  secrets_permissions
 from
   azure_key_vault,
   jsonb_array_elements(access_policies) as policy;


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_key_vault
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_key_vault []

PRETEST: tests/azure_key_vault

TEST: tests/azure_key_vault
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_key_vault.named_test_resource will be created
  + resource "azurerm_key_vault" "named_test_resource" {
      + access_policy              = (known after apply)
      + id                         = (known after apply)
      + location                   = "westus"
      + name                       = "turbottest30549"
      + resource_group_name        = "turbottest30549"
      + sku_name                   = "standard"
      + soft_delete_enabled        = (known after apply)
      + soft_delete_retention_days = 90
      + tags                       = {
          + "name" = "turbottest30549"
        }
      + tenant_id                  = "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
      + vault_uri                  = (known after apply)

      + network_acls {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)
        }
    }

  # azurerm_key_vault_access_policy.named_test_resource will be created
  + resource "azurerm_key_vault_access_policy" "named_test_resource" {
      + id                 = (known after apply)
      + key_permissions    = [
          + "get",
        ]
      + key_vault_id       = (known after apply)
      + object_id          = "bc3de371-eae8-4a42-a172-84bb6ce25bfb"
      + secret_permissions = [
          + "get",
        ]
      + tenant_id          = "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
    }

  # azurerm_monitor_diagnostic_setting.named_test_resource will be created
  + resource "azurerm_monitor_diagnostic_setting" "named_test_resource" {
      + id                 = (known after apply)
      + name               = "turbottest30549"
      + storage_account_id = (known after apply)
      + target_resource_id = (known after apply)

      + log {
          + category = "AuditEvent"
          + enabled  = true

          + retention_policy {
              + days    = 30
              + enabled = true
            }
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westus"
      + name     = "turbottest30549"
    }

  # azurerm_storage_account.named_test_resource will be created
  + resource "azurerm_storage_account" "named_test_resource" {
      + access_tier                      = (known after apply)
      + account_kind                     = "StorageV2"
      + account_replication_type         = "LRS"
      + account_tier                     = "Standard"
      + allow_blob_public_access         = false
      + enable_https_traffic_only        = true
      + id                               = (known after apply)
      + is_hns_enabled                   = false
      + large_file_share_enabled         = (known after apply)
      + location                         = "westus"
      + min_tls_version                  = "TLS1_0"
      + name                             = "turbottest30549"
      + nfsv3_enabled                    = false
      + primary_access_key               = (sensitive value)
      + primary_blob_connection_string   = (sensitive value)
      + primary_blob_endpoint            = (known after apply)
      + primary_blob_host                = (known after apply)
      + primary_connection_string        = (sensitive value)
      + primary_dfs_endpoint             = (known after apply)
      + primary_dfs_host                 = (known after apply)
      + primary_file_endpoint            = (known after apply)
      + primary_file_host                = (known after apply)
      + primary_location                 = (known after apply)
      + primary_queue_endpoint           = (known after apply)
      + primary_queue_host               = (known after apply)
      + primary_table_endpoint           = (known after apply)
      + primary_table_host               = (known after apply)
      + primary_web_endpoint             = (known after apply)
      + primary_web_host                 = (known after apply)
      + resource_group_name              = "turbottest30549"
      + secondary_access_key             = (sensitive value)
      + secondary_blob_connection_string = (sensitive value)
      + secondary_blob_endpoint          = (known after apply)
      + secondary_blob_host              = (known after apply)
      + secondary_connection_string      = (sensitive value)
      + secondary_dfs_endpoint           = (known after apply)
      + secondary_dfs_host               = (known after apply)
      + secondary_file_endpoint          = (known after apply)
      + secondary_file_host              = (known after apply)
      + secondary_location               = (known after apply)
      + secondary_queue_endpoint         = (known after apply)
      + secondary_queue_host             = (known after apply)
      + secondary_table_endpoint         = (known after apply)
      + secondary_table_host             = (known after apply)
      + secondary_web_endpoint           = (known after apply)
      + secondary_web_host               = (known after apply)
      + shared_access_key_enabled        = true

      + blob_properties {
          + change_feed_enabled      = (known after apply)
          + default_service_version  = (known after apply)
          + last_access_time_enabled = (known after apply)
          + versioning_enabled       = (known after apply)

          + container_delete_retention_policy {
              + days = (known after apply)
            }

          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + delete_retention_policy {
              + days = (known after apply)
            }
        }

      + identity {
          + identity_ids = (known after apply)
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = (known after apply)
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)

          + private_link_access {
              + endpoint_resource_id = (known after apply)
              + endpoint_tenant_id   = (known after apply)
            }
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }

      + routing {
          + choice                      = (known after apply)
          + publish_internet_endpoints  = (known after apply)
          + publish_microsoft_endpoints = (known after apply)
        }

      + share_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + retention_policy {
              + days = (known after apply)
            }

          + smb {
              + authentication_types            = (known after apply)
              + channel_encryption_type         = (known after apply)
              + kerberos_ticket_encryption_type = (known after apply)
              + versions                        = (known after apply)
            }
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + object_id          = "bc3de371-eae8-4a42-a172-84bb6ce25bfb"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest30549"
  + storage_account_id = (known after apply)
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
  + tenant_id          = "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549]
azurerm_key_vault.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Creating...
azurerm_key_vault.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 33s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.Storage/storageAccounts/turbottest30549]
azurerm_key_vault.named_test_resource: Still creating... [40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m30s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m40s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [1m50s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m0s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m10s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m20s elapsed]
azurerm_key_vault.named_test_resource: Still creating... [2m30s elapsed]
azurerm_key_vault.named_test_resource: Creation complete after 2m32s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549]
azurerm_key_vault_access_policy.named_test_resource: Creating...
azurerm_monitor_diagnostic_setting.named_test_resource: Creating...
azurerm_key_vault_access_policy.named_test_resource: Still creating... [10s elapsed]
azurerm_monitor_diagnostic_setting.named_test_resource: Still creating... [10s elapsed]
azurerm_monitor_diagnostic_setting.named_test_resource: Creation complete after 12s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549|turbottest30549]
azurerm_key_vault_access_policy.named_test_resource: Creation complete after 14s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549/objectId/bc3de371-eae8-4a42-a172-84bb6ce25bfb]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 28, in data "null_data_source" "resource":
  28: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

object_id = "bc3de371-eae8-4a42-a172-84bb6ce25bfb"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest30549/providers/microsoft.keyvault/vaults/turbottest30549"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549"
resource_name = "turbottest30549"
storage_account_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.Storage/storageAccounts/turbottest30549"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"
tenant_id = "cdffd708-7da0-4cea-abeb-0a4c334d7f64"

Running SQL query: test-get-query.sql
[
  {
    "enabled_for_deployment": false,
    "enabled_for_disk_encryption": false,
    "enabled_for_template_deployment": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549",
    "name": "turbottest30549",
    "region": "westus",
    "resource_group": "turbottest30549",
    "sku_name": "standard",
    "tenant_id": "cdffd708-7da0-4cea-abeb-0a4c334d7f64",
    "type": "Microsoft.KeyVault/vaults",
    "vault_uri": "https://turbottest30549.vault.azure.net/"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_policies": [
      {
        "objectId": "bc3de371-eae8-4a42-a172-84bb6ce25bfb",
        "permissionsCertificates": [],
        "permissionsKeys": [
          "get"
        ],
        "permissionsSecrets": [
          "get"
        ],
        "permissionsStorage": [],
        "tenantId": "cdffd708-7da0-4cea-abeb-0a4c334d7f64"
      }
    ],
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest30549/providers/microsoft.keyvault/vaults/turbottest30549"
    ],
    "name": "turbottest30549",
    "tags": {
      "name": "turbottest30549"
    },
    "title": "turbottest30549"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549",
    "name": "turbottest30549"
  }
]
✔ PASSED

Running SQL query: test-logging-query.sql
[
  {
    "category": "AuditEvent",
    "log_retention_days": 30,
    "name": "turbottest30549",
    "storage_account_id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.Storage/storageAccounts/turbottest30549"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest30549/providers/Microsoft.KeyVault/vaults/turbottest30549",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest30549/providers/microsoft.keyvault/vaults/turbottest30549"
    ],
    "name": "turbottest30549",
    "tags": {
      "name": "turbottest30549"
    },
    "title": "turbottest30549"
  }
]
✔ PASSED

POSTTEST: tests/azure_key_vault

TEARDOWN: tests/azure_key_vault

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  soft_delete_enabled,
  soft_delete_retention_in_days
from
  azure_key_vault
where
  not soft_delete_enabled;
+------+----+---------------------+-------------------------------+
| name | id | soft_delete_enabled | soft_delete_retention_in_days |
+------+----+---------------------+-------------------------------+
+------+----+---------------------+-------------------------------+
> select
  name,
  id,
  soft_delete_enabled,
  soft_delete_retention_in_days
from
  azure_key_vault
where
  soft_delete_retention_in_days < 30;
+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+----
| name                  | id                                                                                                                                                     | soft_delete_enabled | sof
+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+----
| tets56                | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/hipaa-hitrust/providers/Microsoft.KeyVault/vaults/tets56                            | true                | 7  
| testing-service-bus-1 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.KeyVault/vaults/testing-service-bus-1 | true                | 7  
+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+----
> select
  name,
  id,
  enabled_for_deployment,
  enabled_for_disk_encryption,
  enabled_for_template_deployment
from
  azure_key_vault;
+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+-
| name                  | id                                                                                                                                                     | enabled_for_deployment | 
+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+-
| tets56                | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/hipaa-hitrust/providers/Microsoft.KeyVault/vaults/tets56                            | false                  | 
| testing-service-bus-1 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.KeyVault/vaults/testing-service-bus-1 | false                  | 
+-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+-
> select
  name,
  id,
  sku_name,
  sku_family
from
  azure_key_vault
where
  sku_name = 'Premium';
+------+----+----------+------------+
| name | id | sku_name | sku_family |
+------+----+----------+------------+
+------+----+----------+------------+
> select
  name,
  policy -> 'permissionsCertificates' as certificates_permissions,
  policy -> 'permissionsKeys' as keys_permissions,
  policy -> 'permissionsSecrets' as  secrets_permissions
from
  azure_key_vault,
  jsonb_array_elements(access_policies) as policy;
+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name                  | certificates_permissions                                                                                                                                                         |
+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tets56                | ["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]         |
| tets56                | ["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]         |
| tets56                | <null>                                                                                                                                                                           |
| tets56                | []                                                                                                                                                                               |
| testing-service-bus-1 | ["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers","Purge"] |
| testing-service-bus-1 | <null>                                                                                                                                                                           |
+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
> select
  name,
  setting -> 'properties' ->> 'storageAccountId' storage_account_id,
  log ->> 'category' category,
  log -> 'retentionPolicy' ->> 'days' log_retention_days
from
  azure_key_vault,
  jsonb_array_elements(diagnostic_settings) setting,
  jsonb_array_elements(setting -> 'properties' -> 'logs') log
where
  diagnostic_settings is not null
  and setting -> 'properties' ->> 'storageAccountId' <> ''
  and (log ->> 'enabled')::boolean
  and log ->> 'category' = 'AuditEvent'
  and (log -> 'retentionPolicy' ->> 'days')::integer > 0;
+------+--------------------+----------+--------------------+
| name | storage_account_id | category | log_retention_days |
+------+--------------------+----------+--------------------+
+------+--------------------+----------+--------------------+
> select * from azure_key_vault
+-------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------+---------------------------+-------------+------------------------+-----------------------------+---------------------------------+---------------------------+--------------------------+---------------------+-------------------------------+------------+----------+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------------------------+--------------------------------------+
| name              | id                                                                                                                                                 | vault_uri                                  | type                      | create_mode | enabled_for_deployment | enabled_for_disk_encryption | enabled_for_template_deployment | enable_rbac_authorization | purge_protection_enabled | soft_delete_enabled | soft_delete_retention_in_days | sku_family | sku_name | tenant_id                            | access_policies                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | diagnostic_settings | network_acls | private_endpoint_connections                                                                                                                                                                                                                                                                                                                                                          | title             | tags | akas                                                                                                                                                                                                                                                                                                                        | region    | resource_group            | subscription_id                      |
+-------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------+---------------------------+-------------+------------------------+-----------------------------+---------------------------------+---------------------------+--------------------------+---------------------+-------------------------------+------------+----------+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------------------------+--------------------------------------+
| tets56            | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/hipaa-hitrust/providers/Microsoft.KeyVault/vaults/tets56                        | https://tets56.vault.azure.net/            | Microsoft.KeyVault/vaults |             | false                  | false                       | false                           | false                     | true                     | true                | 7                             | A          | Standard | cdffd708-7da0-4cea-abeb-0a4c334d7f64 | [{"objectId":"5ad8be1d-cfa2-481f-8728-f66a04b6df6c","permissionsCertificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"permissionsKeys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","Decrypt","Encrypt","UnwrapKey","WrapKey","Verify","Sign"],"permissionsSecrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"permissionsStorage":null,"tenantId":"cdffd708-7da0-4cea-abeb-0a4c334d7f64"},{"objectId":"92f0bf94-4e47-41ea-bc68-5e97c5a3f9ff","permissionsCertificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"permissionsKeys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"permissionsSecrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"permissionsStorage":null,"tenantId":"cd | <null>              | <null>       | <null>                                                                                                                                                                                                                                                                                                                                                                                | tets56            | {}   | ["azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/hipaa-hitrust/providers/Microsoft.KeyVault/vaults/tets56","azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/hipaa-hitrust/providers/microsoft.keyvault/vaults/tets56"]                                               | eastus    | hipaa-hitrust             | d46d7416-f95f-4771-bbb5-529d4c76659c |
|                   |                                                                                                                                                    |                                            |                           |             |                        |                             |                                 |                           |                          |                     |                               |            |          |                                      | ffd708-7da0-4cea-abeb-0a4c334d7f64"},{"objectId":"dccc7799-e6b8-4ad7-9b4a-3e75e3cf82ee","permissionsCertificates":null,"permissionsKeys":["get","wrapkey","unwrapkey"],"permissionsStorage":null,"tenantId":"cdffd708-7da0-4cea-abeb-0a4c334d7f64"},{"objectId":"4fac0d39-7f08-4c1b-aad8-5da55b20bd08","permissionsCertificates":[],"permissionsKeys":["Get","UnwrapKey","WrapKey"],"permissionsSecrets":[],"permissionsStorage":null,"tenantId":"cdffd708-7da0-4cea-abeb-0a4c334d7f64"}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |                     |              |                                                                                                                                                                                                                                                                                                                                                                                       |                   |      |                                                                                                                                                                                                                                                                                                                             |           |                           |                                      |
| test-key-vault-55 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.KeyVault/vaults/test-key-vault-55 | https://test-key-vault-55.vault.azure.net/ | Microsoft.KeyVault/vaults |             | true                   | false                       | true                            | false                     | false                    | true                | 7                             | A          | Standard | cdffd708-7da0-4cea-abeb-0a4c334d7f64 | [{"objectId":"bc3de371-eae8-4a42-a172-84bb6ce25bfb","permissionsCertificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"permissionsKeys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"permissionsSecrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"permissionsStorage":null,"tenantId":"cdffd708-7da0-4cea-abeb-0a4c334d7f64"}]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | <null>              | <null>       | [{"PrivateEndpointId":"/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.Network/privateEndpoints/test-private-endpoint","PrivateLinkServiceConnectionStateActionRequired":"","PrivateLinkServiceConnectionStateDescription":"","PrivateLinkServiceConnectionStateStatus":"Approved","ProvisioningState":"Succeeded"}] | test-key-vault-55 | {}   | ["azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.KeyVault/vaults/test-key-vault-55","azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/arnab-test-resource-group/providers/microsoft.keyvault/vaults/test-key-vault-55"] | centralus | arnab-test-resource-group | d46d7416-f95f-4771-bbb5-529d4c76659c |
+-------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------+---------------------------+-------------+------------------------+-----------------------------+---------------------------------+---------------------------+--------------------------+---------------------+-------------------------------+------------+----------+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+---------------------------+--------------------------------------+
```
</details>
