### PR TITLE
Fix azure_storage_queue Queue is not supported for the storage account closes #458

### DIFF
--- a/azure/table_azure_storage_queue.go
+++ b/azure/table_azure_storage_queue.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
@@ -30,8 +31,9 @@ func tableAzureStorageQueue(_ context.Context) *plugin.Table {
 			ShouldIgnoreError: isNotFoundError([]string{"ResourceNotFound", "QueueNotFound", "ResourceGroupNotFound"}),
 		},
 		List: &plugin.ListConfig{
-			ParentHydrate: listStorageAccounts,
-			Hydrate:       listStorageQueues,
+			ParentHydrate:     listStorageAccounts,
+			Hydrate:           listStorageQueues,
+			ShouldIgnoreError: isNotFoundError([]string{"FeatureNotSupportedForAccount"}),
 		},
 		Columns: azureColumns([]*plugin.Column{
 			{
@@ -102,7 +104,7 @@ func listStorageQueues(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	account := h.Item.(*storageAccountInfo)
 
 	// Queue is not supported for the account if storage type is FileStorage
-	if account.Account.Kind == "FileStorage" {
+	if account.Account.Kind == "FileStorage" || account.Account.Kind == "BlockBlobStorage" {
 		return nil, nil
 	}
 
@@ -117,6 +119,14 @@ func listStorageQueues(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 	result, err := storageClient.List(ctx, *account.ResourceGroup, *account.Name, "", "")
 	if err != nil {
+		/*
+		* For storage account type 'Page Blob' we are getting the kind value as 'StorageV2'.
+		* Storage account type 'Page Blob' does not support table, so we are getting 'FeatureNotSupportedForAccount'/'OperationNotAllowedOnKind' error.
+		* With same kind(StorageV2) of storage account, we my have different type(File Share) of storage account so we need to handle this particular error.
+		 */
+		if strings.Contains(err.Error(), "FeatureNotSupportedForAccount") || strings.Contains(err.Error(), "OperationNotAllowedOnKind") {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/azure/table_azure_storage_queue.go
+++ b/azure/table_azure_storage_queue.go
@@ -33,7 +33,6 @@ func tableAzureStorageQueue(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			ParentHydrate:     listStorageAccounts,
 			Hydrate:           listStorageQueues,
-			ShouldIgnoreError: isNotFoundError([]string{"FeatureNotSupportedForAccount"}),
 		},
 		Columns: azureColumns([]*plugin.Column{
 			{
@@ -103,7 +102,7 @@ func listStorageQueues(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	// Get the details of storage account
 	account := h.Item.(*storageAccountInfo)
 
-	// Queue is not supported for the account if storage type is FileStorage
+	// Queue is not supported for the account if storage type is FileStorage or BlockBlobStorage
 	if account.Account.Kind == "FileStorage" || account.Account.Kind == "BlockBlobStorage" {
 		return nil, nil
 	}


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_storage_queue []

PRETEST: tests/azure_storage_queue

TEST: tests/azure_storage_queue
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 35s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393/providers/Microsoft.Storage/storageAccounts/turbottest91393]
azurerm_storage_queue.named_test_resource: Creating...
azurerm_storage_queue.named_test_resource: Creation complete after 0s [id=https://turbottest91393.queue.core.windows.net/turbottest91393]

Warning: Deprecated Resource

  on variables.tf line 30, in data "null_data_source" "resource":
  30: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure://https://turbottest91393.queue.core.windows.net/turbottest91393
resource_aka_lower = azure://https://turbottest91393.queue.core.windows.net/turbottest91393
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393/providers/Microsoft.Storage/storageAccounts/turbottest91393/queueServices/default/queues/turbottest91393
resource_name = turbottest91393
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393/providers/Microsoft.Storage/storageAccounts/turbottest91393/queueServices/default/queues/turbottest91393",
    "metadata": {},
    "name": "turbottest91393",
    "storage_account_name": "turbottest91393",
    "type": "Microsoft.Storage/storageAccounts/queueServices/queues"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393/providers/Microsoft.Storage/storageAccounts/turbottest91393/queueServices/default/queues/turbottest91393",
    "metadata": {},
    "name": "turbottest91393",
    "storage_account_name": "turbottest91393",
    "type": "Microsoft.Storage/storageAccounts/queueServices/queues"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393/providers/Microsoft.Storage/storageAccounts/turbottest91393/queueServices/default/queues/turbottest91393",
    "name": "turbottest91393"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest91393/providers/Microsoft.Storage/storageAccounts/turbottest91393/queueServices/default/queues/turbottest91393",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest91393/providers/microsoft.storage/storageaccounts/turbottest91393/queueservices/default/queues/turbottest91393"
    ],
    "title": "turbottest91393"
  }
]
✔ PASSED

POSTTEST: tests/azure_storage_queue

TEARDOWN: tests/azure_storage_queue

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

### Before Fix
  
```
> select * from azure_storage_queue
Error: storage.QueueClient#List: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="FeatureNotSupportedForAccount" Message="Queue is not supported for the account." (SQLSTATE HV000)
```

### After Fix

```
> select * from azure_storage_queue
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+-
| name  | id                                                                                                                                                                       | storage_account_name | 
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+-
| test2 | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbot_rg/providers/Microsoft.Storage/storageAccounts/tetsg8900000/queueServices/default/queues/test2 | tetsg8900000         | 
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------+-
```

</details>
