### PR TITLE
Update hydrate columns in azure_sql_server with latest sql server package Closes #372

### DIFF
--- a/azure-test/tests/azure_sql_server/test-hydrate-expected.json
+++ b/azure-test/tests/azure_sql_server/test-hydrate-expected.json
@@ -5,10 +5,8 @@
 				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/encryptionProtector/current",
 				"kind": "servicemanaged",
 				"name": "current",
-				"properties": {
-					"serverKeyName": "ServiceManaged",
-					"serverKeyType": "ServiceManaged"
-				},
+				"serverKeyName": "ServiceManaged",
+				"serverKeyType": "ServiceManaged",
 				"type": "Microsoft.Sql/servers/encryptionProtector"
 			}
 		],

--- a/azure/table_azure_sql_server.go
+++ b/azure/table_azure_sql_server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2017-03-01-preview/sql"
 	sqlv3 "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
 )
 
@@ -288,7 +287,7 @@ func getSQLServerAuditPolicy(ctx context.Context, d *plugin.QueryData, h *plugin
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	client := sql.NewServerBlobAuditingPoliciesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client := sqlv3.NewServerBlobAuditingPoliciesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
 	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
@@ -371,7 +370,7 @@ func getSQLServerSecurityAlertPolicy(ctx context.Context, d *plugin.QueryData, h
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	client := sql.NewServerSecurityAlertPoliciesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client := sqlv3.NewServerSecurityAlertPoliciesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
 	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
@@ -412,7 +411,7 @@ func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, 
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	client := sql.NewServerAzureADAdministratorsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client := sqlv3.NewServerAzureADAdministratorsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
 	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
@@ -426,7 +425,7 @@ func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, 
 	// If we return the API response directly, the output only gives
 	// the contents of ServerAdministratorProperties
 	var serverAdministrators []map[string]interface{}
-	for _, i := range *op.Value {
+	for _, i := range op.Values() {
 		objectMap := make(map[string]interface{})
 		if i.ID != nil {
 			objectMap["id"] = i.ID
@@ -437,8 +436,8 @@ func getSQLServerAzureADAdministrator(ctx context.Context, d *plugin.QueryData, 
 		if i.Type != nil {
 			objectMap["type"] = i.Type
 		}
-		if i.ServerAdministratorProperties != nil {
-			objectMap["properties"] = i.ServerAdministratorProperties
+		if i.AdministratorProperties != nil {
+			objectMap["properties"] = i.AdministratorProperties
 		}
 		serverAdministrators = append(serverAdministrators, objectMap)
 	}
@@ -456,7 +455,7 @@ func getSQLServerEncryptionProtector(ctx context.Context, d *plugin.QueryData, h
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	client := sql.NewEncryptionProtectorsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client := sqlv3.NewEncryptionProtectorsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
 	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
@@ -557,7 +556,7 @@ func listSQLServerFirewallRules(ctx context.Context, d *plugin.QueryData, h *plu
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	client := sql.NewFirewallRulesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client := sqlv3.NewFirewallRulesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
 	op, err := client.ListByServer(ctx, resourceGroupName, *server.Name)
@@ -599,7 +598,7 @@ func listSQLServerVirtualNetworkRules(ctx context.Context, d *plugin.QueryData, 
 	subscriptionID := session.SubscriptionID
 	resourceGroupName := strings.Split(string(*server.ID), "/")[4]
 
-	client := sql.NewVirtualNetworkRulesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	client := sqlv3.NewVirtualNetworkRulesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
 	// If we return the API response directly, the output only gives
@@ -626,7 +625,7 @@ func listSQLServerVirtualNetworkRules(ctx context.Context, d *plugin.QueryData, 
 	return NetworkRules, nil
 }
 
-func networkRuleMap(rule sql.VirtualNetworkRule) map[string]interface{} {
+func networkRuleMap(rule sqlv3.VirtualNetworkRule) map[string]interface{} {
 	objectMap := make(map[string]interface{})
 	if rule.ID != nil {
 		objectMap["id"] = rule.ID


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Outputs:

firewall_rule_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667/firewallRules/turbottest44667"
location = "eastus"
resource_aka = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667"
resource_aka_lower = "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest44667/providers/microsoft.sql/servers/turbottest44667"
resource_id = "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667"
resource_name = "turbottest44667"
subscription_id = "d46d7416-f95f-4771-bbb5-529d4c76659c"

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "fully_qualified_domain_name": "turbottest44667.database.windows.net",
    "kind": "v12.0",
    "location": "eastus",
    "name": "turbottest44667",
    "region": "eastus",
    "resource_group": "turbottest44667",
    "subscription_id": "d46d7416-f95f-4771-bbb5-529d4c76659c",
    "tags_src": {
      "name": "turbottest44667"
    },
    "type": "Microsoft.Sql/servers",
    "version": "12.0"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "encryption_protector": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667/encryptionProtector/current",
        "kind": "servicemanaged",
        "name": "current",
        "serverKeyName": "ServiceManaged",
        "serverKeyType": "ServiceManaged",
        "type": "Microsoft.Sql/servers/encryptionProtector"
      }
    ],
    "firewall_rules": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667/firewallRules/turbottest44667",
        "name": "turbottest44667",
        "properties": {
          "endIpAddress": "10.0.17.62",
          "startIpAddress": "10.0.17.62"
        },
        "type": "Microsoft.Sql/servers/firewallRules"
      }
    ],
    "name": "turbottest44667",
    "server_audit_policy": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667/auditingSettings/Default",
        "name": "Default",
        "properties": {
          "auditActionsAndGroups": [
            "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
            "FAILED_DATABASE_AUTHENTICATION_GROUP",
            "BATCH_COMPLETED_GROUP"
          ],
          "isAzureMonitorTargetEnabled": true,
          "isStorageSecondaryKeyInUse": true,
          "retentionDays": 6,
          "state": "Enabled",
          "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
          "storageEndpoint": "https://turbottest44667.blob.core.windows.net/"
        },
        "type": "Microsoft.Sql/servers/auditingSettings"
      }
    ],
    "server_azure_ad_administrator": null,
    "server_security_alert_policy": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667/securityAlertPolicies/Default",
        "name": "Default",
        "properties": {
          "disabledAlerts": [
            ""
          ],
          "emailAccountAdmins": false,
          "emailAddresses": [
            ""
          ],
          "retentionDays": 0,
          "state": "Disabled",
          "storageAccountAccessKey": "",
          "storageEndpoint": ""
        },
        "type": "Microsoft.Sql/servers/securityAlertPolicies"
      }
    ],
    "server_vulnerability_assessment": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667/vulnerabilityAssessments/Default",
        "name": "Default",
        "properties": {
          "recurringScans": {
            "emailSubscriptionAdmins": true,
            "isEnabled": false
          }
        },
        "type": "Microsoft.Sql/servers/vulnerabilityAssessments"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667",
    "location": "eastus",
    "name": "turbottest44667"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest44667/providers/Microsoft.Sql/servers/turbottest44667",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest44667/providers/microsoft.sql/servers/turbottest44667"
    ],
    "name": "turbottest44667",
    "title": "turbottest44667"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_server

TEARDOWN: tests/azure_sql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  audit -> 'properties' ->> 'state' as audit_policy_state
from
  azure_sql_server,
  jsonb_array_elements(server_audit_policy) as audit
where
  audit -> 'properties' ->> 'state' = 'Disabled';
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
| name           | id                                                                                                                                         | audit_policy_state |
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
| test-steampipe | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/DefaultResourceGroup-CID/providers/Microsoft.Sql/servers/test-steampipe | Disabled           |
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+

> select
  name,
  id,
  (audit -> 'properties' ->> 'retentionDays')::integer as audit_policy_retention_days
from
  azure_sql_server,
  jsonb_array_elements(server_audit_policy) as audit
where
  (audit -> 'properties' ->> 'retentionDays')::integer < 90;
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| name           | id                                                                                                                                         | audit_policy_retention_days |
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| test-steampipe | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/DefaultResourceGroup-CID/providers/Microsoft.Sql/servers/test-steampipe | 0                           |
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+

> select
  name,
  id,
  security -> 'properties' -> 'disabledAlerts' as security_alert_policy_state
from
  azure_sql_server,
  jsonb_array_elements(server_security_alert_policy) as security,
  jsonb_array_elements_text(security -> 'properties' -> 'disabledAlerts') as disabled_alerts,
  jsonb_array_length(security -> 'properties' -> 'disabledAlerts') as alert_length
where
  alert_length = 1
  and disabled_alerts = '';
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| name           | id                                                                                                                                         | security_alert_policy_state |
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
| test-steampipe | /subscriptions/d46d7416-f95f-4771-bbb5-529d4c7fdgfdgdfgdf/resourceGroups/DefaultResourceGroup-CID/providers/Microsoft.Sql/servers/test-steampipe | [""]                        |
+----------------+--------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------+
```
</details>
