### PR TITLE
fix column name typo

### DIFF
--- a/azure/table_azure_compute_virtual_machine_scale_set_network_interface.go
+++ b/azure/table_azure_compute_virtual_machine_scale_set_network_interface.go
@@ -41,7 +41,7 @@ func tableAzureComputeVirtualMachineScaleSetNetworkInterface(_ context.Context) 
 				Transform:   transform.FromGo(),
 			},
 			{
-				Name:        "	",
+				Name:        "provisioning_state",
 				Description: "The provisioning state of the network interface resource. Possible values include: 'Succeeded', 'Updating', 'Deleting', 'Failed'.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromP(extractScaleSetNetworkInterfaceProperties, "ProvisioningState"),


### PR DESCRIPTION
fix typo in azure_compute_virtual_machine_scale_set_network_interface
