### PR TITLE
Add security_profile column in azure_compute_virtual_machine table. Closes #383

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -321,6 +321,12 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "security_profile",
+				Description: "Specifies the security related profile settings for the virtual machine.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("VirtualMachineProperties.SecurityProfile"),
+			},
+			{
 				Name:        "win_rm",
 				Description: "Specifies the windows remote management listeners. This enables remote windows powershell.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/azure_compute_virtual_machine.md
+++ b/docs/tables/azure_compute_virtual_machine.md
@@ -138,3 +138,14 @@ where
         trim(elem) = 'UserAssigned'
   );
 ```
+
+### List security profile details
+
+```sql
+select
+  name,
+  vm_id,
+  security_profile -> 'encryptionAtHost' as encryption_at_host
+from
+  azure_compute_virtual_machine;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_compute_virtual_machine
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_virtual_machine []

PRETEST: tests/azure_compute_virtual_machine

TEST: tests/azure_compute_virtual_machine
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_network_interface.named_test_resource will be created
  + resource "azurerm_network_interface" "named_test_resource" {
      + applied_dns_servers           = (known after apply)
      + dns_servers                   = (known after apply)
      + enable_accelerated_networking = false
      + enable_ip_forwarding          = false
      + id                            = (known after apply)
      + internal_dns_name_label       = (known after apply)
      + internal_fqdn                 = (known after apply)
      + location                      = "eastus"
      + mac_address                   = (known after apply)
      + name                          = "turbottest56060"
      + private_ip_address            = (known after apply)
      + private_ip_addresses          = (known after apply)
      + resource_group_name           = "turbottest56060"
      + tags                          = (known after apply)
      + virtual_machine_id            = (known after apply)

      + ip_configuration {
          + application_gateway_backend_address_pools_ids = (known after apply)
          + application_security_group_ids                = (known after apply)
          + load_balancer_backend_address_pools_ids       = (known after apply)
          + load_balancer_inbound_nat_rules_ids           = (known after apply)
          + name                                          = "turbottest56060"
          + primary                                       = (known after apply)
          + private_ip_address_allocation                 = "dynamic"
          + private_ip_address_version                    = "IPv4"
          + subnet_id                                     = (known after apply)
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest56060"
      + tags     = (known after apply)
    }

  # azurerm_subnet.named_test_resource will be created
  + resource "azurerm_subnet" "named_test_resource" {
      + address_prefix       = "10.0.2.0/24"
      + id                   = (known after apply)
      + ip_configurations    = (known after apply)
      + name                 = "turbottest56060"
      + resource_group_name  = "turbottest56060"
      + virtual_network_name = "turbottest56060"
    }

  # azurerm_virtual_machine.named_test_resource will be created
  + resource "azurerm_virtual_machine" "named_test_resource" {
      + availability_set_id              = (known after apply)
      + delete_data_disks_on_termination = false
      + delete_os_disk_on_termination    = false
      + id                               = (known after apply)
      + license_type                     = (known after apply)
      + location                         = "eastus"
      + name                             = "turbottest56060"
      + network_interface_ids            = (known after apply)
      + resource_group_name              = "turbottest56060"
      + tags                             = {
          + "name" = "turbottest56060"
        }
      + vm_size                          = "Standard_DS1_v2"

      + identity {
          + identity_ids = (known after apply)
          + principal_id = (known after apply)
          + type         = (known after apply)
        }

      + os_profile {
          + admin_password = (sensitive value)
          + admin_username = "testadmin"
          + computer_name  = "hostname"
          + custom_data    = (known after apply)
        }

      + os_profile_linux_config {
          + disable_password_authentication = false
        }

      + storage_data_disk {
          + caching                   = (known after apply)
          + create_option             = (known after apply)
          + disk_size_gb              = (known after apply)
          + lun                       = (known after apply)
          + managed_disk_id           = (known after apply)
          + managed_disk_type         = (known after apply)
          + name                      = (known after apply)
          + vhd_uri                   = (known after apply)
          + write_accelerator_enabled = (known after apply)
        }

      + storage_image_reference {
          + offer     = "UbuntuServer"
          + publisher = "Canonical"
          + sku       = "16.04-LTS"
          + version   = "latest"
        }

      + storage_os_disk {
          + caching                   = "ReadWrite"
          + create_option             = "FromImage"
          + disk_size_gb              = (known after apply)
          + managed_disk_id           = (known after apply)
          + managed_disk_type         = "Standard_LRS"
          + name                      = "turbottest56060"
          + os_type                   = (known after apply)
          + write_accelerator_enabled = false
        }
    }

  # azurerm_virtual_network.named_test_resource will be created
  + resource "azurerm_virtual_network" "named_test_resource" {
      + address_space       = [
          + "10.0.0.0/16",
        ]
      + id                  = (known after apply)
      + location            = "eastus"
      + name                = "turbottest56060"
      + resource_group_name = "turbottest56060"
      + tags                = (known after apply)

      + subnet {
          + address_prefix = (known after apply)
          + id             = (known after apply)
          + name           = (known after apply)
          + security_group = (known after apply)
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka        = (known after apply)
  + resource_aka_lower  = (known after apply)
  + resource_id         = (known after apply)
  + resource_name       = "turbottest56060"
  + resource_name_upper = "TURBOTTEST56060"
  + subscription_id     = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_network.named_test_resource: Still creating... [20s elapsed]
azurerm_virtual_network.named_test_resource: Creation complete after 21s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Network/virtualNetworks/turbottest56060]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 2s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Network/virtualNetworks/turbottest56060/subnets/turbottest56060]
azurerm_network_interface.named_test_resource: Creating...
azurerm_network_interface.named_test_resource: Creation complete after 7s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Network/networkInterfaces/turbottest56060]
azurerm_virtual_machine.named_test_resource: Creating...
azurerm_virtual_machine.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [20s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [30s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [40s elapsed]
azurerm_virtual_machine.named_test_resource: Creation complete after 48s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Compute/virtualMachines/turbottest56060]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 22, in provider "azurerm":
  22:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Compute/virtualMachines/turbottest56060"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest56060/providers/microsoft.compute/virtualmachines/turbottest56060"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Compute/virtualMachines/turbottest56060"
resource_name = "turbottest56060"
resource_name_upper = "TURBOTTEST56060"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Compute/virtualMachines/turbottest56060",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest56060",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest56060",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest56060",
    "size": "Standard_DS1_v2",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Compute/virtualMachines/turbottest56060",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest56060",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest56060",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest56060",
    "size": "Standard_DS1_v2",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/TURBOTTEST56060/providers/Microsoft.Compute/virtualMachines/turbottest56060",
    "name": "turbottest56060",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest56060/providers/Microsoft.Compute/virtualMachines/turbottest56060",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest56060/providers/microsoft.compute/virtualmachines/turbottest56060"
    ],
    "name": "turbottest56060",
    "tags": {
      "name": "turbottest56060"
    },
    "title": "turbottest56060"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_virtual_machine

TEARDOWN: tests/azure_compute_virtual_machine

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  vm_id,
  security_profile -> 'encryptionAtHost' as encryption_at_host
from
  azure_compute_virtual_machine;
+-----------+--------------------------------------+--------------------+
| name      | vm_id                                | encryption_at_host |
+-----------+--------------------------------------+--------------------+
| linux-sou | fd8240b1-d693-4656-8ef9-ad43d7447a15 | <null>             |
| terete    | b971a922-0ec1-4f4d-b761-71e270ece169 | <null>             |
| test-vm-1 | 7879f527-a128-4d72-8fa2-e472f09c7efc | true               |
+-----------+--------------------------------------+--------------------+
> select
  name,
  power_state,
  private_ips,
  public_ips,
  vm_id,
  size,
  os_type,
  image_offer,
  image_sku
from
  azure_compute_virtual_machine;
+-----------+-------------+----------------+-------------------+--------------------------------------+---------------+---------+----------------+-------------+
| name      | power_state | private_ips    | public_ips        | vm_id                                | size          | os_type | image_offer    | image_sku   |
+-----------+-------------+----------------+-------------------+--------------------------------------+---------------+---------+----------------+-------------+
| linux-sou | running     | ["172.16.0.6"] | ["40.114.47.191"] | fd8240b1-d693-4656-8ef9-ad43d7447a15 | Standard_B1ls | Linux   | UbuntuServer   | 18.04-LTS   |
| test-vm-1 | running     | ["172.17.0.4"] | ["20.112.74.128"] | 7879f527-a128-4d72-8fa2-e472f09c7efc | Standard_B2s  | Windows | sql2019-ws2019 | sqldev      |
| terete    | running     | ["172.16.0.5"] | ["52.149.221.15"] | b971a922-0ec1-4f4d-b761-71e270ece169 | Standard_B1ls | Windows | Windows-10     | 20h2-pro-g2 |
+-----------+-------------+----------------+-------------------+--------------------------------------+---------------+---------+----------------+-------------+
> select
  region,
  count(name)
from
  azure_compute_virtual_machine
group by
  region;
+---------+-------+
| region  | count |
+---------+-------+
| eastus  | 2     |
| westus2 | 1     |
+---------+-------+
> select
  vm.name,
  disk.encryption_type
from
  azure_compute_disk as disk
  join azure_compute_virtual_machine as vm on disk.name = vm.os_disk_name
where
  not disk.encryption_type = 'EncryptionAtRestWithCustomerKey';
+-----------+---------------------------------+
| name      | encryption_type                 |
+-----------+---------------------------------+
| test-vm-1 | EncryptionAtRestWithPlatformKey |
| linux-sou | EncryptionAtRestWithPlatformKey |
| terete    | EncryptionAtRestWithPlatformKey |
+-----------+---------------------------------+
> select
  size,
  count(*) as count
from
  azure_compute_virtual_machine
where
  size not in ('Standard_D8s_v3', 'Standard_DS3_v3')
group by
  size;
+---------------+-------+
| size          | count |
+---------------+-------+
| Standard_B1ls | 2     |
| Standard_B2s  | 1     |
+---------------+-------+
> select
  vm.name vm_name,
  aset.name availability_set_name,
  aset.platform_fault_domain_count,
  aset.platform_update_domain_count,
  aset.sku_name
from
  azure_compute_availability_set as aset
  join azure_compute_virtual_machine as vm on lower(aset.id) = lower(vm.availability_set_id);
+---------+-----------------------+-----------------------------+------------------------------+----------+
| vm_name | availability_set_name | platform_fault_domain_count | platform_update_domain_count | sku_name |
+---------+-----------------------+-----------------------------+------------------------------+----------+
+---------+-----------------------+-----------------------------+------------------------------+----------+
> select
  name,
  vm_id,
  eviction_policy
from
  azure_compute_virtual_machine
where
  priority = 'Spot';
+------+-------+-----------------+
| name | vm_id | eviction_policy |
+------+-------+-----------------+
+------+-------+-----------------+
> select
  vm.name,
  count(d) as num_disks,
  sum(d.disk_size_gb) as total_disk_size_gb
from
  azure.azure_compute_virtual_machine as vm
  left join azure_compute_disk as d on lower(vm.id) = lower(d.managed_by)
group by
  vm.name
order by
  vm.name;
+-----------+-----------+--------------------+
| name      | num_disks | total_disk_size_gb |
+-----------+-----------+--------------------+
| linux-sou | 1         | 30                 |
| terete    | 1         | 127                |
| test-vm-1 | 3         | 2175               |
+-----------+-----------+--------------------+
> select
  vm.name,
  nsg.name,
  jsonb_pretty(security_rules)
from
  azure.azure_compute_virtual_machine as vm,
  jsonb_array_elements(vm.network_interfaces) as vm_nic,
  azure_network_security_group as nsg,
  jsonb_array_elements(nsg.network_interfaces) as nsg_int
where
  lower(vm_nic ->> 'id') = lower(nsg_int ->> 'id')
  and vm.name = 'warehouse-01';
+------+------+--------------+
| name | name | jsonb_pretty |
+------+------+--------------+
+------+------+--------------+
> select
  name,
  identity -> 'type' as identity_type,
  jsonb_pretty(identity -> 'userAssignedIdentities') as identity_user_assignedidentities
from
  azure_compute_virtual_machine
where
    exists (
      select
      from
        unnest(regexp_split_to_array(identity ->> 'type', ',')) elem
      where
        trim(elem) = 'UserAssigned'
  );
+------+---------------+----------------------------------+
| name | identity_type | identity_user_assignedidentities |
+------+---------------+----------------------------------+
+------+---------------+----------------------------------+
> select
  name,
  vm_id,
  security_profile -> 'encryptionAtHost' as encryption_at_host
from
  azure_compute_virtual_machine;
+-----------+--------------------------------------+--------------------+
| name      | vm_id                                | encryption_at_host |
+-----------+--------------------------------------+--------------------+
| linux-sou | fd8240b1-d693-4656-8ef9-ad43d7447a15 | <null>             |
| terete    | b971a922-0ec1-4f4d-b761-71e270ece169 | <null>             |
| test-vm-1 | 7879f527-a128-4d72-8fa2-e472f09c7efc | true               |
+-----------+--------------------------------------+--------------------+
```
</details>
