### PR TITLE
In the azure_compute_virtual_machine table show properties.virtualMachineScaleSet closes #417

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -327,6 +327,13 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VirtualMachineProperties.SecurityProfile"),
 			},
 			{
+				Name:        "scale_set",
+				Description: "Specifies information about the virtual machine scale set that the virtual machine should be assigned to.",
+				Type:        proto.ColumnType_JSON,
+				// Hydrate:     getAzureComputeVirtualMachine,
+				Transform:   transform.FromField("VirtualMachineProperties.VirtualMachineScaleSet"),
+			},
+			{
 				Name:        "win_rm",
 				Description: "Specifies the windows remote management listeners. This enables remote windows powershell.",
 				Type:        proto.ColumnType_JSON,

--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -330,7 +330,6 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Name:        "scale_set",
 				Description: "Specifies information about the virtual machine scale set that the virtual machine should be assigned to.",
 				Type:        proto.ColumnType_JSON,
-				// Hydrate:     getAzureComputeVirtualMachine,
 				Transform:   transform.FromField("VirtualMachineProperties.VirtualMachineScaleSet"),
 			},
 			{


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_compute_virtual_machine []

PRETEST: tests/azure_compute_virtual_machine

TEST: tests/azure_compute_virtual_machine
Running terraform
data.azurerm_client_config.current: Refreshing state...
azurerm_resource_group.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661]
data.null_data_source.resource: Refreshing state...
azurerm_virtual_network.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Network/virtualNetworks/turbottest68661]
azurerm_subnet.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Network/virtualNetworks/turbottest68661/subnets/turbottest68661]
azurerm_network_interface.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Network/networkInterfaces/turbottest68661]
azurerm_virtual_machine.named_test_resource: Refreshing state... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Compute/virtualMachines/turbottest68661]
azurerm_virtual_machine.named_test_resource: Destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Compute/virtualMachines/turbottest68661]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 1m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 1m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 1m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 1m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 1m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 1m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 2m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 2m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 2m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 2m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 2m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 2m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 3m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 3m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 3m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 3m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 3m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 3m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 4m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 4m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 4m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 4m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 4m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 4m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 5m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 5m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 5m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 5m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 5m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 5m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 6m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 6m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 6m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 6m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 6m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 6m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 7m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 7m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 7m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 7m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 7m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 7m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 8m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 8m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 8m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 8m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 8m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 8m50s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 9m0s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 9m10s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 9m20s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 9m30s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 9m40s elapsed]
azurerm_virtual_machine.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...ompute/virtualMachines/turbottest68661, 9m50s elapsed]
azurerm_virtual_machine.named_test_resource: Destruction complete after 9m52s
azurerm_network_interface.named_test_resource: Destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Network/networkInterfaces/turbottest68661]
azurerm_network_interface.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...work/networkInterfaces/turbottest68661, 10s elapsed]
azurerm_network_interface.named_test_resource: Destruction complete after 13s
azurerm_subnet.named_test_resource: Destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Network/virtualNetworks/turbottest68661/subnets/turbottest68661]
azurerm_subnet.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...urbottest68661/subnets/turbottest68661, 10s elapsed]
azurerm_subnet.named_test_resource: Destruction complete after 11s
azurerm_virtual_network.named_test_resource: Destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661/providers/Microsoft.Network/virtualNetworks/turbottest68661]
azurerm_virtual_network.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...etwork/virtualNetworks/turbottest68661, 10s elapsed]
azurerm_virtual_network.named_test_resource: Destruction complete after 12s
azurerm_resource_group.named_test_resource: Destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest68661]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 10s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 20s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 30s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 40s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 50s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 1m0s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 1m10s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 1m20s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 1m30s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 1m40s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 1m50s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 2m0s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 2m10s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 2m20s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 2m30s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 2m40s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 2m50s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 3m0s elapsed]
azurerm_resource_group.named_test_resource: Still destroying... [id=/subscriptions/d46d7416-f95f-4771-bbb5-...c76659c/resourceGroups/turbottest68661, 3m10s elapsed]
azurerm_resource_group.named_test_resource: Destruction complete after 3m14s
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 1s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_network.named_test_resource: Creation complete after 14s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Network/virtualNetworks/turbottest24497]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 7s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Network/virtualNetworks/turbottest24497/subnets/turbottest24497]
azurerm_network_interface.named_test_resource: Creating...
azurerm_network_interface.named_test_resource: Still creating... [10s elapsed]
azurerm_network_interface.named_test_resource: Creation complete after 12s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Network/networkInterfaces/turbottest24497]
azurerm_virtual_machine.named_test_resource: Creating...
azurerm_virtual_machine.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [20s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [30s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [40s elapsed]
azurerm_virtual_machine.named_test_resource: Still creating... [50s elapsed]
azurerm_virtual_machine.named_test_resource: Creation complete after 55s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Compute/virtualMachines/turbottest24497]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Argument is deprecated

  on variables.tf line 52, in resource "azurerm_subnet" "named_test_resource":
  52:   address_prefix       = "10.0.2.0/24"

Use the `address_prefixes` property instead.


Apply complete! Resources: 5 added, 0 changed, 5 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Compute/virtualMachines/turbottest24497
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest24497/providers/microsoft.compute/virtualmachines/turbottest24497
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Compute/virtualMachines/turbottest24497
resource_name = turbottest24497
resource_name_upper = TURBOTTEST24497
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Compute/virtualMachines/turbottest24497",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest24497",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest24497",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest24497",
    "size": "Standard_DS1_v2",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "admin_user_name": "testadmin",
    "computer_name": "hostname",
    "disable_password_authentication": false,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Compute/virtualMachines/turbottest24497",
    "image_offer": "UbuntuServer",
    "image_publisher": "Canonical",
    "image_sku": "16.04-LTS",
    "image_version": "latest",
    "name": "turbottest24497",
    "os_disk_caching": "ReadWrite",
    "os_disk_create_option": "FromImage",
    "os_disk_name": "turbottest24497",
    "os_type": "Linux",
    "priority": "",
    "provision_vm_agent": true,
    "region": "eastus",
    "require_guest_provision_signal": true,
    "resource_group": "turbottest24497",
    "size": "Standard_DS1_v2",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/TURBOTTEST24497/providers/Microsoft.Compute/virtualMachines/turbottest24497",
    "name": "turbottest24497",
    "type": "Microsoft.Compute/virtualMachines"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest24497/providers/Microsoft.Compute/virtualMachines/turbottest24497",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest24497/providers/microsoft.compute/virtualmachines/turbottest24497"
    ],
    "name": "turbottest24497",
    "tags": {
      "name": "turbottest24497"
    },
    "title": "turbottest24497"
  }
]
✔ PASSED

POSTTEST: tests/azure_compute_virtual_machine

TEARDOWN: tests/azure_compute_virtual_machine

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select name, scale_set from azure_compute_virtual_machine
+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| name                  | scale_set                                                                                                                                                |
+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| turbottest43315       | <null>                                                                                                                                                   |
| testScaleSet_2fa97b5f | {"id":"/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/TEST-VM-GRP/providers/Microsoft.Compute/virtualMachineScaleSets/testScaleSet"} |
+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>
