### PR TITLE
Add column `restore_parameters` to table `azure_cosmosdb_account`. Closes #593

### DIFF
--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -215,6 +215,12 @@ func tableAzureCosmosDBAccount(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.ReadLocations"),
 			},
 			{
+				Name:        "restore_parameters",
+				Description: "Parameters to indicate the information about the restore.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.RestoreParameters"),
+			},
+			{
 				Name:        "virtual_network_rules",
 				Description: "A list of Virtual Network ACL rules configured for the Cosmos DB account.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/azure_cosmosdb_account.md
+++ b/docs/tables/azure_cosmosdb_account.md
@@ -106,8 +106,8 @@ from
 ```sql
 select
   name,
-  restore_parameters -> 'restoreMode' as restore_mode,
-  restore_parameters -> 'restoreSource' as restore_source,
+  restore_parameters ->> 'restoreMode' as restore_mode,
+  restore_parameters ->> 'restoreSource' as restore_source,
   d ->> 'databaseName' as restored_database_name,
   c as restored_collection_name
 from

--- a/docs/tables/azure_cosmosdb_account.md
+++ b/docs/tables/azure_cosmosdb_account.md
@@ -113,5 +113,5 @@ select
 from
   azure_cosmosdb_account,
   jsonb_array_elements(restore_parameters -> 'databasesToRestore') d,
-  jsonb_array_elements_text(d -> 'collectionNames') c
+  jsonb_array_elements_text(d -> 'collectionNames') c;
 ```

--- a/docs/tables/azure_cosmosdb_account.md
+++ b/docs/tables/azure_cosmosdb_account.md
@@ -100,3 +100,18 @@ from
   azure_cosmosdb_account,
   jsonb_array_elements(private_endpoint_connections) as c;
 ```
+
+### Get details of accounts restored from backup
+
+```sql
+select
+  name,
+  restore_parameters -> 'restoreMode' as restore_mode,
+  restore_parameters -> 'restoreSource' as restore_source,
+  d ->> 'databaseName' as restored_database_name,
+  c as restored_collection_name
+from
+  azure_cosmosdb_account,
+  jsonb_array_elements(restore_parameters -> 'databasesToRestore') d,
+  jsonb_array_elements_text(d -> 'collectionNames') c
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  restore_parameters -> 'restoreMode' as restore_mode,
  restore_parameters -> 'restoreSource' as restore_source,
  d ->> 'databaseName' as restored_database_name,
  c as restored_collection_name
from
  azure_cosmosdb_account,
  jsonb_array_elements(restore_parameters -> 'databasesToRestore') d,
  jsonb_array_elements_text(d -> 'collectionNames') c;

+-------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+--------------------------+
| name              | restore_mode  | restore_source                                                                                                                                                        | restored_database_name | restored_collection_name |
+-------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+--------------------------+
| test-acc-restored | "PointInTime" | "/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/082cee20-9cf4-44bc-a107-447c9ce81ab5" | demo-db                | demo-coll1               |
+-------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+--------------------------+
```
</details>
