### PR TITLE
Added column diagnostic_settings to azure_storage_account table.

### DIFF
--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -757,16 +757,16 @@ func listStorageAccountDiagnosticSettings(ctx context.Context, d *plugin.QueryDa
 	for _, i := range *op.Value {
 		objectMap := make(map[string]interface{})
 		if i.ID != nil {
-			objectMap["id"] = i.ID
+			objectMap["ID"] = i.ID
 		}
 		if i.Name != nil {
-			objectMap["name"] = i.Name
+			objectMap["Name"] = i.Name
 		}
 		if i.Type != nil {
-			objectMap["type"] = i.Type
+			objectMap["Type"] = i.Type
 		}
 		if i.DiagnosticSettings != nil {
-			objectMap["properties"] = i.DiagnosticSettings
+			objectMap["DiagnosticSettings"] = i.DiagnosticSettings
 		}
 		diagnosticSettings = append(diagnosticSettings, objectMap)
 	}

--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/queue/queues"
@@ -338,6 +339,13 @@ func tableAzureStorageAccount(_ context.Context) *plugin.Table {
 				Description: "Contains the location of the geo-replicated secondary for the storage account.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Account.AccountProperties.SecondaryLocation"),
+			},
+			{
+				Name:        "diagnostic_settings",
+				Description: "A list of active diagnostic settings for the storage account.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listStorageAccountDiagnosticSettings,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "encryption_scope",
@@ -721,6 +729,49 @@ func getAzureStorageAccountQueueProperties(ctx context.Context, d *plugin.QueryD
 		}
 	}
 	return nil, nil
+}
+
+func listStorageAccountDiagnosticSettings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listStorageAccountDiagnosticSettings")
+	accountData := h.Item.(*storageAccountInfo)
+	id := *accountData.Account.ID
+
+	// Create session
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	client := insights.NewDiagnosticSettingsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client.Authorizer = session.Authorizer
+
+	op, err := client.List(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we return the API response directly, the output only gives top level
+	// contents of DiagnosticSettings
+	var diagnosticSettings []map[string]interface{}
+	for _, i := range *op.Value {
+		objectMap := make(map[string]interface{})
+		if i.ID != nil {
+			objectMap["id"] = i.ID
+		}
+		if i.Name != nil {
+			objectMap["name"] = i.Name
+		}
+		if i.Type != nil {
+			objectMap["type"] = i.Type
+		}
+		if i.DiagnosticSettings != nil {
+			objectMap["properties"] = i.DiagnosticSettings
+		}
+		diagnosticSettings = append(diagnosticSettings, objectMap)
+	}
+
+	return diagnosticSettings, nil
 }
 
 // If we return the API response directly, the output only gives the top level property

--- a/docs/tables/azure_storage_account.md
+++ b/docs/tables/azure_storage_account.md
@@ -118,3 +118,13 @@ from
 where
   lifecycle_management_policy -> 'properties' -> 'policy' -> 'rules' is null;
 ```
+
+### List diagnostic settings details
+
+```sql
+select
+  name,
+  jsonb_pretty(diagnostic_settings) as diagnostic_settings
+from
+  azure_storage_account;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_storage_account []

PRETEST: tests/azure_storage_account

TEST: tests/azure_storage_account
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest33803"
      + tags     = (known after apply)
    }

  # azurerm_storage_account.named_test_resource will be created
  + resource "azurerm_storage_account" "named_test_resource" {
      + access_tier                       = "Cool"
      + account_encryption_source         = "Microsoft.Storage"
      + account_kind                      = "StorageV2"
      + account_replication_type          = "LRS"
      + account_tier                      = "Standard"
      + account_type                      = (known after apply)
      + enable_advanced_threat_protection = false
      + enable_blob_encryption            = true
      + enable_file_encryption            = true
      + id                                = (known after apply)
      + is_hns_enabled                    = false
      + location                          = "eastus"
      + name                              = "turbottest33803"
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + resource_group_name               = "turbottest33803"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + tags                              = {
          + "name" = "turbottest33803"
        }

      + identity {
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = (known after apply)
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest33803"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 30s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 22, in provider "azurerm":
  22:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest33803/providers/microsoft.storage/storageaccounts/turbottest33803"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803"
resource_name = "turbottest33803"

Running SQL query: test-get-query.sql
[
  {
    "access_tier": "Cool",
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
    "kind": "StorageV2",
    "name": "turbottest33803",
    "sku_name": "Standard_LRS",
    "sku_tier": "Standard"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_tier": "Cool",
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
    "name": "turbottest33803"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
    "name": "turbottest33803"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest33803/providers/microsoft.storage/storageaccounts/turbottest33803"
    ],
    "tags": {
      "name": "turbottest33803"
    },
    "title": "turbottest33803"
  }
]
✔ PASSED

POSTTEST: tests/azure_storage_account

TEARDOWN: tests/azure_storage_account

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  jsonb_pretty(diagnostic_settings) as diagnostic_settings
from
  azure_storage_account;
+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name                   | diagnostic_settings                                                                                                                                                              
+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| csg10032000527a882b    | <null>                                                                                                                                                                           
| testimmutablecontainer | <null>                                                                                                                                                                           
| testt1                 | [                                                                                                                                                                                
|                        |     {                                                                                                                                                                            
|                        |         "ID": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbot_rg/providers/microsoft.storage/storageaccounts/testt1/providers/microsoft.insights/diagn
|                        |         "Name": "ewre",                                                                                                                                                          
|                        |         "Type": "Microsoft.Insights/diagnosticSettings",                                                                                                                         
|                        |         "DiagnosticSettings": {                                                                                                                                                  
|                        |             "logs": [                                                                                                                                                            
|                        |             ],                                                                                                                                                                   
|                        |             "metrics": [                                                                                                                                                         
|                        |                 {                                                                                                                                                                
|                        |                     "enabled": true,                                                                                                                                             
|                        |                     "category": "Transaction",                                                                                                                                   
|                        |                     "retentionPolicy": {                                                                                                                                         
|                        |                         "days": 0,                                                                                                                                               
|                        |                         "enabled": false                                                                                                                                         
|                        |                     }                                                                                                                                                            
|                        |                 },                                                                                                                                                               
|                        |                 {                                                                                                                                                                
|                        |                     "enabled": false,                                                                                                                                            
|                        |                     "category": "Capacity",                                                                                                                                      
|                        |                     "retentionPolicy": {                                                                                                                                         
|                        |                         "days": 0,                                                                                                                                               
|                        |                         "enabled": false                                                                                                                                         
|                        |                     }                                                                                                                                                            
|                        |                 }                                                                                                                                                                
|                        |             ],                                                                                                                                                                   
|                        |             "storageAccountId": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbot_rg/providers/microsoft.storage/storageaccounts/werewr"                
|                        |         }                                                                                                                                                                        
|                        |     }                                                                                                                                                                            
|                        | ]                                                                                                                                                                                
+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
