### PR TITLE
Fix table azure_storage_table list call throws OperationNotAllowedOnKnd and FeatureNotSupportedForAccount error for unsupported storage account kind closes #457

### DIFF
--- a/azure/table_azure_storage_table.go
+++ b/azure/table_azure_storage_table.go
@@ -96,7 +96,7 @@ func listStorageTables(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	// Get the details of storage account
 	account := h.Item.(*storageAccountInfo)
 
-	// Table is not supported for the account if storage type is FileStorage and BlockBlobStorage
+	// Table is not supported for the account if storage type is FileStorage or BlockBlobStorage
 	if account.Account.Kind == "FileStorage" || account.Account.Kind == "BlockBlobStorage" {
 		return nil, nil
 	}

--- a/azure/table_azure_storage_table.go
+++ b/azure/table_azure_storage_table.go
@@ -114,8 +114,8 @@ func listStorageTables(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	if err != nil {
 		/*
 		* For storage accoung type 'Page Blob' we are getting the kind value as 'StorageV2' .
-		* storage accoung type 'Page Blob' does not support stoarege table so we are getting 'FeatureNotSupportedForAccount' error
-		* With same kind we my have different types of storage account so we need to handle this particular error
+		* Storage account type 'Page Blob' does not support table so we are getting 'FeatureNotSupportedForAccount'/'OperationNotAllowedOnKind' error.
+		* With same kind of we my have different types of storage account so we need to handle this particular error.
 		 */
 		if strings.Contains(err.Error(), "FeatureNotSupportedForAccount") || strings.Contains(err.Error(), "OperationNotAllowedOnKind") {
 			return nil, nil

--- a/azure/table_azure_storage_table.go
+++ b/azure/table_azure_storage_table.go
@@ -113,9 +113,9 @@ func listStorageTables(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	result, err := storageClient.List(ctx, *account.ResourceGroup, *account.Name)
 	if err != nil {
 		/*
-		* For storage accoung type 'Page Blob' we are getting the kind value as 'StorageV2' .
-		* Storage account type 'Page Blob' does not support table so we are getting 'FeatureNotSupportedForAccount'/'OperationNotAllowedOnKind' error.
-		* With same kind of we my have different types of storage account so we need to handle this particular error.
+		* For storage account type 'Page Blob' we are getting the kind value as 'StorageV2'.
+		* Storage account type 'Page Blob' does not support table, so we are getting 'FeatureNotSupportedForAccount'/'OperationNotAllowedOnKind' error.
+		* With same kind(StorageV2) of storage account, we my have different type(File Share) of storage account so we need to handle this particular error.
 		 */
 		if strings.Contains(err.Error(), "FeatureNotSupportedForAccount") || strings.Contains(err.Error(), "OperationNotAllowedOnKind") {
 			return nil, nil

--- a/azure/table_azure_storage_table.go
+++ b/azure/table_azure_storage_table.go
@@ -97,7 +97,7 @@ func listStorageTables(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	account := h.Item.(*storageAccountInfo)
 
 	// Table is not supported for the account if storage type is FileStorage
-	if account.Account.Kind == "FileStorage" || account.Account.Kind == "BlobStorage" {
+	if account.Account.Kind == "FileStorage" || account.Account.Kind == "BlockBlobStorage" {
 		return nil, nil
 	}
 

--- a/azure/table_azure_storage_table.go
+++ b/azure/table_azure_storage_table.go
@@ -96,7 +96,7 @@ func listStorageTables(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	// Get the details of storage account
 	account := h.Item.(*storageAccountInfo)
 
-	// Table is not supported for the account if storage type is FileStorage
+	// Table is not supported for the account if storage type is FileStorage and BlockBlobStorage
 	if account.Account.Kind == "FileStorage" || account.Account.Kind == "BlockBlobStorage" {
 		return nil, nil
 	}


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_storage_table []

PRETEST: tests/azure_storage_table

TEST: tests/azure_storage_table
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [31s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [41s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 43s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729/providers/Microsoft.Storage/storageAccounts/turbottest28729]
azurerm_storage_table.named_test_resource: Creating...
azurerm_storage_table.named_test_resource: Creation complete after 7s [id=https://turbottest28729.table.core.windows.net/Tables('turbottest28729')]

Warning: Deprecated Resource

  on variables.tf line 30, in data "null_data_source" "resource":
  30: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729/providers/Microsoft.Storage/storageAccounts/turbottest28729/tableServices/default/tables/turbottest28729
resource_name = turbottest28729
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729/providers/Microsoft.Storage/storageAccounts/turbottest28729/tableServices/default/tables/turbottest28729",
    "name": "turbottest28729",
    "storage_account_name": "turbottest28729",
    "type": "Microsoft.Storage/storageAccounts/tableServices/tables"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729/providers/Microsoft.Storage/storageAccounts/turbottest28729/tableServices/default/tables/turbottest28729",
    "name": "turbottest28729",
    "storage_account_name": "turbottest28729",
    "type": "Microsoft.Storage/storageAccounts/tableServices/tables"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729/providers/Microsoft.Storage/storageAccounts/turbottest28729/tableServices/default/tables/turbottest28729",
    "name": "turbottest28729"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest28729/providers/Microsoft.Storage/storageAccounts/turbottest28729/tableServices/default/tables/turbottest28729",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest28729/providers/microsoft.storage/storageaccounts/turbottest28729/tableservices/default/tables/turbottest28729"
    ],
    "title": "turbottest28729"
  }
]
✔ PASSED

POSTTEST: tests/azure_storage_table

TEARDOWN: tests/azure_storage_table

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

### Befor fix
  
```
> select name, type from azure_storage_table
⠼ Loading results...

Error: storage.TableClient#List: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="FeatureNotSupportedForAccount" Message="Table is not supported for the account." (SQLSTATE HV000)

+--------+--------------------------------------------------------+
| name   | type                                                   |
+--------+--------------------------------------------------------+
| test12 | Microsoft.Storage/storageAccounts/tableServices/tables |
+--------+--------------------------------------------------------+
```

### After fix

```
> select * from azure_storage_table;
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------
| name   | id                                                                                                                                                                                     | storag
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------
| test12 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/AzureBackupRG_eastus_1/providers/Microsoft.Storage/storageAccounts/testinggh788/tableServices/default/tables/test12 | testin
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------

```

</details>
