### PR TITLE
Add hydrate function to determine the default value for public_network_access column in azure_app_configuration table #364

### DIFF
--- a/azure/table_azure_app_configuration.go
+++ b/azure/table_azure_app_configuration.go
@@ -259,14 +259,15 @@ func listAppConfigurationDiagnosticSettings(ctx context.Context, d *plugin.Query
 func getPublicNetworkAccess(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	configurationStore := h.Item.(appconfiguration.ConfigurationStore)
 
-	if len(configurationStore.PublicNetworkAccess) == 0 && configurationStore.PrivateEndpointConnections == nil {
-		plugin.Logger(ctx).Error("getPublicNetworkAccess", "PublicNetworkAccess", len(configurationStore.PublicNetworkAccess))
+	// In case of automatic is selected at the time of store creation, PublicNetworkAccess value will be nil in API response.
+	// With a private endpoint, public network access will be automatically disabled.
+	// If there is no private endpoint present, public network access is automatically enabled.
+	if len(configurationStore.PublicNetworkAccess) == 0 && len(*configurationStore.PrivateEndpointConnections) == 0 {
 		return "Enabled", nil
-	} else if len(configurationStore.PublicNetworkAccess) == 0 && configurationStore.PrivateEndpointConnections != nil {
-		plugin.Logger(ctx).Error("getPublicNetworkAccess", "PublicNetworkAccess", len(configurationStore.PublicNetworkAccess))
+	} else if len(configurationStore.PublicNetworkAccess) == 0 && len(*configurationStore.PrivateEndpointConnections) != 0 {
 		return "Disabled", nil
 	}
-	plugin.Logger(ctx).Error("getPublicNetworkAccess", "PublicNetworkAccess", len(configurationStore.PublicNetworkAccess))
+
 	return configurationStore.PublicNetworkAccess, nil
 }
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,public_network_access,private_endpoint_connections from azure_app_configuration
+--------------------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name               | public_network_access | private_endpoint_connections                                                                                                                                                                                                     
+--------------------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| new-app-config-raj | Disabled              | <null>                                                                                                                                                                                                                           
| wqewqe             | Disabled              | [{"id":"/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/nist-test_group/providers/Microsoft.AppConfiguration/configurationStores/wqewqe/privateEndpointConnections/ewr","name":"ewr","privateEndpointPropertyI
+--------------------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

> select name,public_network_access,private_endpoint_connections from azure_app_configuration
+--------------------+-----------------------+------------------------------+
| name               | public_network_access | private_endpoint_connections |
+--------------------+-----------------------+------------------------------+
| wqewqe             | Enabled               | <null>                       |
| new-app-config-raj | Disabled              | <null>                       |
+--------------------+-----------------------+------------------------------+
```
</details>
