### PR TITLE
Fix nil pointer dereference error in azure_app_configuration table. Fixes#529

### DIFF
--- a/azure/table_azure_app_configuration.go
+++ b/azure/table_azure_app_configuration.go
@@ -258,9 +258,9 @@ func getPublicNetworkAccess(ctx context.Context, d *plugin.QueryData, h *plugin.
 	// In case of automatic is selected at the time of store creation, PublicNetworkAccess value will be nil in API response.
 	// With a private endpoint, public network access will be automatically disabled.
 	// If there is no private endpoint present, public network access is automatically enabled.
-	if len(configurationStore.PublicNetworkAccess) == 0 && len(*configurationStore.PrivateEndpointConnections) == 0 {
+	if len(configurationStore.PublicNetworkAccess) == 0 && configurationStore.PrivateEndpointConnections == nil {
 		return "Enabled", nil
-	} else if len(configurationStore.PublicNetworkAccess) == 0 && len(*configurationStore.PrivateEndpointConnections) != 0 {
+	} else if len(configurationStore.PublicNetworkAccess) == 0 && configurationStore.PrivateEndpointConnections != nil {
 		return "Disabled", nil
 	}
 


### PR DESCRIPTION
… for table azure_app_configuration closes #529

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_app_configuration []

PRETEST: tests/azure_app_configuration

TEST: tests/azure_app_configuration
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_app_configuration.named_test_resource will be created
  + resource "azurerm_app_configuration" "named_test_resource" {
      + endpoint            = (known after apply)
      + id                  = (known after apply)
      + location            = "westeurope"
      + name                = "turbottest13524"
      + primary_read_key    = (known after apply)
      + primary_write_key   = (known after apply)
      + resource_group_name = "turbottest13524"
      + secondary_read_key  = (known after apply)
      + secondary_write_key = (known after apply)
      + sku                 = "free"
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "turbottest13524"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + region             = "westeurope"
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest13524"
  + subscription_id    = "u85j7416-f95f-4371-bbf5-529v7c763847"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524]
azurerm_app_configuration.named_test_resource: Creating...
azurerm_app_configuration.named_test_resource: Still creating... [10s elapsed]
azurerm_app_configuration.named_test_resource: Creation complete after 18s [id=/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524/providers/Microsoft.AppConfiguration/configurationStores/turbottest13524]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

region = "westeurope"
resource_aka = "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524/providers/Microsoft.AppConfiguration/configurationStores/turbottest13524"
resource_aka_lower = "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourcegroups/turbottest13524/providers/microsoft.appconfiguration/configurationstores/turbottest13524"
resource_id = "/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524/providers/Microsoft.AppConfiguration/configurationStores/turbottest13524"
resource_name = "turbottest13524"
subscription_id = "u85j7416-f95f-4371-bbf5-529v7c763847"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524/providers/Microsoft.AppConfiguration/configurationStores/turbottest13524",
    "name": "turbottest13524",
    "region": "westeurope",
    "resource_group": "turbottest13524",
    "subscription_id": "u85j7416-f95f-4371-bbf5-529v7c763847",
    "type": "Microsoft.AppConfiguration/configurationStores"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524/providers/Microsoft.AppConfiguration/configurationStores/turbottest13524",
    "name": "turbottest13524",
    "region": "westeurope",
    "resource_group": "turbottest13524",
    "subscription_id": "u85j7416-f95f-4371-bbf5-529v7c763847",
    "type": "Microsoft.AppConfiguration/configurationStores"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest13524/providers/Microsoft.AppConfiguration/configurationStores/turbottest13524",
      "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourcegroups/turbottest13524/providers/microsoft.appconfiguration/configurationstores/turbottest13524"
    ],
    "name": "turbottest13524",
    "title": "turbottest13524"
  }
]
✔ PASSED

POSTTEST: tests/azure_app_configuration

TEARDOWN: tests/azure_app_configuration

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select public_network_access from azure_app_configuration
+-----------------------+
| public_network_access |
+-----------------------+
| Enabled               |
+-----------------------+
> select public_network_access from azure_app_configuration
+-----------------------+
| public_network_access |
+-----------------------+
| Disabled              |
+-----------------------+

```
</details>
