### PR TITLE
Fix ExpiredAuthenticationToken errors when using Azure CLI credentials. Fixes #521

### DIFF
--- a/azure/service.go
+++ b/azure/service.go
@@ -164,7 +164,7 @@ func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience strin
 		logger.Trace("Getting token for authorizer from Azure CLI")
 		token, err := cli.GetTokenFromCLI(resource)
 		if err != nil {
-			plugin.Logger(ctx).Error("GetNewSession", "get_token_from_cli_error", err)
+			logger.Error("GetNewSession", "get_token_from_cli_error", err)
 			return nil, err
 		}
 

--- a/azure/table_azure_app_service_plan.go
+++ b/azure/table_azure_app_service_plan.go
@@ -336,6 +336,6 @@ func getServicePlanApps(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 			apps = append(apps, *app)
 		}
 	}
-	
+
 	return apps, nil
 }

--- a/azure/table_azure_compute_resource_sku.go
+++ b/azure/table_azure_compute_resource_sku.go
@@ -140,7 +140,7 @@ func tableAzureResourceSku(_ context.Context) *plugin.Table {
 
 type skuInfo struct {
 	SubscriptionID string
-	Sku skus.ResourceSku
+	Sku            skus.ResourceSku
 }
 
 //// LIST FUNCTION


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
<img width="619" alt="image" src="https://user-images.githubusercontent.com/37527306/200825988-13b559b5-81c7-4666-8ebb-007bb66260c4.png">  

```
lalit@Lalits-MacBook-Pro:~/WORK/Turbot/steampipe/plugins/steampipe-plugin-azure|main⚡ ⇒  steampipe query
Welcome to Steampipe v0.18.0-dev.0
For more information, type .help
> select * from azure_compute_disk
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
| name | id | type | provisioning_state | managed_by | sku_name | sku_tier | time_created | unique_id | disk_access_id | disk_size_bytes | disk_size_gb | disk_state | hyper_v_generation | disk_iops_read_only | dis>
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
> select * from azure_old.azure_compute_disk
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
| name | id | type | provisioning_state | managed_by | sku_name | sku_tier | time_created | unique_id | disk_access_id | disk_size_bytes | disk_size_gb | disk_state | hyper_v_generation | disk_iops_read_only | dis>
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
> 
> 

-- After waiting for Token to Expire
> select * from azure_old.azure_compute_disk

Error: compute.DisksClient#List: Failure responding to request: StatusCode=401 -- Original Error: autorest/azure: Service returned an error. Status=401 Code="ExpiredAuthenticationToken" Message="The access token expiry UTC time '11/9/2022 11:39:38 AM' is earlier than current UTC time '11/9/2022 11:47:06 AM'." (SQLSTATE HV000)

+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
| name | id | type | provisioning_state | managed_by | sku_name | sku_tier | time_created | unique_id | disk_access_id | disk_size_bytes | disk_size_gb | disk_state | hyper_v_generation | disk_iops_read_only | dis>
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
> select * from azure_compute_disk
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
| name | id | type | provisioning_state | managed_by | sku_name | sku_tier | time_created | unique_id | disk_access_id | disk_size_bytes | disk_size_gb | disk_state | hyper_v_generation | disk_iops_read_only | dis>
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
> select * from azure_old.azure_compute_disk

Error: compute.DisksClient#List: Failure responding to request: StatusCode=401 -- Original Error: autorest/azure: Service returned an error. Status=401 Code="ExpiredAuthenticationToken" Message="The access token expiry UTC time '11/9/2022 11:39:38 AM' is earlier than current UTC time '11/9/2022 11:47:32 AM'." (SQLSTATE HV000)

+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
| name | id | type | provisioning_state | managed_by | sku_name | sku_tier | time_created | unique_id | disk_access_id | disk_size_bytes | disk_size_gb | disk_state | hyper_v_generation | disk_iops_read_only | dis>
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+---->
+------+----+------+--------------------+------------+----------+----------+--------------+-----------+----------------+-----------------+--------------+------------+--------------------+---------------------+----
```
</details>
