### PR TITLE
Fix getting null value for column cluster_arm_id in table azure_eventhub_namespace. Closes #323

### DIFF
--- a/azure/table_azure_eventhub_namespace.go
+++ b/azure/table_azure_eventhub_namespace.go
@@ -58,7 +58,7 @@ func tableAzureEventHubNamespace(_ context.Context) *plugin.Table {
 				Name:        "cluster_arm_id",
 				Description: "Cluster ARM ID of the namespace.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("EHNamespaceProperties.ClusterArmId"),
+				Transform:   transform.FromField("EHNamespaceProperties.ClusterArmID"),
 			},
 			{
 				Name:        "is_auto_inflate_enabled",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_eventhub_namespace
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_eventhub_namespace []

PRETEST: tests/azure_eventhub_namespace

TEST: tests/azure_eventhub_namespace
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_eventhub_namespace.named_test_resource will be created
  + resource "azurerm_eventhub_namespace" "named_test_resource" {
      + auto_inflate_enabled                = false
      + capacity                            = 1
      + default_primary_connection_string   = (sensitive value)
      + default_primary_key                 = (sensitive value)
      + default_secondary_connection_string = (sensitive value)
      + default_secondary_key               = (sensitive value)
      + id                                  = (known after apply)
      + kafka_enabled                       = false
      + location                            = "westus"
      + maximum_throughput_units            = (known after apply)
      + name                                = "turbottest42111"
      + network_rulesets                    = (known after apply)
      + resource_group_name                 = "turbottest42111"
      + sku                                 = "Standard"
      + tags                                = {
          + "name" = "turbottest42111"
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westus"
      + name     = "turbottest42111"
      + tags     = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "westus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest42111"
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111]
azurerm_eventhub_namespace.named_test_resource: Creating...
azurerm_eventhub_namespace.named_test_resource: Still creating... [10s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [20s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [30s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [40s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [50s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [1m0s elapsed]
azurerm_eventhub_namespace.named_test_resource: Still creating... [1m10s elapsed]
azurerm_eventhub_namespace.named_test_resource: Creation complete after 1m15s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 28, in data "null_data_source" "resource":
  28: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "westus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest42111/providers/microsoft.eventhub/namespaces/turbottest42111"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111"
resource_name = "turbottest42111"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111",
    "is_auto_inflate_enabled": false,
    "kafka_enabled": true,
    "name": "turbottest42111",
    "region": "westus",
    "resource_group": "turbottest42111",
    "type": "Microsoft.EventHub/Namespaces"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest42111/providers/microsoft.eventhub/namespaces/turbottest42111"
    ],
    "name": "turbottest42111",
    "tags": {
      "name": "turbottest42111"
    },
    "title": "turbottest42111"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111",
    "name": "turbottest42111"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest42111/providers/Microsoft.EventHub/namespaces/turbottest42111",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest42111/providers/microsoft.eventhub/namespaces/turbottest42111"
    ],
    "name": "turbottest42111",
    "tags": {
      "name": "turbottest42111"
    },
    "title": "turbottest42111"
  }
]
✔ PASSED

POSTTEST: tests/azure_eventhub_namespace

TEARDOWN: tests/azure_eventhub_namespace

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  type,
  encryption
from
  azure_eventhub_namespace
where
  encryption is null;
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
| name             | id                                                                                                                                                    | type                          |
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
| testnp12         | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.EventHub/namespaces/testnp12                         | Microsoft.EventHub/Namespaces |
| test-namespace-1 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-namespace-1 | Microsoft.EventHub/Namespaces |
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
> select
  name,
  id,
  type,
  is_auto_inflate_enabled
from
  azure_eventhub_namespace
where
  not is_auto_inflate_enabled;
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
| name             | id                                                                                                                                                    | type                          |
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
| testnp12         | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.EventHub/namespaces/testnp12                         | Microsoft.EventHub/Namespaces |
| test-namespace-1 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-namespace-1 | Microsoft.EventHub/Namespaces |
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------+
> select
  name,
  id,
  connections ->> 'id' as connection_id,
  connections ->> 'name' as connection_name,
  connections ->> 'privateEndpointPropertyID' as property_private_endpoint_id,
  connections ->> 'provisioningState' as property_provisioning_state,
  jsonb_pretty(connections -> 'privateLinkServiceConnectionState') as property_private_link_service_connection_state,
  connections ->> 'type' as connection_type
from
  azure_eventhub_namespace,
  jsonb_array_elements(private_endpoint_connections) as connections;
+------+----+---------------+-----------------+------------------------------+-----------------------------+------------------------------------------------+-----------------+
| name | id | connection_id | connection_name | property_private_endpoint_id | property_provisioning_state | property_private_link_service_connection_state | connection_type |
+------+----+---------------+-----------------+------------------------------+-----------------------------+------------------------------------------------+-----------------+
+------+----+---------------+-----------------+------------------------------+-----------------------------+------------------------------------------------+-----------------+
> select
  name,
  id,
  cluster_arm_id
from
  azure_eventhub_namespace;
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------
| name             | id                                                                                                                                                    | cluster_arm_id                 
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------
| testnp12         | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.EventHub/namespaces/testnp12                         | <null>                         
| test-namespace-1 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.EventHub/namespaces/test-namespace-1 | /subscriptions/d46d7416-f95f-47
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------
> 
```
</details>
