### PR TITLE
Added column server_configurations in azure_mysql_server table. Closes #427

### DIFF
--- a/azure-test/tests/azure_mysql_server/variables.tf
+++ b/azure-test/tests/azure_mysql_server/variables.tf
@@ -13,7 +13,7 @@ variable "azure_environment" {
 
 variable "azure_subscription" {
   type        = string
-  default     = "d46d7416-f95f-4771-bbb5-529d4c76659c"
+  default     = "3510ae4d-530b-497d-8f30-53b9616fc6c1"
   description = "Azure subscription used for the test."
 }
 

--- a/azure-test/tests/azure_mysql_server/variables.tf
+++ b/azure-test/tests/azure_mysql_server/variables.tf
@@ -13,7 +13,7 @@ variable "azure_environment" {
 
 variable "azure_subscription" {
   type        = string
-  default     = "3510ae4d-530b-497d-8f30-53b9616fc6c1"
+  default     = "d46d7416-f95f-4771-bbb5-529d4c76659c"
   description = "Azure subscription used for the test."
 }
 

--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -463,16 +463,16 @@ func extractMySQLServersconfiguration(i mysql.Configuration) map[string]interfac
 	mySQLServersconfiguration := make(map[string]interface{})
 
 	if i.ID != nil {
-		mySQLServersconfiguration["id"] = *i.ID
+		mySQLServersconfiguration["ID"] = *i.ID
 	}
 	if i.Name != nil {
-		mySQLServersconfiguration["name"] = *i.Name
+		mySQLServersconfiguration["Name"] = *i.Name
 	}
 	if i.Type != nil {
-		mySQLServersconfiguration["type"] = *i.Type
+		mySQLServersconfiguration["Type"] = *i.Type
 	}
 	if i.ConfigurationProperties != nil {
-		mySQLServersconfiguration["configurationProperties"] = *i.ConfigurationProperties
+		mySQLServersconfiguration["ConfigurationProperties"] = *i.ConfigurationProperties
 	}
 
 	return mySQLServersconfiguration

--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -193,7 +193,7 @@ func tableAzureMySQLServer(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "server_configurations",
-				Description: "The server configurations details.",
+				Description: "The server configurations(parameters) details of the server.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listMySQLServersConfigurations,
 				Transform:   transform.FromValue(),

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -127,8 +127,8 @@ from
 select
   name as server_name,
   id as server_id,
-  configurations ->> 'name' as configuration_name,
-  configurations -> 'configurationProperties' ->> 'value' as value
+  configurations ->> 'Name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations;
@@ -140,13 +140,13 @@ from
 select
   name as server_name,
   id as server_id,
-  configurations ->> 'name' as configuration_name,
-  configurations -> 'configurationProperties' ->> 'value' as value
+  configurations ->> 'Name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
 where 
-   configurations ->> 'name' = 'audit_log_enabled';
+   configurations ->> 'Name' = 'audit_log_enabled';
 ```
 
 ### List servers with slow_query_log parameter enabled
@@ -155,14 +155,14 @@ where
 select
   name as server_name,
   id as server_id,
-  configurations ->> 'name' as configuration_name,
-  configurations -> 'configurationProperties' ->> 'value' as value
+  configurations ->> 'Name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
 where 
-   configurations ->'configurationProperties' ->> 'value' = 'ON'
-   and configurations ->> 'name' = 'slow_query_log';
+   configurations ->'ConfigurationProperties' ->> 'value' = 'ON'
+   and configurations ->> 'Name' = 'slow_query_log';
 ```
 
 ### List servers with log_output parameter set to file
@@ -171,12 +171,12 @@ where
 select
   name as server_name,
   id as server_id,
-  configurations ->> 'name' as configuration_name,
-  configurations -> 'configurationProperties' ->> 'value' as value
+  configurations ->> 'Name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
 where 
-   configurations ->'configurationProperties' ->> 'value' = 'FILE'
-   and configurations ->> 'name' = 'log_output';
+   configurations ->'ConfigurationProperties' ->> 'value' = 'FILE'
+   and configurations ->> 'Name' = 'log_output';
 ```

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -126,56 +126,55 @@ select
   name as server_name,
   id as server_id,
   configurations ->> 'name' as configuration_name,
-  configurations -> 'ConfigurationProperties' ->> 'value' as value
+  configurations -> 'configurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations;
 ```
 
-### List server with audit log enabled
+### Current state of audit_log_enabled parameter for the servers
 
 ```sql
 select
   name as server_name,
   id as server_id,
   configurations ->> 'name' as configuration_name,
-  configurations -> 'ConfigurationProperties' ->> 'value' as value
+  configurations -> 'configurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
 where 
-   configurations ->'ConfigurationProperties' ->> 'value' = 'ON'
-   and configurations ->> 'name' = 'audit_log_enabled';
+   configurations ->> 'name' = 'audit_log_enabled';
 ```
 
-### List server with slow query log enabled
+### List servers with slow_query_log parameter enabled
 
 ```sql
 select
   name as server_name,
   id as server_id,
   configurations ->> 'name' as configuration_name,
-  configurations -> 'ConfigurationProperties' ->> 'value' as value
+  configurations -> 'configurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
 where 
-   configurations ->'ConfigurationProperties' ->> 'value' = 'ON'
+   configurations ->'configurationProperties' ->> 'value' = 'ON'
    and configurations ->> 'name' = 'slow_query_log';
 ```
 
-### List server with log output set to file
+### List servers with log_output parameter set to file
 
 ```sql
 select
   name as server_name,
   id as server_id,
   configurations ->> 'name' as configuration_name,
-  configurations -> 'ConfigurationProperties' ->> 'value' as value
+  configurations -> 'configurationProperties' ->> 'value' as value
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
 where 
-   configurations ->'ConfigurationProperties' ->> 'value' = 'FILE'
+   configurations ->'configurationProperties' ->> 'value' = 'FILE'
    and configurations ->> 'name' = 'log_output';
 ```

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -119,7 +119,7 @@ from
   jsonb_array_elements(server_keys) as keys;
 ```
 
-### List server configurations details
+### List server configuration details
 
 ```sql
 select

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -121,6 +121,8 @@ from
 
 ### List server configuration details
 
+**Note:** `Server configurations` is the same as `Server parameters` as shown in Azure MySQL server console
+
 ```sql
 select
   name as server_name,

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -118,3 +118,64 @@ from
   azure_mysql_server,
   jsonb_array_elements(server_keys) as keys;
 ```
+
+### List server configurations details
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  configurations ->> 'name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
+from
+  azure_mysql_server,
+  jsonb_array_elements(server_configurations) as configurations;
+```
+
+### List server with audit log enabled
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  configurations ->> 'name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
+from
+  azure_mysql_server,
+  jsonb_array_elements(server_configurations) as configurations
+where 
+   configurations ->'ConfigurationProperties' ->> 'value' = 'ON'
+   and configurations ->> 'name' = 'audit_log_enabled';
+```
+
+### List server with slow query log enabled
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  configurations ->> 'name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
+from
+  azure_mysql_server,
+  jsonb_array_elements(server_configurations) as configurations
+where 
+   configurations ->'ConfigurationProperties' ->> 'value' = 'ON'
+   and configurations ->> 'name' = 'slow_query_log';
+```
+
+### List server with log output set to file
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  configurations ->> 'name' as configuration_name,
+  configurations -> 'ConfigurationProperties' ->> 'value' as value
+from
+  azure_mysql_server,
+  jsonb_array_elements(server_configurations) as configurations
+where 
+   configurations ->'ConfigurationProperties' ->> 'value' = 'FILE'
+   and configurations ->> 'name' = 'log_output';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_mysql_server []

PRETEST: tests/azure_mysql_server

TEST: tests/azure_mysql_server
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_mysql_server.named_test_resource will be created
  + resource "azurerm_mysql_server" "named_test_resource" {
      + administrator_login               = "mradministrator"
      + administrator_login_password      = (sensitive value)
      + auto_grow_enabled                 = false
      + backup_retention_days             = 7
      + create_mode                       = "Default"
      + fqdn                              = (known after apply)
      + geo_redundant_backup_enabled      = false
      + id                                = (known after apply)
      + infrastructure_encryption_enabled = false
      + location                          = "eastus"
      + name                              = "turbottest10163"
      + public_network_access_enabled     = true
      + resource_group_name               = "turbottest10163"
      + sku_name                          = "B_Gen5_2"
      + ssl_enforcement                   = (known after apply)
      + ssl_enforcement_enabled           = true
      + ssl_minimal_tls_version_enforced  = "TLS1_2"
      + storage_mb                        = 5120
      + tags                              = {
          + "name" = "turbottest10163"
        }
      + version                           = "5.7"

      + storage_profile {
          + auto_grow             = (known after apply)
          + backup_retention_days = (known after apply)
          + geo_redundant_backup  = (known after apply)
          + storage_mb            = (known after apply)
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest10163"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + location           = "eastus"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest10163"
  + server_fqdn        = (known after apply)
  + subscription_id    = "d46d7416-f95f-4771-bbb5-529d4c76659c"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest10163]
azurerm_mysql_server.named_test_resource: Creating...
azurerm_mysql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m30s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m40s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m50s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m0s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m20s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m30s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m40s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m50s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [3m0s elapsed]
azurerm_mysql_server.named_test_resource: Creation complete after 3m8s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest10163/providers/Microsoft.DBforMySQL/servers/turbottest10163]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = "eastus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest10163/providers/Microsoft.DBforMySQL/servers/turbottest10163"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest10163/providers/microsoft.dbformysql/servers/turbottest10163"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest10163/providers/Microsoft.DBforMySQL/servers/turbottest10163"
resource_name = "turbottest10163"
server_fqdn = "turbottest10163.mysql.database.azure.com"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "backup_retention_days": 7,
    "fully_qualified_domain_name": "turbottest10163.mysql.database.azure.com",
    "geo_redundant_backup": "Disabled",
    "infrastructure_encryption": "Disabled",
    "location": "eastus",
    "minimal_tls_version": "TLS1_2",
    "name": "turbottest10163",
    "public_network_access": "Enabled",
    "region": "eastus",
    "resource_group": "turbottest10163",
    "sku_capacity": 2,
    "sku_family": "Gen5",
    "sku_name": "B_Gen5_2",
    "sku_tier": "Basic",
    "ssl_enforcement": "Enabled",
    "storage_auto_grow": "Disabled",
    "storage_mb": 5120,
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "type": "Microsoft.DBforMySQL/servers",
    "version": "5.7"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest10163/providers/Microsoft.DBforMySQL/servers/turbottest10163",
    "location": "eastus",
    "name": "turbottest10163"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest10163/providers/Microsoft.DBforMySQL/servers/turbottest10163",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest10163/providers/microsoft.dbformysql/servers/turbottest10163"
    ],
    "name": "turbottest10163",
    "tags": {
      "name": "turbottest10163"
    },
    "title": "turbottest10163"
  }
]
✔ PASSED

POSTTEST: tests/azure_mysql_server

TEARDOWN: tests/azure_mysql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name as server_name,
  id as server_id,
  configurations ->> 'Name' as configuration_name,
  configurations -> 'ConfigurationProperties' ->> 'value' as value
from
  azure_mysql_server,
  jsonb_array_elements(server_configurations) as configurations
where 
   configurations ->'ConfigurationProperties' ->> 'value' = 'OFF'
   and configurations ->> 'Name' = 'audit_log_enabled';
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
| server_name | server_id                                                                                                                 | configuration_name | value |
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
| qwewq       | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.DBforMySQL/servers/qwewq | audit_log_enabled  | OFF   |
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+

> select
  name as server_name,
  id as server_id,
  configurations ->> 'Name' as configuration_name,
  configurations -> 'ConfigurationProperties' ->> 'value' as value
from
  azure_mysql_server,
  jsonb_array_elements(server_configurations) as configurations
where 
   configurations ->> 'Name' = 'slow_query_log';
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
| server_name | server_id                                                                                                                 | configuration_name | value |
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
| qwewq       | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.DBforMySQL/servers/qwewq | slow_query_log     | OFF   |
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
> select
  name as server_name,
  id as server_id,
  configurations ->> 'Name' as configuration_name,
  configurations -> 'ConfigurationProperties' ->> 'value' as value
from
  azure_mysql_server,
  jsonb_array_elements(server_configurations) as configurations
where 
   configurations ->> 'Name' = 'log_output';
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
| server_name | server_id                                                                                                                 | configuration_name | value |
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+
| qwewq       | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.DBforMySQL/servers/qwewq | log_output         | FILE  |
+-------------+---------------------------------------------------------------------------------------------------------------------------+--------------------+-------+

```
</details>
