### PR TITLE
Add key_vault_key_uri column in azure_healthcare_service table. Closes #390

### DIFF
--- a/azure/table_azure_healthcare_service.go
+++ b/azure/table_azure_healthcare_service.go
@@ -74,12 +74,6 @@ func tableAzureHealthcareService(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Properties.AuthenticationConfiguration.Authority").Transform(transform.ToString),
 			},
 			{
-				Name:        "cosmos_db_configuration",
-				Description: "The settings for the Cosmos DB database backing the service.",
-				Type:        proto.ColumnType_INT,
-				Transform:   transform.FromField("Properties.CosmosDbConfiguration.OfferThroughput"),
-			},
-			{
 				Name:        "kind",
 				Description: "The kind of the service. Possible values include: 'Fhir', 'FhirStu3', 'FhirR4'.",
 				Type:        proto.ColumnType_STRING,
@@ -106,6 +100,12 @@ func tableAzureHealthcareService(_ context.Context) *plugin.Table {
 				Description: "The access policies of the healthcare service.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Properties.AccessPolicies"),
+			},
+			{
+				Name:        "cosmos_db_configuration",
+				Description: "The settings for the Cosmos DB database backing the service.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Properties.CosmosDbConfiguration"),
 			},
 			{
 				Name:        "diagnostic_settings",

--- a/docs/tables/azure_healthcare_service.md
+++ b/docs/tables/azure_healthcare_service.md
@@ -62,3 +62,15 @@ from
   azure_healthcare_service,
   jsonb_array_elements(diagnostic_settings) as d;
 ```
+
+### List Cosmos DB configuration settings
+
+```sql
+select
+  name,
+  id,
+  cosmos_db_configuration ->> 'keyVaultKeyUri' as key_vault_key_uri,
+  cosmos_db_configuration -> 'offerThroughput' as offer_throughput
+from
+  azure_healthcare_service;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro azure-test % ./tint.js azure_healthcare_service
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_healthcare_service []

PRETEST: tests/azure_healthcare_service

TEST: tests/azure_healthcare_service
Running terraform
azurerm_resource_group.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838]
azurerm_healthcare_service.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838/providers/Microsoft.HealthcareApis/services/turbottest28838]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # azurerm_healthcare_service.named_test_resource has been deleted
  - resource "azurerm_healthcare_service" "named_test_resource" {
      - access_policy_object_ids = [] -> null
      - cosmosdb_throughput      = 2000 -> null
      - id                       = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838/providers/Microsoft.HealthcareApis/services/turbottest28838" -> null
      - kind                     = "fhir-R4" -> null
      - location                 = "eastus" -> null
      - name                     = "turbottest28838" -> null
      - resource_group_name      = "turbottest28838" -> null
      - tags                     = {
          - "name" = "turbottest28838"
        } -> null

      - authentication_configuration {
          - audience            = "https://turbottest28838.azurehealthcareapis.com" -> null
          - authority           = "https://login.microsoftonline.com/cdffd708-7da0-4cea-abeb-0a4c334d7f64" -> null
          - smart_proxy_enabled = false -> null
        }

      - cors_configuration {
          - allow_credentials  = false -> null
          - allowed_headers    = [] -> null
          - allowed_methods    = [] -> null
          - allowed_origins    = [] -> null
          - max_age_in_seconds = 0 -> null
        }
    }

Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # azurerm_healthcare_service.named_test_resource will be created
  + resource "azurerm_healthcare_service" "named_test_resource" {
      + cosmosdb_throughput = 2000
      + id                  = (known after apply)
      + kind                = "fhir-R4"
      + location            = "eastus"
      + name                = "turbottest77867"
      + resource_group_name = "turbottest77867"
      + tags                = {
          + "name" = "turbottest77867"
        }

      + authentication_configuration {
          + audience            = (known after apply)
          + authority           = (known after apply)
          + smart_proxy_enabled = (known after apply)
        }

      + cors_configuration {
          + allow_credentials  = (known after apply)
          + allowed_headers    = (known after apply)
          + allowed_methods    = (known after apply)
          + allowed_origins    = (known after apply)
          + max_age_in_seconds = (known after apply)
        }
    }

  # azurerm_resource_group.named_test_resource must be replaced
-/+ resource "azurerm_resource_group" "named_test_resource" {
      ~ id       = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838" -> (known after apply)
      ~ name     = "turbottest28838" -> "turbottest77867" # forces replacement
      - tags     = {} -> null
        # (1 unchanged attribute hidden)
    }

Plan: 2 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest77867"
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 10s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 20s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 30s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 40s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 50s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 1m0s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 1m10s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest28838, 1m20s elapsed]
azurerm_resource_group.named_test_resource: Destruction complete after 1m22s
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 1s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867]
azurerm_healthcare_service.named_test_resource: Creating...
azurerm_healthcare_service.named_test_resource: Still creating... [10s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [20s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [30s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [40s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [50s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [1m0s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [1m10s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [1m20s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [1m30s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [1m40s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [1m50s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [2m0s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [2m10s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [2m20s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [2m30s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [2m40s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [2m50s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [3m0s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [3m10s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [3m20s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [3m30s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [3m40s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [3m50s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [4m0s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [4m10s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [4m20s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [4m30s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [4m40s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [4m50s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [5m0s elapsed]
azurerm_healthcare_service.named_test_resource: Still creating... [5m10s elapsed]
azurerm_healthcare_service.named_test_resource: Creation complete after 5m14s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867/providers/Microsoft.HealthcareApis/services/turbottest77867]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 22, in provider "azurerm":
  22:   version = "=2.41.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 30, in data "null_data_source" "resource":
  30: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 1 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867/providers/Microsoft.HealthcareApis/services/turbottest77867"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest77867/providers/microsoft.healthcareapis/services/turbottest77867"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867/providers/Microsoft.HealthcareApis/services/turbottest77867"
resource_name = "turbottest77867"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867/providers/Microsoft.HealthcareApis/services/turbottest77867",
    "kind": "fhir-R4",
    "name": "turbottest77867",
    "region": "eastus",
    "type": "Microsoft.HealthcareApis/services"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867/providers/Microsoft.HealthcareApis/services/turbottest77867",
    "name": "turbottest77867"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest77867/providers/Microsoft.HealthcareApis/services/turbottest77867",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest77867/providers/microsoft.healthcareapis/services/turbottest77867"
    ],
    "name": "turbottest77867",
    "tags": {
      "name": "turbottest77867"
    },
    "title": "turbottest77867"
  }
]
✔ PASSED

POSTTEST: tests/azure_healthcare_service

TEARDOWN: tests/azure_healthcare_service

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  kind,
  type,
  allow_credentials,
  audience,
  authority
from
  azure_healthcare_service;
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+---------+-----------------------------------+-------------------+-------------------------------------------------+------------------------------------------------------------------------+
| name            | id                                                                                                                                                 | kind    | type                              | allow_credentials | audience                                        | authority                                                              |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+---------+-----------------------------------+-------------------+-------------------------------------------------+------------------------------------------------------------------------+
| turbottest28838 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838/providers/Microsoft.HealthcareApis/services/turbottest28838     | fhir-R4 | Microsoft.HealthcareApis/services | false             | https://turbottest28838.azurehealthcareapis.com | https://login.microsoftonline.com/cdffd708-7da0-4cea-abeb-0a4c334d7f64 |
| test-fihr       | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.HealthcareApis/services/test-fihr | fhir-R4 | Microsoft.HealthcareApis/services | false             | https://test-fihr.azurehealthcareapis.com       | https://login.microsoftonline.com/cdffd708-7da0-4cea-abeb-0a4c334d7f64 |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+---------+-----------------------------------+-------------------+-------------------------------------------------+------------------------------------------------------------------------+
> select
  name,
  id,
  type,
  kind
from
  azure_healthcare_service
where
  kind = 'fhir-R4';
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+---------+
| name            | id                                                                                                                                                 | type                              | kind    |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+---------+
| test-fihr       | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.HealthcareApis/services/test-fihr | Microsoft.HealthcareApis/services | fhir-R4 |
| turbottest28838 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838/providers/Microsoft.HealthcareApis/services/turbottest28838     | Microsoft.HealthcareApis/services | fhir-R4 |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+---------+
> select
  name,
  id,
  p ->> 'PrivateEndpointConnectionId' as private_endpoint_connection_id,
  p ->> 'ProvisioningState' as private_endpoint_provisioning_state,
  p ->> 'PrivateEndpointConnectionName' as private_endpoint_connection_name,
  p ->> 'PrivateEndpointConnectionType' as private_endpoint_connection_type
from
  azure_healthcare_service,
  jsonb_array_elements(private_endpoint_connections) as p;
+------+----+--------------------------------+-------------------------------------+----------------------------------+----------------------------------+
| name | id | private_endpoint_connection_id | private_endpoint_provisioning_state | private_endpoint_connection_name | private_endpoint_connection_type |
+------+----+--------------------------------+-------------------------------------+----------------------------------+----------------------------------+
+------+----+--------------------------------+-------------------------------------+----------------------------------+----------------------------------+
> select
  name,
  id,
  d ->> 'id' as diagnostic_setting_id,
  d ->> 'name' as diagnostic_setting_name,
  d ->> 'type' as diagnostic_setting_type,
  d ->> 'properties' as diagnostic_setting_properties
from
  azure_healthcare_service,
  jsonb_array_elements(diagnostic_settings) as d;
+------+----+-----------------------+-------------------------+-------------------------+-------------------------------+
| name | id | diagnostic_setting_id | diagnostic_setting_name | diagnostic_setting_type | diagnostic_setting_properties |
+------+----+-----------------------+-------------------------+-------------------------+-------------------------------+
+------+----+-----------------------+-------------------------+-------------------------+-------------------------------+
> select
  name,
  id,
  cosmos_db_configuration ->> 'keyVaultKeyUri' as key_vault_key_uri,
  cosmos_db_configuration -> 'offerThroughput' as offer_throughput
from
  azure_healthcare_service;
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+------------------+
| name            | id                                                                                                                                                 | key_vault_key_uri                                              | offer_throughput |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+------------------+
| turbottest28838 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28838/providers/Microsoft.HealthcareApis/services/turbottest28838     | <null>                                                         | 2000             |
| test-fihr       | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/arnab-test-resource-group/providers/Microsoft.HealthcareApis/services/test-fihr | https://testing-hdinsight.vault.azure.net/keys/kafkaClusterKey | 400              |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+------------------+  
```
</details>
