### PR TITLE
Change the column type for read_scale & create_mode in azure_sql_database. closes #454

### DIFF
--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -198,13 +198,13 @@ func tableAzureSqlDatabase(_ context.Context) *plugin.Table {
 			{
 				Name:        "create_mode",
 				Description: "Specifies the mode of database creation.",
-				Type:        proto.ColumnType_JSON,
+				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("DatabaseProperties.CreateMode"),
 			},
 			{
 				Name:        "read_scale",
 				Description: "ReadScale indicates whether read-only connections are allowed to this database or not if the database is a geo-secondary.",
-				Type:        proto.ColumnType_JSON,
+				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("DatabaseProperties.ReadScale"),
 			},
 			{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-plugin-azure
 
-go 1.18
+go 1.17
 
 require (
 	github.com/Azure/azure-sdk-for-go v58.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-plugin-azure
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go v58.0.0+incompatible


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_sql_database []

PRETEST: tests/azure_sql_database

TEST: tests/azure_sql_database
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m22s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068]
azurerm_sql_database.named_test_resource: Creating...
azurerm_sql_database.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_database.named_test_resource: Creation complete after 1m10s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068]

Warning: Deprecated Resource

  on variables.tf line 35, in data "null_data_source" "resource":
  35: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals

(and 2 more similar warnings elsewhere)


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest92068/providers/microsoft.sql/servers/turbottest92068/databases/turbottest92068
resource_creation_date = 2022-04-01T06:35:19.92Z
resource_default_secondary_location = West US
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068
resource_location = East US
resource_name = turbottest92068
resource_region = east us
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest92068/providers/microsoft.sql/servers/turbottest92068/databases/turbottest92068"
    ],
    "containment_state": 2,
    "default_secondary_location": "West US",
    "earliest_restore_date": null,
    "edition": "GeneralPurpose",
    "elastic_pool_name": null,
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068",
    "location": "East US",
    "max_size_bytes": "34359738368",
    "name": "turbottest92068",
    "region": "east us",
    "requested_service_objective_name": "GP_Gen5_2",
    "resource_group": "turbottest92068",
    "server_name": "turbottest92068",
    "service_level_objective": "GP_Gen5_2",
    "status": "Online",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest92068",
    "transparent_data_encryption": {
      "status": "Enabled"
    },
    "type": "Microsoft.Sql/servers/databases",
    "zone_redundant": false
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068",
    "name": "turbottest92068",
    "server_name": "turbottest92068",
    "transparent_data_encryption": {
      "status": "Enabled"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068",
    "location": "East US",
    "name": "turbottest92068",
    "resource_group": "turbottest92068",
    "server_name": "turbottest92068"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest92068/providers/Microsoft.Sql/servers/turbottest92068/databases/turbottest92068",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest92068/providers/microsoft.sql/servers/turbottest92068/databases/turbottest92068"
    ],
    "name": "turbottest92068",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest92068"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_database

TEARDOWN: tests/azure_sql_database

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, server_name, read_scale, create_mode from azure_sql_database
+--------+-----------------+------------+-------------+
| name   | server_name     | read_scale | create_mode |
+--------+-----------------+------------+-------------+
| master | turbottest92068 | Disabled   |             |
| master | test-turbot     | Disabled   |             |
| tte5s6 | test-turbot     | Disabled   |             |
+--------+-----------------+------------+-------------+
```
</details>
