### PR TITLE
Fix azure_servicebus_namespace table break if encryption is set for servicebus namespace. Closes #332

### DIFF
--- a/azure/table_azure_servicebus_namespace.go
+++ b/azure/table_azure_servicebus_namespace.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
-	"github.com/Azure/azure-sdk-for-go/services/preview/servicebus/mgmt/2018-01-01-preview/servicebus"
+	"github.com/Azure/azure-sdk-for-go/services/preview/servicebus/mgmt/2021-06-01-preview/servicebus"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"

--- a/docs/tables/azure_servicebus_namespace.md
+++ b/docs/tables/azure_servicebus_namespace.md
@@ -84,3 +84,16 @@ from
   azure_servicebus_namespace,
   jsonb_array_elements(private_endpoint_connections) as connections;
 ```
+
+### List encryption details
+
+```sql
+select
+  name,
+  id,
+  encryption ->> 'keySource' as key_source,
+  jsonb_pretty(encryption -> 'keyVaultProperties') as key_vault_properties,
+  encryption -> 'requireInfrastructureEncryption' as require_infrastructure_encryption
+from
+  azure_servicebus_namespace;
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/turbot/steampipe-plugin-azure
 go 1.15
 
 require (
-	github.com/Azure/azure-sdk-for-go v55.4.0+incompatible
+	github.com/Azure/azure-sdk-for-go v58.0.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.12.0
 	github.com/Azure/go-autorest/autorest v0.11.17
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/Azure/azure-sdk-for-go v45.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v47.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v55.4.0+incompatible h1:zn3+QwgCjRgIRgE0iWpF2LrFy5er/T0e5/EHrp1Zgak=
 github.com/Azure/azure-sdk-for-go v55.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v58.0.0+incompatible h1:Cw16jiP4dI+CK761aq44ol4RV5dUiIIXky1+EKpoiVM=
+github.com/Azure/azure-sdk-for-go v58.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-blob-go v0.12.0 h1:7bFXA1QB+lOK2/ASWHhp6/vnxjaeeZq6t8w1Jyp0Iaw=
 github.com/Azure/azure-storage-blob-go v0.12.0/go.mod h1:A0u4VjtpgZJ7Y7um/+ix2DHBuEKFC6sEIlj0xc13a4Q=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_servicebus_namespace
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_servicebus_namespace []

PRETEST: tests/azure_servicebus_namespace

TEST: tests/azure_servicebus_namespace
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest93414"
    }

  # azurerm_servicebus_namespace.named_test_resource will be created
  + resource "azurerm_servicebus_namespace" "named_test_resource" {
      + capacity                            = 0
      + default_primary_connection_string   = (sensitive value)
      + default_primary_key                 = (sensitive value)
      + default_secondary_connection_string = (sensitive value)
      + default_secondary_key               = (sensitive value)
      + id                                  = (known after apply)
      + location                            = "eastus"
      + name                                = "turbottest93414"
      + resource_group_name                 = "turbottest93414"
      + sku                                 = "Basic"
      + tags                                = {
          + "name" = "turbottest93414"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "eastus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest93414"
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414]
azurerm_servicebus_namespace.named_test_resource: Creating...
azurerm_servicebus_namespace.named_test_resource: Still creating... [10s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [20s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [30s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [40s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [51s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [1m1s elapsed]
azurerm_servicebus_namespace.named_test_resource: Still creating... [1m11s elapsed]
azurerm_servicebus_namespace.named_test_resource: Creation complete after 1m13s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 21, in provider "azurerm":
  21:   version = "=2.41.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest93414/providers/microsoft.servicebus/namespaces/turbottest93414"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414"
resource_name = "turbottest93414"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "encryption": null,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414",
    "name": "turbottest93414",
    "network_rule_set": {
      "properties": {
        "defaultAction": "Deny",
        "ipRules": [],
        "virtualNetworkRules": []
      }
    },
    "provisioning_state": "Succeeded",
    "servicebus_endpoint": "https://turbottest93414.servicebus.windows.net:443/",
    "sku_name": "Basic",
    "sku_tier": "Basic",
    "type": "Microsoft.ServiceBus/Namespaces",
    "zone_redundant": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414",
    "name": "turbottest93414"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest93414/providers/microsoft.servicebus/namespaces/turbottest93414"
    ],
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414",
    "name": "turbottest93414",
    "region": "eastus",
    "resource_group": "turbottest93414",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "tags": {
      "name": "turbottest93414"
    },
    "title": "turbottest93414"
  }
]
✔ PASSED

POSTTEST: tests/azure_servicebus_namespace

TEARDOWN: tests/azure_servicebus_namespace

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  sku_tier,
  provisioning_state,
  created_at
from
  azure_servicebus_namespace;
+-------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----------------
| name              | id                                                                                                                                                       | sku_tier | provisioning_sta
+-------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----------------
| test-namespace-13 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-namespace-13 | Premium  | Succeeded       
| turbottest93414   | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest93414/providers/Microsoft.ServiceBus/namespaces/turbottest93414             | Basic    | Succeeded       
| nistnest          | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/nist-test_group/providers/Microsoft.ServiceBus/namespaces/nistnest                    | Basic    | Succeeded       
+-------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----------------
> select
  name,
  sku_tier,
  region
from
  azure_servicebus_namespace
where
  sku_tier = 'Premium';
+-------------------+----------+--------+
| name              | sku_tier | region |
+-------------------+----------+--------+
| test-namespace-13 | Premium  | eastus |
+-------------------+----------+--------+
> select
  name,
  sku_tier,
  encryption
from
  azure_servicebus_namespace
where
  sku_tier = 'Premium'
  and encryption is null;
+------+----------+------------+
| name | sku_tier | encryption |
+------+----------+------------+
+------+----------+------------+
> select
  name,
  region,
  network_rule_set -> 'properties' -> 'virtualNetworkRules' as virtual_network_rules
from
  azure_servicebus_namespace
where
  sku_tier = 'Premium'
  and (
    jsonb_array_length(network_rule_set -> 'properties' -> 'virtualNetworkRules') = 0
    or exists (
      select
        * 
      from
        jsonb_array_elements(network_rule_set -> 'properties' -> 'virtualNetworkRules') as t
      where
        t -> 'subnet' ->> 'id' is null
    )
  );
+-------------------+--------+-----------------------+
| name              | region | virtual_network_rules |
+-------------------+--------+-----------------------+
| test-namespace-13 | eastus | []                    |
+-------------------+--------+-----------------------+
> select
  name,
  id,
  connections ->> 'id' as connection_id,
  connections ->> 'name' as connection_name,
  connections ->> 'privateEndpointPropertyID' as property_private_endpoint_id,
  connections ->> 'provisioningState' as property_provisioning_state,
  jsonb_pretty(connections -> 'privateLinkServiceConnectionState') as property_private_link_service_connection_state,
  connections ->> 'type' as connection_type
from
  azure_servicebus_namespace,
  jsonb_array_elements(private_endpoint_connections) as connections;
+------+----+---------------+-----------------+------------------------------+-----------------------------+------------------------------------------------+-----------------+
| name | id | connection_id | connection_name | property_private_endpoint_id | property_provisioning_state | property_private_link_service_connection_state | connection_type |
+------+----+---------------+-----------------+------------------------------+-----------------------------+------------------------------------------------+-----------------+
+------+----+---------------+-----------------+------------------------------+-----------------------------+------------------------------------------------+-----------------+
> select
  name,
  id,
  encryption ->> 'keySource' as key_source,
  jsonb_pretty(encryption -> 'keyVaultProperties') as key_vault_properties,
  encryption -> 'requireInfrastructureEncryption' as require_infrastructure_encryption
from
  azure_servicebus_namespace;
+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+--------------------------------------------------------------------+-----------------------------------+
| name                | id                                                                                                                                                         | key_source         | key_vault_properties                                               | require_infrastructure_encryption |
+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+--------------------------------------------------------------------+-----------------------------------+
| nistnest            | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/nist-test_group/providers/Microsoft.ServiceBus/namespaces/nistnest                      | <null>             | <null>                                                             | <null>                            |
| test-service-bus-13 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-service-bus-13 | Microsoft.KeyVault | [                                                                  | false                             |
|                     |                                                                                                                                                            |                    |     {                                                              |                                   |
|                     |                                                                                                                                                            |                    |         "keyName": "test-key",                                     |                                   |
|                     |                                                                                                                                                            |                    |         "keyVersion": "",                                          |                                   |
|                     |                                                                                                                                                            |                    |         "keyVaultUri": "https://test-key-vault-13.vault.azure.net" |                                   |
|                     |                                                                                                                                                            |                    |     }                                                              |                                   |
|                     |                                                                                                                                                            |                    | ]                                                                  |                                   |
+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+--------------------------------------------------------------------+-----------------------------------+  
```
</details>
