### PR TITLE
Avoid panic when ip_configuration data on firewall is null

### DIFF
--- a/azure/table_azure_firewall.go
+++ b/azure/table_azure_firewall.go
@@ -261,8 +261,8 @@ func ipConfigurationData(ctx context.Context, d *transform.TransformData) (inter
 	data := d.HydrateItem.(network.AzureFirewall)
 
 	var output []map[string]interface{}
-// Add a check for AzureFirewallPropertiesFormat.IPConfigurations data to ensure that
-// it is not null to avoid panic errors
+	// Add a check for AzureFirewallPropertiesFormat.IPConfigurations data to ensure that
+	// it is not null to avoid panic errors
 	if data.AzureFirewallPropertiesFormat.IPConfigurations != nil {
 		for _, firewall := range *data.AzureFirewallPropertiesFormat.IPConfigurations {
 			objectMap := make(map[string]interface{})

--- a/azure/table_azure_firewall.go
+++ b/azure/table_azure_firewall.go
@@ -261,6 +261,8 @@ func ipConfigurationData(ctx context.Context, d *transform.TransformData) (inter
 	data := d.HydrateItem.(network.AzureFirewall)
 
 	var output []map[string]interface{}
+// Add a check for AzureFirewallPropertiesFormat.IPConfigurations data to ensure that
+// it is not null to avoid panic errors
 	if data.AzureFirewallPropertiesFormat.IPConfigurations != nil {
 		for _, firewall := range *data.AzureFirewallPropertiesFormat.IPConfigurations {
 			objectMap := make(map[string]interface{})

--- a/azure/table_azure_firewall.go
+++ b/azure/table_azure_firewall.go
@@ -261,21 +261,24 @@ func ipConfigurationData(ctx context.Context, d *transform.TransformData) (inter
 	data := d.HydrateItem.(network.AzureFirewall)
 
 	var output []map[string]interface{}
-	for _, firewall := range *data.AzureFirewallPropertiesFormat.IPConfigurations {
-		objectMap := make(map[string]interface{})
-		if firewall.AzureFirewallIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
-			objectMap["privateIPAddress"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.PrivateIPAddress
+	if data.AzureFirewallPropertiesFormat.IPConfigurations != nil {
+		for _, firewall := range *data.AzureFirewallPropertiesFormat.IPConfigurations {
+			objectMap := make(map[string]interface{})
+			if firewall.AzureFirewallIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
+				objectMap["privateIPAddress"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.PrivateIPAddress
+			}
+			if firewall.AzureFirewallIPConfigurationPropertiesFormat.PublicIPAddress != nil {
+				objectMap["publicIPAddress"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.PublicIPAddress
+			}
+			if firewall.AzureFirewallIPConfigurationPropertiesFormat.Subnet != nil {
+				objectMap["subnet"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.Subnet
+			}
+			if firewall.AzureFirewallIPConfigurationPropertiesFormat.ProvisioningState != "" {
+				objectMap["provisioningState"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.ProvisioningState
+			}
+			output = append(output, objectMap)
 		}
-		if firewall.AzureFirewallIPConfigurationPropertiesFormat.PublicIPAddress != nil {
-			objectMap["publicIPAddress"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.PublicIPAddress
-		}
-		if firewall.AzureFirewallIPConfigurationPropertiesFormat.Subnet != nil {
-			objectMap["subnet"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.Subnet
-		}
-		if firewall.AzureFirewallIPConfigurationPropertiesFormat.ProvisioningState != "" {
-			objectMap["provisioningState"] = firewall.AzureFirewallIPConfigurationPropertiesFormat.ProvisioningState
-		}
-		output = append(output, objectMap)
+		return output, nil
 	}
-	return output, nil
+	return nil, nil
 }


### PR DESCRIPTION
When ipConfigurations data is null on azure firewall steampipe throwns an error:

```
   ERROR:  rpc error: code = Unknown desc = failed to populate column
'ip_configurations': rpc error: code = Internal desc = transform
ipConfigurationData failed with panic runtime error: invalid memory
address or nil pointer dereference
````

A json dump of the firewall resource shows:

```
  "ipConfigurations": null
```

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
