### PR TITLE
Fix tint.js to remove the unused `variablesTmp` variable

### DIFF
--- a/azure-test/tint.js
+++ b/azure-test/tint.js
@@ -384,7 +384,6 @@ const _runGraphqlQuery = function (test, query) {
   return new Promise((resolve, reject) => {
     try {
       var queryTmp = _renderToTmp(test, query.query);
-      var variablesTmp = _renderToTmp(test, query.variables, {});
       var expectedTmp = _renderToTmp(test, query.expected);
     } catch (e) {
       console.log(chalk.red(`Template Error: ${e.sourcePath}`));


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
