### PR TITLE
Fix column virtual_network_rules for table azure_cosmosdb_account closes #524

### DIFF
--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -212,7 +212,8 @@ func tableAzureCosmosDBAccount(_ context.Context) *plugin.Table {
 				Name:        "virtual_network_rules",
 				Description: "A list of Virtual Network ACL rules configured for the Cosmos DB account.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules"),
+				Transform: transform.From(extractCosmosDBVirtualNetworkRule),
+				// Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules"),
 			},
 			{
 				Name:        "write_locations",
@@ -310,4 +311,16 @@ func getCosmosDBAccount(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 
 	return databaseAccountInfo{op, op.Name, &resourceGroup}, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func extractCosmosDBVirtualNetworkRule(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	info := d.HydrateItem.(databaseAccountInfo)
+		if info.DatabaseAccount.DatabaseAccountGetProperties != nil {
+			if info.DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules != nil {
+				return *info.DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules, nil
+			}
+		}
+	return nil, nil
 }

--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -212,7 +212,7 @@ func tableAzureCosmosDBAccount(_ context.Context) *plugin.Table {
 				Name:        "virtual_network_rules",
 				Description: "A list of Virtual Network ACL rules configured for the Cosmos DB account.",
 				Type:        proto.ColumnType_JSON,
-				Transform: transform.From(extractCosmosDBVirtualNetworkRule),
+				Transform:   transform.From(extractCosmosDBVirtualNetworkRule),
 			},
 			{
 				Name:        "write_locations",
@@ -316,10 +316,10 @@ func getCosmosDBAccount(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 func extractCosmosDBVirtualNetworkRule(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	info := d.HydrateItem.(databaseAccountInfo)
-		if info.DatabaseAccount.DatabaseAccountGetProperties != nil {
-			if info.DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules != nil {
-				return *info.DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules, nil
-			}
+	if info.DatabaseAccount.DatabaseAccountGetProperties != nil {
+		if info.DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules != nil {
+			return *info.DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules, nil
 		}
+	}
 	return nil, nil
 }

--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -213,7 +213,6 @@ func tableAzureCosmosDBAccount(_ context.Context) *plugin.Table {
 				Description: "A list of Virtual Network ACL rules configured for the Cosmos DB account.",
 				Type:        proto.ColumnType_JSON,
 				Transform: transform.From(extractCosmosDBVirtualNetworkRule),
-				// Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.VirtualNetworkRules"),
 			},
 			{
 				Name:        "write_locations",


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_cosmosdb_account []

PRETEST: tests/azure_cosmosdb_account

TEST: tests/azure_cosmosdb_account
Running terraform
data.azurerm_client_config.current: Reading...
data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MDZmZDQ2YjAtYTg2Ny00OWExLWE0ZjEtZjc3Njg0NjVjYWJhO3N1YnNjcmlwdGlvbklkPWQ0NmQ3NDE2LWY5NWYtNDc3MS1iYmI1LTUyOWQ0Yzc2NjU5Yzt0ZW5hbnRJZD1jZGZmZDcwOC03ZGEwLTRjZWEtYWJlYi0wYTRjMzM0ZDdmNjQ=]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_cosmosdb_account.named_test_resource will be created
  + resource "azurerm_cosmosdb_account" "named_test_resource" {
      + access_key_metadata_writes_enabled       = true
      + analytical_storage_enabled               = false
      + connection_strings                       = (sensitive value)
      + create_mode                              = (known after apply)
      + default_identity_type                    = "FirstPartyIdentity"
      + enable_automatic_failover                = true
      + enable_free_tier                         = false
      + enable_multiple_write_locations          = false
      + endpoint                                 = (known after apply)
      + id                                       = (known after apply)
      + is_virtual_network_filter_enabled        = false
      + kind                                     = "GlobalDocumentDB"
      + local_authentication_disabled            = false
      + location                                 = "eastus"
      + mongo_server_version                     = (known after apply)
      + name                                     = "turbottest57606"
      + network_acl_bypass_for_azure_services    = false
      + offer_type                               = "Standard"
      + primary_key                              = (sensitive value)
      + primary_readonly_key                     = (sensitive value)
      + primary_readonly_sql_connection_string   = (sensitive value)
      + primary_sql_connection_string            = (sensitive value)
      + public_network_access_enabled            = true
      + read_endpoints                           = (known after apply)
      + resource_group_name                      = "turbottest57606"
      + secondary_key                            = (sensitive value)
      + secondary_readonly_key                   = (sensitive value)
      + secondary_readonly_sql_connection_string = (sensitive value)
      + secondary_sql_connection_string          = (sensitive value)
      + tags                                     = {
          + "name" = "turbottest57606"
        }
      + write_endpoints                          = (known after apply)

      + analytical_storage {
          + schema_type = (known after apply)
        }

      + backup {
          + interval_in_minutes = (known after apply)
          + retention_in_hours  = (known after apply)
          + storage_redundancy  = (known after apply)
          + type                = (known after apply)
        }

      + capabilities {
          + name = (known after apply)
        }

      + capacity {
          + total_throughput_limit = (known after apply)
        }

      + consistency_policy {
          + consistency_level       = "BoundedStaleness"
          + max_interval_in_seconds = 600
          + max_staleness_prefix    = 200000
        }

      + geo_location {
          + failover_priority = 0
          + id                = (known after apply)
          + location          = "eastus"
          + zone_redundant    = false
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest57606"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest57606"
  + subscription_id    = "u85j7416-f95f-4371-bbf5-529v7c763847"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606]
azurerm_cosmosdb_account.named_test_resource: Creating...
azurerm_cosmosdb_account.named_test_resource: Still creating... [10s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [20s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [30s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [40s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [50s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [1m0s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [1m10s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [1m20s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [1m30s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [1m40s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [1m50s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [2m0s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [2m10s elapsed]
azurerm_cosmosdb_account.named_test_resource: Still creating... [2m20s elapsed]
azurerm_cosmosdb_account.named_test_resource: Creation complete after 2m26s [id=/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606"
resource_aka_lower = "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourcegroups/turbottest57606/providers/microsoft.documentdb/databaseaccounts/turbottest57606"
resource_id = "/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606"
resource_name = "turbottest57606"
subscription_id = "u85j7416-f95f-4371-bbf5-529v7c763847"

Running SQL query: test-get-query.sql
[
  {
    "consistency_policy_max_interval": 600,
    "consistency_policy_max_staleness_prefix": 200000,
    "database_account_offer_type": "Standard",
    "default_consistency_level": "BoundedStaleness",
    "disable_key_based_metadata_write_access": false,
    "document_endpoint": "https://turbottest57606.documents.azure.com:443/",
    "enable_automatic_failover": true,
    "enable_multiple_write_locations": false,
    "id": "/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606",
    "is_virtual_network_filter_enabled": false,
    "kind": "GlobalDocumentDB",
    "name": "turbottest57606",
    "region": "east us",
    "resource_group": "turbottest57606",
    "type": "Microsoft.DocumentDB/databaseAccounts"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606",
      "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourcegroups/turbottest57606/providers/microsoft.documentdb/databaseaccounts/turbottest57606"
    ],
    "name": "turbottest57606",
    "tags": {
      "name": "turbottest57606"
    },
    "title": "turbottest57606"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606",
    "name": "turbottest57606"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/turbottest57606/providers/Microsoft.DocumentDB/databaseAccounts/turbottest57606",
      "azure:///subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourcegroups/turbottest57606/providers/microsoft.documentdb/databaseaccounts/turbottest57606"
    ],
    "name": "turbottest57606",
    "tags": {
      "name": "turbottest57606"
    },
    "title": "turbottest57606"
  }
]
✔ PASSED

POSTTEST: tests/azure_cosmosdb_account

TEARDOWN: tests/azure_cosmosdb_account

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select virtual_network_rules from azure_cosmosdb_account;
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| virtual_network_rules                                                                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| [{"id":"/subscriptions/u85j7416-f95f-4371-bbf5-529v7c763847/resourceGroups/demo/providers/Microsoft.Network/virtualNetworks/test-grapg-vn/subnets/default","ignoreMissingVNetServiceEndpoint":false},{"id"
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
