### PR TITLE
Getting ResourceNotFound error in table azure_subnet closes #555

### DIFF
--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -311,6 +311,9 @@ func getIpConfiguration(ctx context.Context, ipConfig *network.IPConfiguration, 
 
 	configuration, err := client.Get(ctx, resourceGroup, networkInterface, configName)
 	if err != nil {
+		if strings.Contains(err.Error(), "ResourceNotFound") {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -294,7 +294,7 @@ func getIpConfigurationAsync(ctx context.Context, ipConfig *network.IPConfigurat
 	rowData, err := getIpConfiguration(ctx, ipConfig, client)
 	if err != nil {
 		errorCh <- err
-	} else if rowData.ID != nil {
+	} else if rowData != nil {
 		ipCh <- rowData
 	}
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_subnet []

PRETEST: tests/azure_subnet

TEST: tests/azure_subnet
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 4s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Still creating... [10s elapsed]
azurerm_virtual_network.named_test_resource: Creation complete after 15s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 7s [id=/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455]

Warning: Deprecated Resource

  on variables.tf line 30, in data "null_data_source" "resource":
  30: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: "address_prefix": [DEPRECATED] Use the `address_prefixes` property instead.

  on variables.tf line 48, in resource "azurerm_subnet" "named_test_resource":
  48: resource "azurerm_subnet" "named_test_resource" {



Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455
resource_aka_lower = azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest74455/providers/microsoft.network/virtualnetworks/turbottest74455/subnets/turbottest74455
resource_id = /subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455
resource_name = turbottest74455
subscription_id = d46d7416-f95f-4771-bbb5-529d4c76659c

Running SQL query: test-get-query.sql
[
  {
    "address_prefix": "10.0.1.0/24",
    "delegations": [
      {
        "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455/delegations/delegation",
        "name": "delegation",
        "properties": {
          "serviceName": "Microsoft.ContainerInstance/containerGroups"
        }
      }
    ],
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
    "name": "turbottest74455",
    "resource_group": "turbottest74455",
    "type": "Microsoft.Network/subnets",
    "virtual_network_name": "turbottest74455"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest74455/providers/microsoft.network/virtualnetworks/turbottest74455/subnets/turbottest74455"
    ],
    "name": "turbottest74455",
    "title": "turbottest74455"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
    "name": "turbottest74455"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/turbottest74455/providers/Microsoft.Network/virtualNetworks/turbottest74455/subnets/turbottest74455",
      "azure:///subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourcegroups/turbottest74455/providers/microsoft.network/virtualnetworks/turbottest74455/subnets/turbottest74455"
    ],
    "name": "turbottest74455",
    "title": "turbottest74455"
  }
]
✔ PASSED

POSTTEST: tests/azure_subnet

TEARDOWN: tests/azure_subnet

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
   > select
	st.name subnet_name,
	st.virtual_network_name,
	rt.name route_table_name,
	jsonb_array_elements(rt.routes) -> 'properties' ->> 'addressPrefix' as route_address_prefix,
	jsonb_array_elements(rt.routes) -> 'properties' ->> 'nextHopType' as route_next_hop_type
from
	azure_route_table as rt
	join azure_subnet st on rt.id = st.route_table_id;
+-------------------------------+------------------------------+--------------------------------------+----------------------+---------------------+
| subnet_name                   | virtual_network_name         | route_table_name                     | route_address_prefix | route_next_hop_type |
+-------------------------------+------------------------------+--------------------------------------+----------------------+---------------------+
| AzureFirewallManagementSubnet | delete-rk-firewall-test-vnet | 6f922654-baa1-49b0-88db-6857a52644a0 | 0.0.0.0/0            | Internet            |
+-------------------------------+------------------------------+--------------------------------------+----------------------+---------------------+

> select
	name subnet_name,
	virtual_network_name,
	split_part(network_security_group_id, '/', 9) as network_security_name
from
	azure_subnet;
+-------------------------------+------------------------------+----------------------------+
| subnet_name                   | virtual_network_name         | network_security_name      |
+-------------------------------+------------------------------+----------------------------+
| default                       | turbot_rg-vnet               | <null>                     |
| default                       | dev-vnet                     | <null>                     |
| AzureFirewallSubnet           | vnet67                       | <null>                     |
| default                       | devvnet524                   | <null>                     |
| default                       | devvnet638                   | <null>                     |
| default                       | demovnet857                  | <null>                     |
| default                       | defender                     | machi7888-nsg              |
| default                       | test-1234_group-vnet         | <null>                     |
| fff                           | test-1234_group-vnet         | <null>                     |
| aks-subnet                    | aks-vnet-16724419            | aks-agentpool-16724419-nsg |
| default                       | turbot_rg-vnet               | test53-nsg                 |
| kba-appgwsubnet               | demo-vnet                    | <null>                     |
| nhw-appgwsubnet               | demo-vnet                    | apimnsghpfroq3dms45k       |
| AzureFirewallSubnet           | demo-vnet                    | <null>                     |
| default                       | test-12_group-vnet           | <null>                     |
| ffffff                        | demovnet218                  | <null>                     |
| default                       | demovnet218                  | <null>                     |
| AzureFirewallSubnet           | delete-rk-firewall-test-vnet | <null>                     |
| AzureFirewallManagementSubnet | delete-rk-firewall-test-vnet | <null>                     |
| default                       | demovnet599                  | <null>                     |
| default                       | test32_group-vnet            | <null>                     |
| default                       | demo-vnet                    | apimnsghpfroq3dms45k       |
+-------------------------------+------------------------------+----------------------------+

     > select
	name,
	endpoint -> 'locations' as location,
	endpoint -> 'service' as service
from
	azure_subnet
	cross join jsonb_array_elements(service_endpoints) as endpoint;
+---------------------+---------------------+---------------------------+
| name                | location            | service                   |
+---------------------+---------------------+---------------------------+
| default             | ["eastus","westus"] | "Microsoft.Storage"       |
| default             | ["eastus"]          | "Microsoft.Sql"           |
| default             | ["*"]               | "Microsoft.KeyVault"      |
| default             | ["eastus"]          | "Microsoft.Sql"           |
| AzureFirewallSubnet | ["eastus","westus"] | "Microsoft.Storage"       |
| AzureFirewallSubnet | ["eastus"]          | "Microsoft.Sql"           |
| kba-appgwsubnet     | ["eastus","westus"] | "Microsoft.Storage"       |
| nhw-appgwsubnet     | ["eastus","westus"] | "Microsoft.Storage"       |
| nhw-appgwsubnet     | ["eastus"]          | "Microsoft.Sql"           |
| nhw-appgwsubnet     | ["*"]               | "Microsoft.AzureCosmosDB" |
| default             | ["westus","eastus"] | "Microsoft.Storage"       |
| default             | ["westus"]          | "Microsoft.Sql"           |
+---------------------+---------------------+---------------------------+
```
</details>
