### PR TITLE
Add missing properties of encryption_protector  column in azure_sql_server table. Closes #335

### DIFF
--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -468,8 +468,20 @@ func getSQLServerEncryptionProtector(ctx context.Context, d *plugin.QueryData, h
 		if i.Kind != nil {
 			objectMap["kind"] = i.Kind
 		}
-		if i.EncryptionProtectorProperties != nil {
-			objectMap["properties"] = i.EncryptionProtectorProperties
+		if i.Subregion != nil {
+			objectMap["subregion"] = i.Subregion
+		}
+		if i.ServerKeyName != nil {
+			objectMap["server_key_name"] = i.ServerKeyName
+		}
+		if i.ServerKeyType != "" {
+			objectMap["server_key_type"] = i.ServerKeyType
+		}
+		if i.URI != nil {
+			objectMap["uri"] = i.URI
+		}
+		if i.Thumbprint != nil {
+			objectMap["thumbprint"] = i.Thumbprint
 		}
 		encryptionProtectors = append(encryptionProtectors, objectMap)
 	}

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -472,10 +472,10 @@ func getSQLServerEncryptionProtector(ctx context.Context, d *plugin.QueryData, h
 			objectMap["subregion"] = i.Subregion
 		}
 		if i.ServerKeyName != nil {
-			objectMap["server_key_name"] = i.ServerKeyName
+			objectMap["serverKeyName"] = i.ServerKeyName
 		}
 		if i.ServerKeyType != "" {
-			objectMap["server_key_type"] = i.ServerKeyType
+			objectMap["serverKeyType"] = i.ServerKeyType
 		}
 		if i.URI != nil {
 			objectMap["uri"] = i.URI


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select jsonb_pretty(encryption_protector) from azure_sql_server
+----------------------------------------------------------------------------------------------------------------------------------------------
| jsonb_pretty                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------
| [                                                                                                                                            
|     {                                                                                                                                        
|         "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/nist-test_group/providers/Microsoft.Sql/servers/terete/encr
|         "uri": "https://fabric-nist-query.vault.azure.net/keys/werer/de76c81afa4941d68b12cee311831b93",                                      
|         "kind": "azurekeyvault",                                                                                                             
|         "name": "current",                                                                                                                   
|         "type": "Microsoft.Sql/servers/encryptionProtector",                                                                                 
|         "server_key_name": "fabric-nist-query_werer_de76c81afa4941d68b12cee311831b93",                                                       
|         "server_key_type": "AzureKeyVault"                                                                                                   
|     }                                                                                                                                        
| ]                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------
```
</details>
