### PR TITLE
Update GetNewSession method to properly handle the token

### DIFF
--- a/azure/service.go
+++ b/azure/service.go
@@ -42,11 +42,11 @@ type Session struct {
 func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience string) (session *Session, err error) {
 	logger := plugin.Logger(ctx)
 
-	cacheKey := "GetNewSession"
+	cacheKey := "GetNewSession" + tokenAudience
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		session = cachedData.(*Session)
 		if session.Expires != nil && WillExpireIn(*session.Expires, 0) {
-			d.ConnectionManager.Cache.Delete("GetNewSession")
+			d.ConnectionManager.Cache.Delete(cacheKey)
 		} else {
 			return cachedData.(*Session), nil
 		}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from azure_key_vault
+----------------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+--------------
| name           | id                                                                                                                              | vault_uri                               | type         
+----------------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+--------------
| rajsoftwarekey | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/steampipe/providers/Microsoft.KeyVault/vaults/rajsoftwarekey | https://rajsoftwarekey.vault.azure.net/ | Microsoft.Key
| test-35        | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.KeyVault/vaults/test-35        | https://test-35.vault.azure.net/        | Microsoft.Key
| test89         | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/demo/providers/Microsoft.KeyVault/vaults/test89              | https://test89.vault.azure.net/         | Microsoft.Key
+----------------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+--------------

```

```
> select * from azure_key_vault_secret where vault_name = 'test-35' and name = 'Test'
+------+-------------------------------------------------------------------------------+------------+---------+---------+--------------+---------------------------+------------+--------+------------+---
| name | id                                                                            | vault_name | enabled | managed | content_type | created_at                | expires_at | kid    | not_before | re
+------+-------------------------------------------------------------------------------+------------+---------+---------+--------------+---------------------------+------------+--------+------------+---
| Test | https://test-35.vault.azure.net/secrets/Test/7228fcf80334421280abbe41086ede95 | test-35    | true    | <null>  | <null>       | 2022-03-28T12:04:59+05:30 | <null>     | <null> | <null>     | 7 
+------+-------------------------------------------------------------------------------+------------+---------+---------+--------------+---------------------------+------------+--------+------------+---
```

</details>
