### PR TITLE
Fix column access_control inconsistent state in table azure_logic_app_workflow closes #484

### DIFF
--- a/azure-test/tests/azure_logic_app_workflow/test-list-query.sql
+++ b/azure-test/tests/azure_logic_app_workflow/test-list-query.sql
@@ -1,3 +1,3 @@
 select name, id, type
 from azure.azure_logic_app_workflow
-where name = '{{ resourceName }}';
+where id = '{{ output.resource_id.value }}';

--- a/azure/table_azure_logic_app_workflow.go
+++ b/azure/table_azure_logic_app_workflow.go
@@ -285,7 +285,7 @@ func listLogicAppWorkflowDiagnosticSettings(ctx context.Context, d *plugin.Query
 
 //// TRANSFORM FUNCTION
 
-// Access Control configuration for Any IP is comming as "{}" instead of nill if wea re not providing any IP in configuration
+// Access Control configuration for any IP is coming as "{}" instead of nil if we are not providing any IP in configuration
 func getAccessControl(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	data := d.HydrateItem.(logic.Workflow)
 	if data.WorkflowProperties != nil {

--- a/azure/table_azure_logic_app_workflow.go
+++ b/azure/table_azure_logic_app_workflow.go
@@ -88,7 +88,7 @@ func tableAzureLogicAppWorkflow(_ context.Context) *plugin.Table {
 				Name:        "access_control",
 				Description: "The access control configuration.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.From(getAccessControl),
+				Transform:   transform.From(extractAccessControl),
 			},
 			{
 				Name:        "definition",
@@ -286,12 +286,13 @@ func listLogicAppWorkflowDiagnosticSettings(ctx context.Context, d *plugin.Query
 //// TRANSFORM FUNCTION
 
 // Access Control configuration for any IP is coming as "{}" instead of nil if we are not providing any IP in configuration
-func getAccessControl(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+func extractAccessControl(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	data := d.HydrateItem.(logic.Workflow)
 	if data.WorkflowProperties != nil {
 		if data.WorkflowProperties.AccessControl == nil {
 			return nil, nil
 		} else {
+			// Due to the inconsistency in the API behaviour we need this check.
 			if data.WorkflowProperties.AccessControl.Actions != nil || data.WorkflowProperties.AccessControl.Contents != nil || data.WorkflowProperties.AccessControl.Triggers != nil || data.WorkflowProperties.AccessControl.WorkflowManagement != nil {
 				return data.WorkflowProperties.AccessControl, nil
 			} else {

--- a/azure/table_azure_logic_app_workflow.go
+++ b/azure/table_azure_logic_app_workflow.go
@@ -292,7 +292,7 @@ func extractAccessControl(ctx context.Context, d *transform.TransformData) (inte
 		if data.WorkflowProperties.AccessControl == nil {
 			return nil, nil
 		} else {
-			// Due to the inconsistency in the API behaviour we need this check.
+			// Due to inconsistency in the API behaviour we need this check.
 			if data.WorkflowProperties.AccessControl.Actions != nil || data.WorkflowProperties.AccessControl.Contents != nil || data.WorkflowProperties.AccessControl.Triggers != nil || data.WorkflowProperties.AccessControl.WorkflowManagement != nil {
 				return data.WorkflowProperties.AccessControl, nil
 			} else {


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_logic_app_workflow []

PRETEST: tests/azure_logic_app_workflow

TEST: tests/azure_logic_app_workflow
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 5s [id=/subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107]
azurerm_logic_app_workflow.named_test_resource: Creating...
azurerm_logic_app_workflow.named_test_resource: Creation complete after 8s [id=/subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107/providers/Microsoft.Logic/workflows/turbottest70107]

Warning: Deprecated Resource

  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = eastus
resource_aka = azure:///subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107/providers/Microsoft.Logic/workflows/turbottest70107
resource_aka_lower = azure:///subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourcegroups/turbottest70107/providers/microsoft.logic/workflows/turbottest70107
resource_id = /subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107/providers/Microsoft.Logic/workflows/turbottest70107
resource_name = turbottest70107
subscription_id = f5t37416-f95f-4771-bbb5-529d4c76ef46

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107/providers/Microsoft.Logic/workflows/turbottest70107",
    "name": "turbottest70107",
    "region": "eastus",
    "resource_group": "turbottest70107",
    "subscription_id": "f5t37416-f95f-4771-bbb5-529d4c76ef46",
    "type": "Microsoft.Logic/workflows"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107/providers/Microsoft.Logic/workflows/turbottest70107",
    "name": "turbottest70107",
    "type": "Microsoft.Logic/workflows"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourceGroups/turbottest70107/providers/Microsoft.Logic/workflows/turbottest70107",
      "azure:///subscriptions/f5t37416-f95f-4771-bbb5-529d4c76ef46/resourcegroups/turbottest70107/providers/microsoft.logic/workflows/turbottest70107"
    ],
    "name": "turbottest70107",
    "title": "turbottest70107"
  }
]
✔ PASSED

POSTTEST: tests/azure_logic_app_workflow

TEARDOWN: tests/azure_logic_app_workflow

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
After the creation of logic app  workflow
> select access_control from azure_logic_app_workflow
+----------------+
| access_control |
+----------------+
| <null>         |
+----------------+
```

```
After configuring the access control to a IP range

> select access_control from azure_logic_app_workflow
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| access_control                                                                                                                                                   |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| {"actions":{"allowedCallerIpAddresses":[{"addressRange":"123.123.123.123/32"}]},"triggers":{"allowedCallerIpAddresses":[{"addressRange":"123.123.123.123/32"}]}} |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

```
After modifying the access control to any IP

> select access_control from azure_logic_app_workflow
+----------------+
| access_control |
+----------------+
| <null>         |
+----------------+
```

</details>
