### PR TITLE
Add VNET rules in table azure_mysql_server closes #557

### DIFF
--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -207,6 +207,13 @@ func tableAzureMySQLServer(_ context.Context) *plugin.Table {
 				Hydrate:     listMySQLServersServerKeys,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "vnet_rules",
+				Description: "The server keys of the server.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listMySQLServerVnetRules,
+				Transform:   transform.FromValue(),
+			},
 
 			// Steampipe standard columns
 			{

--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -209,7 +209,7 @@ func tableAzureMySQLServer(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "vnet_rules",
-				Description: "The server keys of the server.",
+				Description: "VirtualNetworkRule a virtual network rule.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listMySQLServerVnetRules,
 				Transform:   transform.FromValue(),
@@ -387,9 +387,7 @@ func listMySQLServerVnetRules(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	var vnetRules []mysql.VirtualNetworkRule
 
-	for _, i := range op.Values() {
-		vnetRules = append(vnetRules, i)
-	}
+	vnetRules = append(vnetRules, op.Values()...)
 
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
@@ -397,9 +395,7 @@ func listMySQLServerVnetRules(ctx context.Context, d *plugin.QueryData, h *plugi
 			plugin.Logger(ctx).Error("listMySQLServerVnetRules", "list_paging", err)
 			return nil, err
 		}
-		for _, i := range op.Values() {
-			vnetRules = append(vnetRules, i)
-		}
+		vnetRules = append(vnetRules, op.Values()...)
 	}
 
 	return vnetRules, nil

--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -390,7 +390,7 @@ func listMySQLServerVnetRules(ctx context.Context, d *plugin.QueryData, h *plugi
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("azure_mysql_server.listMySQLServerVnetRules", "api_error_pagging", err)
+			plugin.Logger(ctx).Error("azure_mysql_server.listMySQLServerVnetRules", "api_pagging_error", err)
 			return nil, err
 		}
 		vnetRules = append(vnetRules, op.Values()...)

--- a/azure/table_azure_mysql_server.go
+++ b/azure/table_azure_mysql_server.go
@@ -363,15 +363,13 @@ func listMySQLServersServerKeys(ctx context.Context, d *plugin.QueryData, h *plu
 }
 
 func listMySQLServerVnetRules(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("listMySQLServerVnetRules")
-
 	namespace := h.Item.(mysql.Server)
 	resourceGroup := strings.Split(string(*namespace.ID), "/")[4]
 	serverName := *namespace.Name
 
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
 	if err != nil {
-		plugin.Logger(ctx).Error("")
+		plugin.Logger(ctx).Error("azure_mysql_server.listMySQLServerVnetRules", "connection_error", err)
 		return nil, err
 	}
 	subscriptionID := session.SubscriptionID
@@ -381,7 +379,7 @@ func listMySQLServerVnetRules(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	op, err := client.ListByServer(ctx, resourceGroup, serverName)
 	if err != nil {
-		plugin.Logger(ctx).Error("azure_mysql_server.listMySQLServerVnetRules", "list", err)
+		plugin.Logger(ctx).Error("azure_mysql_server.listMySQLServerVnetRules", "api_error", err)
 		return nil, err
 	}
 
@@ -392,7 +390,7 @@ func listMySQLServerVnetRules(ctx context.Context, d *plugin.QueryData, h *plugi
 	for op.NotDone() {
 		err = op.NextWithContext(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("listMySQLServerVnetRules", "list_paging", err)
+			plugin.Logger(ctx).Error("azure_mysql_server.listMySQLServerVnetRules", "api_error_pagging", err)
 			return nil, err
 		}
 		vnetRules = append(vnetRules, op.Values()...)

--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -145,7 +145,7 @@ select
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
-where 
+where
    configurations ->> 'Name' = 'audit_log_enabled';
 ```
 
@@ -160,7 +160,7 @@ select
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
-where 
+where
    configurations ->'ConfigurationProperties' ->> 'value' = 'ON'
    and configurations ->> 'Name' = 'slow_query_log';
 ```
@@ -176,7 +176,20 @@ select
 from
   azure_mysql_server,
   jsonb_array_elements(server_configurations) as configurations
-where 
+where
    configurations ->'ConfigurationProperties' ->> 'value' = 'FILE'
    and configurations ->> 'Name' = 'log_output';
+```
+
+### Get VNET rules details of the server
+
+```sql
+select
+  name as server_name,
+  id as server_id,
+  rules -> 'properties' ->> 'ignoreMissingVnetServiceEndpoint' as ignore_missing_vnet_service_endpoint,
+  rules -> 'properties' ->> 'virtualNetworkSubnetId' as virtual_network_subnet_id
+from
+  azure_mysql_server,
+  jsonb_array_elements(vnet_rules) as rules;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/azure_mysql_server []

PRETEST: tests/azure_mysql_server

TEST: tests/azure_mysql_server
Running terraform
data.azurerm_client_config.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest34770]
azurerm_mysql_server.named_test_resource: Creating...
azurerm_mysql_server.named_test_resource: Still creating... [10s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [21s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [31s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [41s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [51s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m1s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m11s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m21s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m31s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m41s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [1m51s elapsed]
azurerm_mysql_server.named_test_resource: Still creating... [2m1s elapsed]
azurerm_mysql_server.named_test_resource: Creation complete after 2m9s [id=/subscriptions/********-****-****-****-************/resourceGroups/turbottest34770/providers/Microsoft.DBforMySQL/servers/turbottest34770]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

location = eastus
resource_aka = azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest34770/providers/Microsoft.DBforMySQL/servers/turbottest34770
resource_aka_lower = azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest34770/providers/microsoft.dbformysql/servers/turbottest34770
resource_id = /subscriptions/********-****-****-****-************/resourceGroups/turbottest34770/providers/Microsoft.DBforMySQL/servers/turbottest34770
resource_name = turbottest34770
server_fqdn = turbottest34770.mysql.database.azure.com
subscription_id = ********-****-****-****-************

Running SQL query: test-get-query.sql
[
  {
    "administrator_login": "mradministrator",
    "backup_retention_days": 7,
    "fully_qualified_domain_name": "turbottest34770.mysql.database.azure.com",
    "geo_redundant_backup": "Disabled",
    "infrastructure_encryption": "Disabled",
    "location": "eastus",
    "minimal_tls_version": "TLS1_2",
    "name": "turbottest34770",
    "public_network_access": "Enabled",
    "region": "eastus",
    "resource_group": "turbottest34770",
    "sku_capacity": 1,
    "sku_family": "Gen5",
    "sku_name": "B_Gen5_1",
    "sku_tier": "Basic",
    "ssl_enforcement": "Enabled",
    "storage_auto_grow": "Disabled",
    "storage_mb": 5120,
    "subscription_id": "********-****-****-****-************",
    "type": "Microsoft.DBforMySQL/servers",
    "version": "5.6"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/********-****-****-****-************/resourceGroups/turbottest34770/providers/Microsoft.DBforMySQL/servers/turbottest34770",
    "location": "eastus",
    "name": "turbottest34770"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/********-****-****-****-************/resourceGroups/turbottest34770/providers/Microsoft.DBforMySQL/servers/turbottest34770",
      "azure:///subscriptions/********-****-****-****-************/resourcegroups/turbottest34770/providers/microsoft.dbformysql/servers/turbottest34770"
    ],
    "name": "turbottest34770",
    "tags": {
      "name": "turbottest34770"
    },
    "title": "turbottest34770"
  }
]
✔ PASSED

POSTTEST: tests/azure_mysql_server

TEARDOWN: tests/azure_mysql_server

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select name, vnet_rules from azure_mysql_server
+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name    | vnet_rules                                                                                                                                                                                                                           |
+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| mysqlio | [{"properties":{"ignoreMissingVnetServiceEndpoint":false,"virtualNetworkSubnetId":"/subscriptions/00737495-000-4771-0000-0078439647893/resourceGroups/demo/providers/Microsoft.Network/virtualNetworks/demo-vnet/subnets/default"}}] |
+---------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>
