### PR TITLE
Fix column network_access_policy in table azure_compute_disk closes #446

### DIFF
--- a/azure/table_azure_compute_disk.go
+++ b/azure/table_azure_compute_disk.go
@@ -310,7 +310,6 @@ func listAzureComputeDisks(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 	for _, disk := range result.Values() {
 		d.StreamListItem(ctx, disk)
-		plugin.Logger(ctx).Info("Network Access Policy without page ===>>", disk.NetworkAccessPolicy)
 		// Check if context has been cancelled or if the limit has been hit (if specified)
 		// if there is a limit, it will return the number of rows required to reach this limit
 		if d.QueryStatus.RowsRemaining(ctx) == 0 {
@@ -326,7 +325,6 @@ func listAzureComputeDisks(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 		for _, disk := range result.Values() {
 			d.StreamListItem(ctx, disk)
-			plugin.Logger(ctx).Info("Network Access Policy with page ===>>", disk.NetworkAccessPolicy)
 			// Check if context has been cancelled or if the limit has been hit (if specified)
 			// if there is a limit, it will return the number of rows required to reach this limit
 			if d.QueryStatus.RowsRemaining(ctx) == 0 {

--- a/azure/table_azure_compute_disk.go
+++ b/azure/table_azure_compute_disk.go
@@ -170,6 +170,7 @@ func tableAzureComputeDisk(_ context.Context) *plugin.Table {
 				Name:        "network_access_policy",
 				Description: "Policy for accessing the disk via network",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DiskProperties.NetworkAccessPolicy"),
 			},
 			{
 				Name:        "creation_data_option",
@@ -309,6 +310,7 @@ func listAzureComputeDisks(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 	for _, disk := range result.Values() {
 		d.StreamListItem(ctx, disk)
+		plugin.Logger(ctx).Info("Network Access Policy without page ===>>", disk.NetworkAccessPolicy)
 		// Check if context has been cancelled or if the limit has been hit (if specified)
 		// if there is a limit, it will return the number of rows required to reach this limit
 		if d.QueryStatus.RowsRemaining(ctx) == 0 {
@@ -324,6 +326,7 @@ func listAzureComputeDisks(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 		for _, disk := range result.Values() {
 			d.StreamListItem(ctx, disk)
+			plugin.Logger(ctx).Info("Network Access Policy with page ===>>", disk.NetworkAccessPolicy)
 			// Check if context has been cancelled or if the limit has been hit (if specified)
 			// if there is a limit, it will return the number of rows required to reach this limit
 			if d.QueryStatus.RowsRemaining(ctx) == 0 {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, network_access_policy from azure_compute_disk
+-----------------------------------------------------------+-----------------------+
| name                                                      | network_access_policy |
+-----------------------------------------------------------+-----------------------+
| newwarriors-AAA_OsDisk_1_eac82728fe9a4e58b3db75d0518dd24d | AllowAll              |
+-----------------------------------------------------------+-----------------------+
```
</details>
