### PR TITLE
Add encryption properties in azure_kusto_cluster table closes #373

### DIFF
--- a/azure/table_azure_kusto_cluster.go
+++ b/azure/table_azure_kusto_cluster.go
@@ -70,6 +70,36 @@ func tableAzureKustoCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "enable_disk_encryption",
+				Description: "A boolean value that indicates if the cluster's disks are encrypted.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("ClusterProperties.EnableDiskEncryption"),
+			},
+			{
+				Name:        "enable_double_encryption",
+				Description: "A boolean value that indicates if double encryption is enabled.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("ClusterProperties.EnableDoubleEncryption"),
+			},
+			{
+				Name:        "enable_purge",
+				Description: "A boolean value that indicates if the purge operations are enabled.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("ClusterProperties.EnablePurge"),
+			},
+			{
+				Name:        "enable_streaming_ingest",
+				Description: "A boolean value that indicates if the streaming ingest is enabled.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("ClusterProperties.EnableStreamingIngest"),
+			},
+			{
+				Name:        "engine_type",
+				Description: "The engine type. Possible values include: 'EngineTypeV2', 'EngineTypeV3'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ClusterProperties.EngineType"),
+			},
+			{
 				Name:        "sku_capacity",
 				Description: "SKU capacity of the resource.",
 				Type:        proto.ColumnType_INT,
@@ -88,16 +118,46 @@ func tableAzureKustoCluster(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Sku.Tier"),
 			},
 			{
+				Name:        "state_reason",
+				Description: "SKU tier of the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("SClusterPropertiesku.StateReason"),
+			},
+			{
 				Name:        "uri",
 				Description: "The cluster URI.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("ClusterProperties.URI"),
 			},
 			{
+				Name:        "language_extensions",
+				Description: "List of the cluster's language extensions.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ClusterProperties.LanguageExtensions"),
+			},
+			{
+				Name:        "key_vault_properties",
+				Description: "KeyVault properties for the cluster encryption.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ClusterProperties.KeyVaultProperties"),
+			},
+			{
+				Name:        "optimized_autoscale",
+				Description: "Optimized auto scale definition.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ClusterProperties.OptimizedAutoscale"),
+			},
+			{
 				Name:        "trusted_external_tenants",
 				Description: "The cluster's external tenants.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("ClusterProperties.TrustedExternalTenants"),
+			},
+			{
+				Name:        "virtual_network_configuration",
+				Description: "Virtual network definition of the resource.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ClusterProperties.VirtualNetworkConfiguration"),
 			},
 
 			// Steampipe standard columns


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_kusto_cluster []

PRETEST: tests/azure_kusto_cluster

TEST: tests/azure_kusto_cluster
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065]
azurerm_kusto_cluster.named_test_resource: Creating...
azurerm_kusto_cluster.named_test_resource: Still creating... [10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [1m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [1m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [1m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [1m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [1m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [1m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [2m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [2m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [2m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [2m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [2m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [2m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [3m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [3m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [3m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [3m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [3m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [3m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [4m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [4m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [4m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [4m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [4m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [4m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [5m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [5m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [5m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [5m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [5m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [5m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [6m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [6m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [6m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [6m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [6m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [6m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [7m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [7m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [7m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [7m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [7m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [7m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [8m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [8m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [8m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [8m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [8m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [8m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [9m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [9m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [9m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [9m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [9m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [9m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [10m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [10m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [10m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [10m30s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [10m40s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [10m50s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [11m0s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [11m10s elapsed]
azurerm_kusto_cluster.named_test_resource: Still creating... [11m20s elapsed]
azurerm_kusto_cluster.named_test_resource: Creation complete after 11m28s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065/providers/Microsoft.Kusto/Clusters/turbottest69065]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

cluster_uri = https://turbottest69065.eastus.kusto.windows.net
location = eastus
resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065/providers/Microsoft.Kusto/Clusters/turbottest69065
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest69065/providers/microsoft.kusto/clusters/turbottest69065
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065/providers/Microsoft.Kusto/Clusters/turbottest69065
resource_name = turbottest69065
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065/providers/Microsoft.Kusto/Clusters/turbottest69065",
    "name": "turbottest69065",
    "sku_name": "Standard_D13_v2",
    "uri": "https://turbottest69065.eastus.kusto.windows.net"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065/providers/Microsoft.Kusto/Clusters/turbottest69065",
    "name": "turbottest69065"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest69065/providers/Microsoft.Kusto/Clusters/turbottest69065",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest69065/providers/microsoft.kusto/clusters/turbottest69065"
    ],
    "name": "turbottest69065",
    "title": "turbottest69065"
  }
]
✔ PASSED

POSTTEST: tests/azure_kusto_cluster

TEARDOWN: tests/azure_kusto_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
 select name, enable_disk_encryption, enable_double_encryption, enable_purge, enable_streaming_ingest, engine_type from azure_kusto_cluster;
```

```
+-----------------+------------------------+--------------------------+--------------+-------------------------+-------------+
| name            | enable_disk_encryption | enable_double_encryption | enable_purge | enable_streaming_ingest | engine_type |
+-----------------+------------------------+--------------------------+--------------+-------------------------+-------------+
| turbottest69065 | false                  | false                    | false        | false                   | V2          |
| testdemo34      | false                  | false                    | false        | true                    | V3          |
+-----------------+------------------------+--------------------------+--------------+-------------------------+-------------+
```

</details>
