### PR TITLE
Fixed VulnerabilityAssessmentInvalidPolicy error for table azure_sql_database closes #551

### DIFF
--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -530,6 +530,8 @@ func listSqlDatabaseVulnerabilityAssessmentScans(ctx context.Context, d *plugin.
 
 	op, err := client.ListByDatabase(ctx, resourceGroupName, serverName, databaseName)
 	if err != nil {
+		// API throws "VulnerabilityAssessmentInvalidPolicy" error if Vulnerability Assessment settings don't exist or invalid storage specified in settings.
+		// https://learn.microsoft.com/en-us/rest/api/sql/2022-05-01-preview/database-vulnerability-assessment-scans/list-by-database?tabs=HTTP
 		if strings.Contains(err.Error(), "VulnerabilityAssessmentInvalidPolicy") {
 			return vulnerabilityAssessmentScanRecords, nil
 		}

--- a/azure/table_azure_sql_database.go
+++ b/azure/table_azure_sql_database.go
@@ -526,13 +526,15 @@ func listSqlDatabaseVulnerabilityAssessmentScans(ctx context.Context, d *plugin.
 
 	client := sqlV5.NewDatabaseVulnerabilityAssessmentScansClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
+	var vulnerabilityAssessmentScanRecords []map[string]interface{}
 
 	op, err := client.ListByDatabase(ctx, resourceGroupName, serverName, databaseName)
 	if err != nil {
+		if strings.Contains(err.Error(), "VulnerabilityAssessmentInvalidPolicy") {
+			return vulnerabilityAssessmentScanRecords, nil
+		}
 		return nil, err
 	}
-
-	var vulnerabilityAssessmentScanRecords []map[string]interface{}
 
 	for _, i := range op.Values() {
 		objectMap := make(map[string]interface{})


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_sql_database []

PRETEST: tests/azure_sql_database

TEST: tests/azure_sql_database
Running terraform
data.azurerm_client_config.current: Reading...
data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MDZmZDQ2YjAtYTg2Ny00OWExLWE0ZjEtZjc3Njg0NjVjYWJhO3N1YnNjcmlwdGlvbklkPWQ0NmQ3NDE2LWY5NWYtNDc3MS1iYmI1LTUyOWQ0Yzc2NjU5Yzt0ZW5hbnRJZD1jZGZmZDcwOC03ZGEwLTRjZWEtYWJlYi0wYTRjMzM0ZDdmNjQ=]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest72144"
    }

  # azurerm_sql_database.named_test_resource will be created
  + resource "azurerm_sql_database" "named_test_resource" {
      + collation                        = (known after apply)
      + create_mode                      = "Default"
      + creation_date                    = (known after apply)
      + default_secondary_location       = (known after apply)
      + edition                          = (known after apply)
      + elastic_pool_name                = (known after apply)
      + encryption                       = (known after apply)
      + id                               = (known after apply)
      + location                         = "eastus"
      + max_size_bytes                   = (known after apply)
      + max_size_gb                      = (known after apply)
      + name                             = "turbottest72144"
      + read_scale                       = false
      + requested_service_objective_id   = (known after apply)
      + requested_service_objective_name = (known after apply)
      + resource_group_name              = "turbottest72144"
      + restore_point_in_time            = (known after apply)
      + server_name                      = "turbottest72144"
      + source_database_deletion_date    = (known after apply)
      + source_database_id               = (known after apply)
      + tags                             = {
          + "foo" = "bar"
        }

      + threat_detection_policy {
          + disabled_alerts            = (known after apply)
          + email_account_admins       = (known after apply)
          + email_addresses            = (known after apply)
          + retention_days             = (known after apply)
          + state                      = (known after apply)
          + storage_account_access_key = (sensitive value)
          + storage_endpoint           = (known after apply)
        }
    }

  # azurerm_sql_server.named_test_resource will be created
  + resource "azurerm_sql_server" "named_test_resource" {
      + administrator_login          = "mradministrator"
      + administrator_login_password = (sensitive value)
      + connection_policy            = "Default"
      + fully_qualified_domain_name  = (known after apply)
      + id                           = (known after apply)
      + location                     = "eastus"
      + name                         = "turbottest72144"
      + resource_group_name          = "turbottest72144"
      + version                      = "12.0"

      + threat_detection_policy {
          + disabled_alerts            = (known after apply)
          + email_account_admins       = (known after apply)
          + email_addresses            = (known after apply)
          + retention_days             = (known after apply)
          + state                      = (known after apply)
          + storage_account_access_key = (sensitive value)
          + storage_endpoint           = (known after apply)
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka                        = (known after apply)
  + resource_aka_lower                  = (known after apply)
  + resource_creation_date              = (known after apply)
  + resource_default_secondary_location = (known after apply)
  + resource_id                         = (known after apply)
  + resource_location                   = "East US"
  + resource_name                       = "turbottest72144"
  + resource_region                     = "east us"
  + subscription_id                     = "f56237416-f95f-4771-sss5-459d4c767485"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 3s [id=/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144]
azurerm_sql_server.named_test_resource: Creating...
azurerm_sql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_server.named_test_resource: Still creating... [1m20s elapsed]
azurerm_sql_server.named_test_resource: Creation complete after 1m22s [id=/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144]
azurerm_sql_database.named_test_resource: Creating...
azurerm_sql_database.named_test_resource: Still creating... [10s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [20s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [30s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [40s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [50s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [1m0s elapsed]
azurerm_sql_database.named_test_resource: Still creating... [1m10s elapsed]
azurerm_sql_database.named_test_resource: Creation complete after 1m14s [id=/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 35, in data "null_data_source" "resource":
  35: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Deprecated Resource

  with azurerm_sql_server.named_test_resource,
  on variables.tf line 46, in resource "azurerm_sql_server" "named_test_resource":
  46: resource "azurerm_sql_server" "named_test_resource" {

The `azurerm_sql_server` resource is deprecated and will be removed in
version 4.0 of the AzureRM provider. Please use the `azurerm_mssql_server`
resource instead.

(and 5 more similar warnings elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144"
resource_aka_lower = "azure:///subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourcegroups/turbottest72144/providers/microsoft.sql/servers/turbottest72144/databases/turbottest72144"
resource_creation_date = "2022-12-07T08:27:07.22Z"
resource_default_secondary_location = "West US"
resource_id = "/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144"
resource_location = "East US"
resource_name = "turbottest72144"
resource_region = "east us"
subscription_id = "f56237416-f95f-4771-sss5-459d4c767485"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144",
      "azure:///subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourcegroups/turbottest72144/providers/microsoft.sql/servers/turbottest72144/databases/turbottest72144"
    ],
    "containment_state": 2,
    "default_secondary_location": "West US",
    "earliest_restore_date": null,
    "edition": "GeneralPurpose",
    "elastic_pool_name": null,
    "id": "/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144",
    "location": "East US",
    "max_size_bytes": "34359738368",
    "name": "turbottest72144",
    "region": "east us",
    "requested_service_objective_name": "GP_Gen5_2",
    "resource_group": "turbottest72144",
    "server_name": "turbottest72144",
    "service_level_objective": "GP_Gen5_2",
    "status": "Online",
    "subscription_id": "f56237416-f95f-4771-sss5-459d4c767485",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest72144",
    "transparent_data_encryption": {
      "status": "Enabled"
    },
    "type": "Microsoft.Sql/servers/databases",
    "zone_redundant": false
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "id": "/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144",
    "name": "turbottest72144",
    "server_name": "turbottest72144",
    "transparent_data_encryption": {
      "status": "Enabled"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144",
    "location": "East US",
    "name": "turbottest72144",
    "resource_group": "turbottest72144",
    "server_name": "turbottest72144"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbottest72144/providers/Microsoft.Sql/servers/turbottest72144/databases/turbottest72144",
      "azure:///subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourcegroups/turbottest72144/providers/microsoft.sql/servers/turbottest72144/databases/turbottest72144"
    ],
    "name": "turbottest72144",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest72144"
  }
]
✔ PASSED

POSTTEST: tests/azure_sql_database

TEARDOWN: tests/azure_sql_database

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from azure_sql_database
+--------+--------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+---------------------------------+------------------------------+-------------------+-----------------
| name   | id                                                                                                                                   | server_name | status | type                            | collation                    | containment_state | creation_date   
+--------+--------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+---------------------------------+------------------------------+-------------------+-----------------
| master | /subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/test63/databases/master | test63      | Online | Microsoft.Sql/servers/databases | SQL_Latin1_General_CP1_CI_AS | 2                 | 2022-12-07T13:29
| test43 | /subscriptions/f56237416-f95f-4771-sss5-459d4c767485/resourceGroups/turbot_rg/providers/Microsoft.Sql/servers/test63/databases/test43 | test63      | Online | Microsoft.Sql/servers/databases | SQL_Latin1_General_CP1_CI_AS | 2                 | 2022-12-07T13:33
+--------+--------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+---------------------------------+------------------------------+-------------------+-----------------

```
</details>
