### PR TITLE
Add column ip_configurations in the table azure_subnet closes #472

### DIFF
--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -114,7 +114,7 @@ func tableAzureSubnet(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "ip_configurations",
-				Description: "IP Configuration details in a network interface.",
+				Description: "IP Configuration details in a subnet.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getSubnetIpConfigurations,
 				Transform:   transform.FromValue(),
@@ -234,7 +234,7 @@ func getSubnet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 
 // List or Get call of subnet doesn't return more info baout ip configuration except the ip configuration id.
 func getSubnetIpConfigurations(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getSubnet")
+	plugin.Logger(ctx).Trace("getSubnetIpConfigurations")
 	subnet := h.Item.(subnetInfo).Subnet
 
 	configurations := []network.IPConfiguration{}

--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -232,7 +232,7 @@ func getSubnet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 	return nil, nil
 }
 
-// List or Get call of subnet doesn't return more info baout ip configuration except the ip configuration id.
+// List or Get call of subnet doesn't return more info about ip configuration except the ip configuration id.
 func getSubnetIpConfigurations(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getSubnetIpConfigurations")
 	subnet := h.Item.(subnetInfo).Subnet

--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
@@ -110,6 +111,13 @@ func tableAzureSubnet(_ context.Context) *plugin.Table {
 				Description: "A list of references to the delegations on the subnet.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Subnet.SubnetPropertiesFormat.Delegations"),
+			},
+			{
+				Name:        "ip_configurations",
+				Description: "IP Configuration details in a network interface.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSubnetIpConfigurations,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "service_endpoints",
@@ -222,4 +230,87 @@ func getSubnet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 	}
 
 	return nil, nil
+}
+
+// List/Get call of subnet doesn't return more data baout ip configuration.
+func getSubnetIpConfigurations(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getSubnet")
+	subnet := h.Item.(subnetInfo).Subnet
+
+	configurations := []network.IPConfiguration{}
+
+	if subnet.SubnetPropertiesFormat != nil {
+		if subnet.SubnetPropertiesFormat.IPConfigurations != nil {
+			configurations = *subnet.SubnetPropertiesFormat.IPConfigurations
+		}
+	}
+	if len(configurations) <= 0 {
+		return nil, nil
+	}
+
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	subnetClient := network.NewInterfaceIPConfigurationsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	subnetClient.Authorizer = session.Authorizer
+
+	var wg sync.WaitGroup
+	ipCh := make(chan *network.InterfaceIPConfiguration, len(configurations))
+	errorCh := make(chan error, len(configurations))
+
+	for i := 0; i < len(configurations); i++ {
+		wg.Add(1)
+		go getIpConfigurationAsync(ctx, &configurations[i], subnetClient, &wg, ipCh, errorCh)
+	}
+
+	// wait for all ip configurations to be processed
+	wg.Wait()
+	// NOTE: close channel before ranging over results
+	close(ipCh)
+	close(errorCh)
+
+	for err := range errorCh {
+		// return the first error
+		return nil, err
+	}
+
+	var ipConfigurations []*network.InterfaceIPConfiguration
+
+	for ipConfig := range ipCh {
+		ipConfigurations = append(ipConfigurations, ipConfig)
+	}
+
+	return ipConfigurations, nil
+}
+
+func getIpConfigurationAsync(ctx context.Context, ipConfig *network.IPConfiguration, client network.InterfaceIPConfigurationsClient, wg *sync.WaitGroup, ipCh chan *network.InterfaceIPConfiguration, errorCh chan error) {
+	defer wg.Done()
+
+	rowData, err := getIpConfiguration(ctx, ipConfig, client)
+	if err != nil {
+		errorCh <- err
+	} else if rowData.ID != nil {
+		ipCh <- rowData
+	}
+}
+
+func getIpConfiguration(ctx context.Context, ipConfig *network.IPConfiguration, client network.InterfaceIPConfigurationsClient) (*network.InterfaceIPConfiguration, error) {
+	if ipConfig == nil {
+		return nil, nil
+	}
+
+	configurationId := *ipConfig.ID
+	resourceGroup := strings.Split(configurationId, "/")[4]
+	networkInterface := strings.Split(configurationId, "/")[8]
+	configName := strings.Split(configurationId, "/")[len(strings.Split(configurationId, "/"))-1]
+
+	configuration, err := client.Get(ctx, resourceGroup, networkInterface, configName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &configuration, nil
 }

--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -232,7 +232,7 @@ func getSubnet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 	return nil, nil
 }
 
-// List/Get call of subnet doesn't return more data baout ip configuration.
+// List or Get call of subnet doesn't return more info baout ip configuration except the ip configuration id.
 func getSubnetIpConfigurations(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getSubnet")
 	subnet := h.Item.(subnetInfo).Subnet
@@ -252,8 +252,8 @@ func getSubnetIpConfigurations(ctx context.Context, d *plugin.QueryData, h *plug
 	if err != nil {
 		return nil, err
 	}
-	subscriptionID := session.SubscriptionID
 
+	subscriptionID := session.SubscriptionID
 	subnetClient := network.NewInterfaceIPConfigurationsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	subnetClient.Authorizer = session.Authorizer
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_subnet []

PRETEST: tests/azure_subnet

TEST: tests/azure_subnet
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_network.named_test_resource: Creation complete after 15s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 7s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455]

Warning: Deprecated Resource

  on variables.tf line 30, in data "null_data_source" "resource":
  30: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: "address_prefix": [DEPRECATED] Use the `address_prefixes` property instead.

  on variables.tf line 48, in resource "azurerm_subnet" "named_test_resource":
  48: resource "azurerm_subnet" "named_test_resource" {



Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest74455/providers/microsoft.network/virtualnetworks/turbottest74455/subnets/turbottest74455
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455
resource_name = turbottest74455
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "address_prefix": "10.0.1.0/24",
    "delegations": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455/delegations/delegation",
        "name": "delegation",
        "properties": {
          "serviceName": "Microsoft.ContainerInstance/containerGroups"
        }
      }
    ],
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
    "name": "turbottest74455",
    "resource_group": "turbottest74455",
    "type": "Microsoft.Network/subnets",
    "virtual_network_name": "turbottest74455"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest74455/providers/microsoft.network/virtualnetworks/turbottest74455/subnets/turbottest74455"
    ],
    "name": "turbottest74455",
    "title": "turbottest74455"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
    "name": "turbottest74455"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest74455/providers/microsoft.network/virtualnetworks/turbottest74455/subnets/turbottest74455"
    ],
    "name": "turbottest74455",
    "title": "turbottest74455"
  }
]
✔ PASSED

POSTTEST: tests/azure_subnet

TEARDOWN: tests/azure_subnet

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(ip_configurations) from azure_subnet
+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name      | jsonb_pretty                                                                                                                                                                   |
+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| default   | {                                                                                                                                                                              |
|           | }                                                                                                                                                                              |
| test-vn-1 | {                                                                                                                                                                              |
|           | }                                                                                                                                                                              |
| default   | {                                                                                                                                                                              |
|           | }                                                                                                                                                                              |
| test-sub  | [                                                                                                                                                                              |
|           |     {                                                                                                                                                                          |
|           |         "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c234re4/resourceGroups/turbot_rg/providers/Microsoft.Network/networkInterfaces/test-ni/ipConfigurations/ipconfig1", |
|           |         "name": "ipconfig1",                                                                                                                                                   |
|           |         "properties": {                                                                                                                                                        |
|           |             "subnet": {                                                                                                                                                        |
|           |                 "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c234re4/resourceGroups/turbot_rg/providers/Microsoft.Network/virtualNetworks/test-vn/subnets/test-sub"      |
|           |             },                                                                                                                                                                 |
|           |             "primary": true,                                                                                                                                                   |
|           |             "privateIPAddress": "10.1.0.4",                                                                                                                                    |
|           |             "privateIPAddressVersion": "IPv4",                                                                                                                                 |
|           |             "privateIPAllocationMethod": "Dynamic"                                                                                                                             |
|           |         }                                                                                                                                                                      |
|           |     },                                                                                                                                                                         |
|           |     {                                                                                                                                                                          |
|           |         "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c234re4/resourceGroups/turbot_rg/providers/Microsoft.Network/networkInterfaces/test-ni/ipConfigurations/test2",     |
|           |         "name": "test2",                                                                                                                                                       |
|           |         "properties": {                                                                                                                                                        |
|           |             "subnet": {                                                                                                                                                        |
|           |                 "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c234re4/resourceGroups/turbot_rg/providers/Microsoft.Network/virtualNetworks/test-vn/subnets/test-sub"      |
|           |             },                                                                                                                                                                 |
|           |             "primary": false,                                                                                                                                                  |
|           |             "publicIPAddress": {                                                                                                                                               |
|           |                 "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c234re4/resourceGroups/turbot_rg/providers/Microsoft.Network/publicIPAddresses/test"                        |
|           |             },                                                                                                                                                                 |
|           |             "privateIPAddress": "10.1.0.65",                                                                                                                                   |
|           |             "privateIPAddressVersion": "IPv4",                                                                                                                                 |
|           |             "privateIPAllocationMethod": "Static"                                                                                                                              |
|           |         }                                                                                                                                                                      |
|           |     }                                                                                                                                                                          |
|           | ]                                                                                                                                                                              |
+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>
