### PR TITLE
Update integration test TF file to use latest version of azurerm provider closes #504

### DIFF
--- a/azure-test/tests/azure_api_management/variables.tf
+++ b/azure-test/tests/azure_api_management/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_app_configuration/variables.tf
+++ b/azure-test/tests/azure_app_configuration/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_app_service_environment/variables.tf
+++ b/azure-test/tests/azure_app_service_environment/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_app_service_function_app/variables.tf
+++ b/azure-test/tests/azure_app_service_function_app/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_app_service_plan/variables.tf
+++ b/azure-test/tests/azure_app_service_plan/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_app_service_web_app/variables.tf
+++ b/azure-test/tests/azure_app_service_web_app/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_application_gateway/variables.tf
+++ b/azure-test/tests/azure_application_gateway/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_application_security_group/variables.tf
+++ b/azure-test/tests/azure_application_security_group/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}

--- a/azure-test/tests/azure_batch_account/variables.tf
+++ b/azure-test/tests/azure_batch_account/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_cognitive_account/variables.tf
+++ b/azure-test/tests/azure_cognitive_account/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_compute_availability_set/test-get-expected.json
+++ b/azure-test/tests/azure_compute_availability_set/test-get-expected.json
@@ -6,7 +6,6 @@
     "platform_update_domain_count": 5,
     "region": "eastus",
     "resource_group": "{{resourceName}}",
-    "sku_name": "Classic",
     "subscription_id": "{{ output.subscription_id.value }}",
     "type": "Microsoft.Compute/availabilitySets"
   }

--- a/azure-test/tests/azure_compute_availability_set/test-get-query.sql
+++ b/azure-test/tests/azure_compute_availability_set/test-get-query.sql
@@ -1,3 +1,3 @@
-select name, id, type, platform_update_domain_count, platform_fault_domain_count, sku_name, region, resource_group, subscription_id
+select name, id, type, platform_update_domain_count, platform_fault_domain_count, region, resource_group, subscription_id
 from azure.azure_compute_availability_set
 where name = '{{resourceName}}' and resource_group = '{{resourceName}}'

--- a/azure-test/tests/azure_compute_availability_set/test-hydrate-expected.json
+++ b/azure-test/tests/azure_compute_availability_set/test-hydrate-expected.json
@@ -6,7 +6,6 @@
     "platform_update_domain_count": 5,
     "region": "eastus",
     "resource_group": "{{resourceName}}",
-    "sku_name": "Classic",
     "subscription_id": "{{ output.subscription_id.value }}",
     "type": "Microsoft.Compute/availabilitySets"
   }

--- a/azure-test/tests/azure_compute_availability_set/test-hydrate-query.sql
+++ b/azure-test/tests/azure_compute_availability_set/test-hydrate-query.sql
@@ -1,3 +1,3 @@
-select name, id, type, platform_update_domain_count, platform_fault_domain_count, sku_name, region, resource_group, subscription_id
+select name, id, type, platform_update_domain_count, platform_fault_domain_count, region, resource_group, subscription_id
 from azure.azure_compute_availability_set
 where name = '{{resourceName}}' and resource_group = '{{resourceName}}'

--- a/azure-test/tests/azure_compute_availability_set/variables.tf
+++ b/azure-test/tests/azure_compute_availability_set/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_compute_disk/variables.tf
+++ b/azure-test/tests/azure_compute_disk/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_compute_disk_access/variables.tf
+++ b/azure-test/tests/azure_compute_disk_access/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_compute_snapshot/variables.tf
+++ b/azure-test/tests/azure_compute_snapshot/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_compute_virtual_machine/variables.tf
+++ b/azure-test/tests/azure_compute_virtual_machine/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -48,7 +48,7 @@ resource "azurerm_subnet" "named_test_resource" {
   name                 = var.resource_name
   resource_group_name  = azurerm_resource_group.named_test_resource.name
   virtual_network_name = azurerm_virtual_network.named_test_resource.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes      = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "named_test_resource" {

--- a/azure-test/tests/azure_compute_virtual_machine_scale_set/varable.tf
+++ b/azure-test/tests/azure_compute_virtual_machine_scale_set/varable.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_container_registry/variables.tf
+++ b/azure-test/tests/azure_container_registry/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_cosmosdb_account/variables.tf
+++ b/azure-test/tests/azure_cosmosdb_account/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -52,7 +52,6 @@ resource "azurerm_cosmosdb_account" "named_test_resource" {
   }
 
   geo_location {
-    prefix = "turbot-cosmos-db"
     location = azurerm_resource_group.named_test_resource.location
     failover_priority = 0
   }

--- a/azure-test/tests/azure_cosmosdb_mongo_database/variables.tf
+++ b/azure-test/tests/azure_cosmosdb_mongo_database/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_cosmosdb_sql_database/variables.tf
+++ b/azure-test/tests/azure_cosmosdb_sql_database/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_data_factory/variables.tf
+++ b/azure-test/tests/azure_data_factory/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_data_factory_dataset/variables.tf
+++ b/azure-test/tests/azure_data_factory_dataset/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -48,15 +48,13 @@ resource "azurerm_data_factory" "named_test_resource" {
 
 resource "azurerm_data_factory_linked_service_mysql" "named_test_resource" {
   name                = var.resource_name
-  resource_group_name = azurerm_resource_group.named_test_resource.name
-  data_factory_name   = azurerm_data_factory.named_test_resource.name
+  data_factory_id = azurerm_data_factory.named_test_resource.id
   connection_string   = "Server=test;Port=3306;Database=test;User=test;SSLMode=1;UseSystemTrustStore=0;Password=test"
 }
 
 resource "azurerm_data_factory_dataset_mysql" "named_test_resource" {
   name                = var.resource_name
-  resource_group_name = azurerm_resource_group.named_test_resource.name
-  data_factory_name   = azurerm_data_factory.named_test_resource.name
+  data_factory_id = azurerm_data_factory.named_test_resource.id
   linked_service_name = azurerm_data_factory_linked_service_mysql.named_test_resource.name
 }
 

--- a/azure-test/tests/azure_data_factory_pipeline/variables.tf
+++ b/azure-test/tests/azure_data_factory_pipeline/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -45,8 +45,7 @@ resource "azurerm_data_factory" "named_test_resource" {
 
 resource "azurerm_data_factory_pipeline" "named_test_resource" {
   name                = var.resource_name
-  resource_group_name = azurerm_resource_group.named_test_resource.name
-  data_factory_name   = azurerm_data_factory.named_test_resource.name
+  data_factory_id = azurerm_data_factory.named_test_resource.id
   variables = {
     "bob" = "item1"
   }

--- a/azure-test/tests/azure_databox_edge_device/variables.tf
+++ b/azure-test/tests/azure_databox_edge_device/variables.tf
@@ -17,9 +17,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_diagnostic_setting/variables.tf
+++ b/azure-test/tests/azure_diagnostic_setting/variables.tf
@@ -17,9 +17,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_eventgrid_domain/variable.tf
+++ b/azure-test/tests/azure_eventgrid_domain/variable.tf
@@ -17,9 +17,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_eventgrid_topic/variable.tf
+++ b/azure-test/tests/azure_eventgrid_topic/variable.tf
@@ -17,9 +17,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_eventhub_namespace/variables.tf
+++ b/azure-test/tests/azure_eventhub_namespace/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_express_route_circuit/varibles.tf
+++ b/azure-test/tests/azure_express_route_circuit/varibles.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_firewall/variables.tf
+++ b/azure-test/tests/azure_firewall/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_frontdoor/variables.tf
+++ b/azure-test/tests/azure_frontdoor/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_hdinsight_cluster/variables.tf
+++ b/azure-test/tests/azure_hdinsight_cluster/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_healthcare_service/variables.tf
+++ b/azure-test/tests/azure_healthcare_service/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_hpc_cache/variables.tf
+++ b/azure-test/tests/azure_hpc_cache/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_iothub/variables.tf
+++ b/azure-test/tests/azure_iothub/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -81,7 +81,6 @@ resource "azurerm_iothub" "named_test_resource" {
   sku {
     name     = "S1"
     capacity = "1"
-    tier     = "Basic"
   }
 
   endpoint {

--- a/azure-test/tests/azure_iothub_dps/variables.tf
+++ b/azure-test/tests/azure_iothub_dps/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_key_vault/variables.tf
+++ b/azure-test/tests/azure_key_vault/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_key_vault_deleted_vault/variables.tf
+++ b/azure-test/tests/azure_key_vault_deleted_vault/variables.tf
@@ -17,9 +17,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_key_vault_key/variables.tf
+++ b/azure-test/tests/azure_key_vault_key/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_key_vault_managed_hardware_security_module/variables.tf
+++ b/azure-test/tests/azure_key_vault_managed_hardware_security_module/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_key_vault_secret/variables.tf
+++ b/azure-test/tests/azure_key_vault_secret/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -49,12 +49,13 @@ resource "azurerm_key_vault" "named_test_resource" {
     object_id = data.azurerm_client_config.current.object_id
 
     secret_permissions = [
-      "set",
-      "get",
-      "list",
-      "delete",
-      "purge",
-      "recover"
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "Recover",
+      "Restore",
+      "Set"
     ]
   }
 }

--- a/azure-test/tests/azure_kubernetes_cluster/variables.tf
+++ b/azure-test/tests/azure_kubernetes_cluster/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -59,7 +59,7 @@ resource "azurerm_kubernetes_cluster" "named_test_resource" {
 }
 
 output "resource_aka" {
-  value = "azure://${azurerm_kubernetes_cluster.named_test_resource.id}"
+  value = replace("azure://${azurerm_kubernetes_cluster.named_test_resource.id}", "resourceGroups", "resourcegroups")
 }
 
 output "resource_aka_lower" {

--- a/azure-test/tests/azure_kusto_cluster/variables.tf
+++ b/azure-test/tests/azure_kusto_cluster/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.50.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_lb/variables.tf
+++ b/azure-test/tests/azure_lb/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}

--- a/azure-test/tests/azure_lb_backend_address_pool/variables.tf
+++ b/azure-test/tests/azure_lb_backend_address_pool/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}
@@ -49,7 +49,6 @@ resource "azurerm_lb" "named_test_resource" {
 }
 
 resource "azurerm_lb_backend_address_pool" "named_test_resource" {
-  resource_group_name = azurerm_resource_group.named_test_resource.name
   loadbalancer_id = azurerm_lb.named_test_resource.id
   name            = var.resource_name
 }

--- a/azure-test/tests/azure_lb_nat_rule/variables.tf
+++ b/azure-test/tests/azure_lb_nat_rule/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}
@@ -51,7 +51,6 @@ resource "azurerm_lb" "named_test_resource" {
 }
 
 resource "azurerm_lb_backend_address_pool" "named_test_resource" {
-  resource_group_name = azurerm_resource_group.named_test_resource.name
   loadbalancer_id     = azurerm_lb.named_test_resource.id
   name                = var.resource_name
 }

--- a/azure-test/tests/azure_lb_outbound_rule/variables.tf
+++ b/azure-test/tests/azure_lb_outbound_rule/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}
@@ -51,13 +51,11 @@ resource "azurerm_lb" "named_test_resource" {
 }
 
 resource "azurerm_lb_backend_address_pool" "named_test_resource" {
-  resource_group_name = azurerm_resource_group.named_test_resource.name
   loadbalancer_id     = azurerm_lb.named_test_resource.id
   name                = var.resource_name
 }
 
 resource "azurerm_lb_outbound_rule" "named_test_resource" {
-  resource_group_name     = azurerm_resource_group.named_test_resource.name
   loadbalancer_id         = azurerm_lb.named_test_resource.id
   name                    = var.resource_name
   protocol                = "Tcp"
@@ -69,7 +67,7 @@ resource "azurerm_lb_outbound_rule" "named_test_resource" {
 }
 
 output "resource_aka" {
-  depends_on = [azurerm_lb_rule.named_test_resource]
+  depends_on = [azurerm_lb_outbound_rule.named_test_resource]
   value      = "azure://${azurerm_lb_outbound_rule.named_test_resource.id}"
 }
 

--- a/azure-test/tests/azure_lb_probe/variables.tf
+++ b/azure-test/tests/azure_lb_probe/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}
@@ -49,7 +49,6 @@ resource "azurerm_lb" "named_test_resource" {
 }
 
 resource "azurerm_lb_probe" "named_test_resource" {
-  resource_group_name = azurerm_resource_group.named_test_resource.name
   loadbalancer_id     = azurerm_lb.named_test_resource.id
   name                = var.resource_name
   port                = 22

--- a/azure-test/tests/azure_lb_rule/variables.tf
+++ b/azure-test/tests/azure_lb_rule/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}
@@ -49,7 +49,6 @@ resource "azurerm_lb" "named_test_resource" {
 }
 
 resource "azurerm_lb_rule" "named_test_resource" {
-  resource_group_name            = azurerm_resource_group.named_test_resource.name
   loadbalancer_id                = azurerm_lb.named_test_resource.id
   name                           = var.resource_name
   protocol                       = "Tcp"

--- a/azure-test/tests/azure_logic_app_workflow/variables.tf
+++ b/azure-test/tests/azure_logic_app_workflow/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_machine_learning_workspace/variables.tf
+++ b/azure-test/tests/azure_machine_learning_workspace/variables.tf
@@ -18,7 +18,6 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=2.41.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
   features {}

--- a/azure-test/tests/azure_management_lock/variables.tf
+++ b/azure-test/tests/azure_management_lock/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_mariadb_server/variables.tf
+++ b/azure-test/tests/azure_mariadb_server/variables.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_mssql_elasticpool/variables.tf
+++ b/azure-test/tests/azure_mssql_elasticpool/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_mssql_virtual_machine/variables.tf
+++ b/azure-test/tests/azure_mssql_virtual_machine/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_mysql_flexible_server/variables.tf
+++ b/azure-test/tests/azure_mysql_flexible_server/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_mysql_server/variables.tf
+++ b/azure-test/tests/azure_mysql_server/variables.tf
@@ -28,9 +28,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_network_interface/variables.tf
+++ b/azure-test/tests/azure_network_interface/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -48,7 +48,7 @@ resource "azurerm_subnet" "named_test_resource" {
   name                 = var.resource_name
   resource_group_name  = azurerm_resource_group.named_test_resource.name
   virtual_network_name = azurerm_virtual_network.named_test_resource.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "named_test_resource" {

--- a/azure-test/tests/azure_network_security_group/variables.tf
+++ b/azure-test/tests/azure_network_security_group/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}

--- a/azure-test/tests/azure_network_watcher/variables.tf
+++ b/azure-test/tests/azure_network_watcher/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_network_watcher_flow_log/variables.tf
+++ b/azure-test/tests/azure_network_watcher_flow_log/variables.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.52.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_policy_assignment/variables.tf
+++ b/azure-test/tests/azure_policy_assignment/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_policy_definition/variables.tf
+++ b/azure-test/tests/azure_policy_definition/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_postgresql_server/variables.tf
+++ b/azure-test/tests/azure_postgresql_server/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_public_ip/variables.tf
+++ b/azure-test/tests/azure_public_ip/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_recovery_services_vault/variables.tf
+++ b/azure-test/tests/azure_recovery_services_vault/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_redis_cache/variables.tf
+++ b/azure-test/tests/azure_redis_cache/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_resource_group/variables.tf
+++ b/azure-test/tests/azure_resource_group/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_role_assignment/variables.tf
+++ b/azure-test/tests/azure_role_assignment/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -51,7 +51,7 @@ resource "azurerm_role_definition" "named_test_resource" {
 
 resource "azurerm_role_assignment" "named_test_resource" {
   scope              = data.azurerm_subscription.primary.id
-  role_definition_id = azurerm_role_definition.named_test_resource.id
+  role_definition_id = azurerm_role_definition.named_test_resource.role_definition_resource_id
   principal_id       = data.azurerm_client_config.current.object_id
 }
 
@@ -76,7 +76,7 @@ output "subscription_id" {
 }
 
 output "role_definition_id" {
-  value = azurerm_role_definition.named_test_resource.id
+  value = azurerm_role_definition.named_test_resource.role_definition_resource_id
 }
 
 output "principal_id" {

--- a/azure-test/tests/azure_role_definition/variables.tf
+++ b/azure-test/tests/azure_role_definition/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_route_table/variables.tf
+++ b/azure-test/tests/azure_route_table/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -46,7 +46,7 @@ resource "azurerm_route_table" "named_test_resource" {
   route {
     name           = var.resource_name
     address_prefix = "10.1.0.0/16"
-    next_hop_type  = "vnetlocal"
+    next_hop_type  = "VnetLocal"
   }
 
   tags = {

--- a/azure-test/tests/azure_search_service/variables.tf
+++ b/azure-test/tests/azure_search_service/variables.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.50.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_security_center_auto_provisioning/variables.tf
+++ b/azure-test/tests/azure_security_center_auto_provisioning/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_security_center_automation/variables.tf
+++ b/azure-test/tests/azure_security_center_automation/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -70,7 +69,7 @@ resource "azurerm_security_center_automation" "named_test_resource" {
   resource_group_name = azurerm_resource_group.named_test_resource.name
 
   action {
-    type              = "EventHub"
+    type              = "eventhub"
     resource_id       = azurerm_eventhub.named_test_resource.id
     connection_string = azurerm_eventhub_authorization_rule.named_test_resource.primary_connection_string
   }
@@ -91,7 +90,7 @@ resource "azurerm_security_center_automation" "named_test_resource" {
 }
 
 output "resource_aka" {
-  value = "azure://${azurerm_security_center_automation.named_test_resource.id}"
+  value = replace("azure://${azurerm_security_center_automation.named_test_resource.id}", "resourceGroups", "resourcegroups")
 }
 
 output "resource_aka_lower" {

--- a/azure-test/tests/azure_security_center_contact/variables.tf
+++ b/azure-test/tests/azure_security_center_contact/variables.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_security_center_setting/variables.tf
+++ b/azure-test/tests/azure_security_center_setting/variables.tf
@@ -24,10 +24,9 @@ variable "setting_name" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_security_center_subscription_pricing/variables.tf
+++ b/azure-test/tests/azure_security_center_subscription_pricing/variables.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.43.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_service_fabric_cluster/variables.tf
+++ b/azure-test/tests/azure_service_fabric_cluster/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {
@@ -43,7 +43,7 @@ resource "azurerm_service_fabric_cluster" "named_test_resource" {
   location             = azurerm_resource_group.named_test_resource.location
   reliability_level    = "Bronze"
   upgrade_mode         = "Manual"
-  cluster_code_version = "7.2.413.9590"
+  cluster_code_version = "8.1.316.9590"
   vm_image             = "Windows"
   management_endpoint  = "https://example:80"
 

--- a/azure-test/tests/azure_servicebus_namespace/test-get-expected.json
+++ b/azure-test/tests/azure_servicebus_namespace/test-get-expected.json
@@ -5,8 +5,9 @@
     "name": "{{ resourceName }}",
     "network_rule_set": {
       "properties": {
-        "defaultAction": "Deny",
+        "defaultAction": "Allow",
         "ipRules": [],
+        "publicNetworkAccess": "Enabled",
         "virtualNetworkRules": []
       }
     },

--- a/azure-test/tests/azure_servicebus_namespace/variables.tf
+++ b/azure-test/tests/azure_servicebus_namespace/variables.tf
@@ -18,10 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.41.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_sql_server/test-hydrate-expected.json
+++ b/azure-test/tests/azure_sql_server/test-hydrate-expected.json
@@ -5,10 +5,8 @@
 				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/encryptionProtector/current",
 				"kind": "servicemanaged",
 				"name": "current",
-				"properties": {
-					"serverKeyName": "ServiceManaged",
-					"serverKeyType": "ServiceManaged"
-				},
+				"serverKeyName": "ServiceManaged",
+        		"serverKeyType": "ServiceManaged",
 				"type": "Microsoft.Sql/servers/encryptionProtector"
 			}
 		],
@@ -29,17 +27,13 @@
 				"id": "/subscriptions/{{ output.subscription_id.value }}/resourceGroups/{{ resourceName }}/providers/Microsoft.Sql/servers/{{ resourceName }}/auditingSettings/Default",
 				"name": "Default",
 				"properties": {
-					"auditActionsAndGroups": [
-						"SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
-						"FAILED_DATABASE_AUTHENTICATION_GROUP",
-						"BATCH_COMPLETED_GROUP"
-					],
-					"isAzureMonitorTargetEnabled": true,
-					"isStorageSecondaryKeyInUse": true,
-					"retentionDays": 6,
-					"state": "Enabled",
+					"auditActionsAndGroups": [],
+					"isAzureMonitorTargetEnabled": false,
+					"isStorageSecondaryKeyInUse": false,
+					"retentionDays": 0,
+					"state": "Disabled",
 					"storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
-					"storageEndpoint": "https://{{ resourceName }}.blob.core.windows.net/"
+					"storageEndpoint": ""
 				},
 				"type": "Microsoft.Sql/servers/auditingSettings"
 			}

--- a/azure-test/tests/azure_sql_server/variables.tf
+++ b/azure-test/tests/azure_sql_server/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.50.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -53,13 +52,6 @@ resource "azurerm_sql_server" "named_test_resource" {
   version                      = "12.0"
   administrator_login          = "mradministrator"
   administrator_login_password = "thisIsDog11"
-
-  extended_auditing_policy {
-    storage_endpoint                        = azurerm_storage_account.named_test_resource.primary_blob_endpoint
-    storage_account_access_key              = azurerm_storage_account.named_test_resource.primary_access_key
-    storage_account_access_key_is_secondary = true
-    retention_in_days                       = 6
-  }
 
   tags = {
     name = var.resource_name

--- a/azure-test/tests/azure_storage_account/variables.tf
+++ b/azure-test/tests/azure_storage_account/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_storage_blob/variables.tf
+++ b/azure-test/tests/azure_storage_blob/variables.tf
@@ -19,10 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version = "=2.44.0"
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_storage_blob_service/variables.tf
+++ b/azure-test/tests/azure_storage_blob_service/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_storage_container/variables.tf
+++ b/azure-test/tests/azure_storage_container/variables.tf
@@ -17,9 +17,9 @@ variable "azure_subscription" {
 }
 
 provider "azurerm" {
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_storage_queue/variables.tf
+++ b/azure-test/tests/azure_storage_queue/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_storage_share_file/variables.tf
+++ b/azure-test/tests/azure_storage_share_file/variables.tf
@@ -19,7 +19,6 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=3.0.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
   features{}

--- a/azure-test/tests/azure_storage_sync/variables.tf
+++ b/azure-test/tests/azure_storage_sync/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}

--- a/azure-test/tests/azure_storage_table/variables.tf
+++ b/azure-test/tests/azure_storage_table/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_storage_table_service/variables.tf
+++ b/azure-test/tests/azure_storage_table_service/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_stream_analytics_job/variables.tf
+++ b/azure-test/tests/azure_stream_analytics_job/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_subnet/variables.tf
+++ b/azure-test/tests/azure_subnet/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
@@ -48,7 +48,7 @@ resource "azurerm_subnet" "named_test_resource" {
   name                 = var.resource_name
   resource_group_name  = azurerm_resource_group.named_test_resource.name
   virtual_network_name = azurerm_virtual_network.named_test_resource.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes       = ["10.0.1.0/24"]
 
   delegation {
     name = "delegation"

--- a/azure-test/tests/azure_subscription/variables.tf
+++ b/azure-test/tests/azure_subscription/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azuread" {
   # Cannot be passed as a variable
-  version         = "=0.10.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azuread_client_config" "current" {}

--- a/azure-test/tests/azure_synapse_workspace/variables.tf
+++ b/azure-test/tests/azure_synapse_workspace/variables.tf
@@ -27,9 +27,9 @@ terraform {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  features {}
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 resource "azurerm_resource_group" "named_test_resource" {

--- a/azure-test/tests/azure_tenant/test-list-expected.json
+++ b/azure-test/tests/azure_tenant/test-list-expected.json
@@ -1,7 +1,7 @@
 [
   {
-    "display_name": null,
-    "name": "{{ output.current_tenant_display_name.value }}",
+    "display_name": "turbot",
+    "name": "turbot",
     "tenant_id": "{{ output.tenant_id.value }}"
   }
 ]

--- a/azure-test/tests/azure_tenant/test-list-query.sql
+++ b/azure-test/tests/azure_tenant/test-list-query.sql
@@ -1,3 +1,3 @@
 select name, display_name, tenant_id
 from azure.azure_tenant
-where tenant_id = '{{ output.tenant_id.value }}'
+where tenant_id = '{{ output.tenant_id.value }}';

--- a/azure-test/tests/azure_tenant/test-turbot-expected.json
+++ b/azure-test/tests/azure_tenant/test-turbot-expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "{{ output.current_tenant_display_name.value }}",
-    "title": "{{ output.current_tenant_display_name.value }}"
+    "name": "turbot",
+    "title": "turbot"
   }
 ]

--- a/azure-test/tests/azure_virtual_network/variables.tf
+++ b/azure-test/tests/azure_virtual_network/variables.tf
@@ -19,9 +19,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure-test/tests/azure_virtual_network_gateway/variables.tf
+++ b/azure-test/tests/azure_virtual_network_gateway/variables.tf
@@ -18,9 +18,9 @@ variable "azure_subscription" {
 
 provider "azurerm" {
   # Cannot be passed as a variable
-  version         = "=1.36.0"
   environment     = var.azure_environment
   subscription_id = var.azure_subscription
+  features {}
 }
 
 data "azurerm_client_config" "current" {}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
A file has been attached below which contains the integration test logs. Please find out the attachment

1. azure_compute_availability_set
2. azure_compute_disk_access
3. azure_compute_disk_encryption_set
4. azure_compute_virtual_machine
5. azure_cosmosdb_account
6. azure_cosmosdb_sql_database
7. azure_data_factory_dataset
8. azure_data_factory_pipeline
9. azure_data_lake_analytics_account
10. azure_data_lake_store
11. azure_express_route_circuit
12. azure_iothub
13. azure_iothub_dps
14. azure_key_vault_secret
15. azure_kubernetes_cluster
16. azure_kusto_cluster
17. azure_lb_backend_address_pool
18. azure_lb_nat_rule
19. azure_lb_outbound_rule
20. azure_lb_probe
21. azure_lb_rule
22. azure_log_alert
23. azure_log_profile
24. azure_mssql_virtual_machine
25. azure_mysql_flexible_server
26. azure_network_interface
27. azure_provider
28. azure_role_assignment
29. azure_role_definition
30. azure_route_table
31. azure_security_center_automation
32. azure_service_fabric_cluster
33. azure_servicebus_namespace
34. azure_sql_server
35. azure_subnet
36. azure_subscription
37. azure_tenant

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)


```
</details>

[intg-test-12-07-22.txt](https://github.com/turbot/steampipe-plugin-azure/files/9136600/intg-test-12-07-22.txt)