### PR TITLE
Queries fail to fetch data from azure_key_vault_secret closes #452

### DIFF
--- a/azure/service.go
+++ b/azure/service.go
@@ -42,11 +42,11 @@ type Session struct {
 func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience string) (session *Session, err error) {
 	logger := plugin.Logger(ctx)
 
-	cacheKey := "GetNewSession" + tokenAudience
+	cacheKey := "GetNewSession"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		session = cachedData.(*Session)
 		if session.Expires != nil && WillExpireIn(*session.Expires, 0) {
-			d.ConnectionManager.Cache.Delete(cacheKey)
+			d.ConnectionManager.Cache.Delete("GetNewSession")
 		} else {
 			return cachedData.(*Session), nil
 		}

--- a/azure/service.go
+++ b/azure/service.go
@@ -42,11 +42,11 @@ type Session struct {
 func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience string) (session *Session, err error) {
 	logger := plugin.Logger(ctx)
 
-	cacheKey := "GetNewSession"
+	cacheKey := "GetNewSession" + tokenAudience
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		session = cachedData.(*Session)
 		if session.Expires != nil && WillExpireIn(*session.Expires, 0) {
-			d.ConnectionManager.Cache.Delete("GetNewSession")
+			d.ConnectionManager.Cache.Delete(cacheKey)
 		} else {
 			return cachedData.(*Session), nil
 		}

--- a/azure/table_azure_key_vault_secret.go
+++ b/azure/table_azure_key_vault_secret.go
@@ -168,6 +168,17 @@ func listKeyVaultSecrets(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	client.Authorizer = session.Authorizer
 	result, err := client.GetSecrets(ctx, vaultURI, &maxResults)
 	if err != nil {
+		/*
+		* To make the above API call user must have list secrets grant.
+		* If an user does not have this access to perform list operation for secrets then the api returns forbiden error.
+		* The permission should be grant through the key valult access policy.
+		* If the forbidden error is not being handled here then it will make the table to fail, 
+		  if there is at least a single key vault on which user does not have access to perform list secret operation.
+		*/
+
+		if strings.Contains(err.Error(), "Forbidden") {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/azure/table_azure_key_vault_secret.go
+++ b/azure/table_azure_key_vault_secret.go
@@ -176,7 +176,7 @@ func listKeyVaultSecrets(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		  if there is at least a single key vault on which user does not have access to perform list secret operation.
 		*/
 
-		if strings.Contains(err.Error(), "Invalid audience. Expected https://vault.azure.net") {
+		if strings.Contains(err.Error(), "Forbidden") {
 			return nil, nil
 		}
 		return nil, err

--- a/azure/table_azure_key_vault_secret.go
+++ b/azure/table_azure_key_vault_secret.go
@@ -170,10 +170,10 @@ func listKeyVaultSecrets(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	if err != nil {
 		/*
 		* To make the above API call user must have list secrets permission.
-		* If an user does not have this permission to perform list operation for secrets then the api returns forbiden error.
-		* The permission should be grant in the key valult access policy.
-		* If the forbidden error is not being handled here then it will make the table fail,
-		  if there is at least a single key vault on which user does not have access to perform list secret operation.
+		* If the user does not have this permission then the API returns an unauthorized error.
+		* The permission should be granted in the key valult access policy.
+		* If the unauthorized error is not handled, then it will cause the table to fail
+		  if there is at least a single key vault on which the user does not have access to perform list secret operation.
 		*/
 
 		if strings.Contains(err.Error(), "Forbidden") {

--- a/azure/table_azure_key_vault_secret.go
+++ b/azure/table_azure_key_vault_secret.go
@@ -169,10 +169,10 @@ func listKeyVaultSecrets(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	result, err := client.GetSecrets(ctx, vaultURI, &maxResults)
 	if err != nil {
 		/*
-		* To make the above API call user must have list secrets grant.
-		* If an user does not have this access to perform list operation for secrets then the api returns forbiden error.
-		* The permission should be grant through the key valult access policy.
-		* If the forbidden error is not being handled here then it will make the table to fail, 
+		* To make the above API call user must have list secrets permission.
+		* If an user does not have this permission to perform list operation for secrets then the api returns forbiden error.
+		* The permission should be grant in the key valult access policy.
+		* If the forbidden error is not being handled here then it will make the table fail, 
 		  if there is at least a single key vault on which user does not have access to perform list secret operation.
 		*/
 

--- a/azure/table_azure_key_vault_secret.go
+++ b/azure/table_azure_key_vault_secret.go
@@ -172,11 +172,11 @@ func listKeyVaultSecrets(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		* To make the above API call user must have list secrets permission.
 		* If an user does not have this permission to perform list operation for secrets then the api returns forbiden error.
 		* The permission should be grant in the key valult access policy.
-		* If the forbidden error is not being handled here then it will make the table fail, 
+		* If the forbidden error is not being handled here then it will make the table fail,
 		  if there is at least a single key vault on which user does not have access to perform list secret operation.
 		*/
 
-		if strings.Contains(err.Error(), "Forbidden") {
+		if strings.Contains(err.Error(), "Invalid audience. Expected https://vault.azure.net") {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from azure_key_vault
+----------------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+------------
| name           | id                                                                                                                              | vault_uri                               | type       
+----------------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+------------
| test-35        | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.KeyVault/vaults/test-35        | https://test-35.vault.azure.net/        | Microsoft.K
| test89         | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/demo/providers/Microsoft.KeyVault/vaults/test89              | https://test89.vault.azure.net/         | Microsoft.K
| rajsoftwarekey | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/steampipe/providers/Microsoft.KeyVault/vaults/rajsoftwarekey | https://rajsoftwarekey.vault.azure.net/ | Microsoft.K
+----------------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+------------
> select * from azure_key_vault_key
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+---------+---
| name             | id                                                                                                                                                    | vault_name     | enabled | ke
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+---------+---
| tets566          | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/demo/providers/Microsoft.KeyVault/vaults/test89/keys/tets566                       | test89         | true    | RS
| teest-key-by-raj | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/steampipe/providers/Microsoft.KeyVault/vaults/rajsoftwarekey/keys/teest-key-by-raj | rajsoftwarekey | true    | EC
+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+---------+---
> select * from azure_key_vault_secret where vault_name = 'test-35' and name = 'Test'
+------+-------------------------------------------------------------------------------+------------+---------+---------+--------------+---------------------------+------------+--------+------------+---
| name | id                                                                            | vault_name | enabled | managed | content_type | created_at                | expires_at | kid    | not_before | re
+------+-------------------------------------------------------------------------------+------------+---------+---------+--------------+---------------------------+------------+--------+------------+---
| Test | https://test-35.vault.azure.net/secrets/Test/7228fcf80334421280abbe41086ede95 | test-35    | true    | <null>  | <null>       | 2022-03-28T12:04:59+05:30 | <null>     | <null> | <null>     | 7 
+------+-------------------------------------------------------------------------------+------------+---------+---------+--------------+---------------------------+------------+--------+------------+---
> select * from azure_compute_virtual_machine
+--------------+-------------+---------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+
| name         | power_state | id                                                                                                                                    | type                              |
+--------------+-------------+---------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+
| withno-pubip | running     | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/STEAMPIPE/providers/Microsoft.Compute/virtualMachines/withno-pubip | Microsoft.Compute/virtualMachines |
|              |             |                                                                                                                                       |                                   |
+--------------+-------------+---------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+
```
</details>
