### PR TITLE
Docs: replace reference to 'GCP Monitoring' with 'Azure Monitor'

### DIFF
--- a/docs/tables/azure_compute_disk_metric_read_ops.md
+++ b/docs/tables/azure_compute_disk_metric_read_ops.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_disk_metric_read_ops
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_disk_metric_read_ops` table provides metric statistics at 5 minutes intervals for the most recent 5 days.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_disk_metric_read_ops` table provides metric statistics at 5 minutes intervals for the most recent 5 days.
 
 ## Examples
 

--- a/docs/tables/azure_compute_disk_metric_read_ops_daily.md
+++ b/docs/tables/azure_compute_disk_metric_read_ops_daily.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_disk_metric_read_ops_daily
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_disk_metric_read_ops_daily` table provides metric statistics at 24 hours intervals for the most recent 1 year.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_disk_metric_read_ops_daily` table provides metric statistics at 24 hours intervals for the most recent 1 year.
 
 ## Examples
 

--- a/docs/tables/azure_compute_disk_metric_read_ops_hourly.md
+++ b/docs/tables/azure_compute_disk_metric_read_ops_hourly.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_disk_metric_read_ops_hourly
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_disk_metric_read_ops_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_disk_metric_read_ops_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
 
 ## Examples
 

--- a/docs/tables/azure_compute_disk_metric_write_ops.md
+++ b/docs/tables/azure_compute_disk_metric_write_ops.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_disk_metric_write_ops
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_disk_metric_write_ops` table provides metric statistics at 5 minutes intervals for the most recent 5 days.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_disk_metric_write_ops` table provides metric statistics at 5 minutes intervals for the most recent 5 days.
 
 ## Examples
 

--- a/docs/tables/azure_compute_disk_metric_write_ops_daily.md
+++ b/docs/tables/azure_compute_disk_metric_write_ops_daily.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_disk_metric_write_ops_daily
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_disk_metric_write_ops_daily` table provides metric statistics at 24 hours intervals for the most recent 1 year.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_disk_metric_write_ops_daily` table provides metric statistics at 24 hours intervals for the most recent 1 year.
 
 ## Examples
 

--- a/docs/tables/azure_compute_disk_metric_write_ops_hourly.md
+++ b/docs/tables/azure_compute_disk_metric_write_ops_hourly.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_disk_metric_write_ops_hourly
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_disk_metric_write_ops_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_disk_metric_write_ops_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
 
 ## Examples
 

--- a/docs/tables/azure_compute_virtual_machine_metric_cpu_utilization.md
+++ b/docs/tables/azure_compute_virtual_machine_metric_cpu_utilization.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_virtual_machine_metric_cpu_utilization
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_virtual_machine_metric_cpu_utilization` table provides metric statistics at 5 minutes intervals for the most recent 5 days.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_virtual_machine_metric_cpu_utilization` table provides metric statistics at 5 minutes intervals for the most recent 5 days.
 
 ## Examples
 

--- a/docs/tables/azure_compute_virtual_machine_metric_cpu_utilization_daily.md
+++ b/docs/tables/azure_compute_virtual_machine_metric_cpu_utilization_daily.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_virtual_machine_metric_cpu_utilization_daily
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_virtual_machine_metric_cpu_utilization_daily` table provides metric statistics at 24 hours intervals for the most recent 1 year.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_virtual_machine_metric_cpu_utilization_daily` table provides metric statistics at 24 hours intervals for the most recent 1 year.
 
 ## Examples
 

--- a/docs/tables/azure_compute_virtual_machine_metric_cpu_utilization_hourly.md
+++ b/docs/tables/azure_compute_virtual_machine_metric_cpu_utilization_hourly.md
@@ -1,6 +1,6 @@
 # Table: azure_compute_virtual_machine_metric_cpu_utilization_hourly
 
-GCP Monitoring metrics provide data about the performance of your systems. The `azure_compute_virtual_machine_metric_cpu_utilization_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
+Azure Monitor metrics provide data about the performance of your systems. The `azure_compute_virtual_machine_metric_cpu_utilization_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
 
 ## Examples
 


### PR DESCRIPTION
This PR fixes a documentation typo: several of the metric tables' docs refer to "GCP Monitoring", but I think they meant to refer to "Azure Monitor" instead.