### PR TITLE
Fix error on fetching throughput settings

### DIFF
--- a/azure/table_azure_cosmosdb_mongo_collection.go
+++ b/azure/table_azure_cosmosdb_mongo_collection.go
@@ -341,10 +341,12 @@ func mapCollectionThroughputSettings(result documentdb.ThroughputSettingsGetResu
 				data.AutoscaleSettingsMaxThroughput = *result.Resource.AutoscaleSettings.MaxThroughput
 			}
 
-			if result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy != nil {
-				data.AutoscaleSettingsThroughputPolicy = documentdb.ThroughputPolicyResource{
-					IsEnabled:        result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IsEnabled,
-					IncrementPercent: result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IncrementPercent,
+			if result.Resource.AutoscaleSettings.AutoUpgradePolicy != nil {
+				if result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy != nil {
+					data.AutoscaleSettingsThroughputPolicy = documentdb.ThroughputPolicyResource{
+						IsEnabled:        result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IsEnabled,
+						IncrementPercent: result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IncrementPercent,
+					}
 				}
 			}
 

--- a/azure/table_azure_cosmosdb_mongo_database.go
+++ b/azure/table_azure_cosmosdb_mongo_database.go
@@ -288,10 +288,12 @@ func mapThroughputSettings(result documentdb.ThroughputSettingsGetResults) *Thro
 				data.AutoscaleSettingsMaxThroughput = *result.Resource.AutoscaleSettings.MaxThroughput
 			}
 
-			if result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy != nil {
-				data.AutoscaleSettingsThroughputPolicy = documentdb.ThroughputPolicyResource{
-					IsEnabled:        result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IsEnabled,
-					IncrementPercent: result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IncrementPercent,
+			if result.Resource.AutoscaleSettings.AutoUpgradePolicy != nil {
+				if result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy != nil {
+					data.AutoscaleSettingsThroughputPolicy = documentdb.ThroughputPolicyResource{
+						IsEnabled:        result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IsEnabled,
+						IncrementPercent: result.Resource.AutoscaleSettings.AutoUpgradePolicy.ThroughputPolicy.IncrementPercent,
+					}
 				}
 			}
 


### PR DESCRIPTION
The table rendering used to break when using the `default` Throughput settings and `ThroughputPolicy` was not set explicitly.

{
        "throughput_settings": {
        "AutoscaleSettingsMaxThroughput": 1000,
        "AutoscaleSettingsTargetMaxThroughput": 0,
        "AutoscaleSettingsThroughputPolicy": `{}`,
        "ID": `"/subscriptions/abcd7416-f95f-4771-bbb5- 529d4c76659c/resourceGroups/demo/providers/Microsoft.DocumentDB/databaseAccounts/demo-insight-acc/mongodbDatabases/test-db/throughputSettings/default"`,
        "Location": "",
        "Name": "Nlrk",
        "ResourceEtag": "",
        "ResourceMinimumThroughput": "1000",
        "ResourceOfferReplacePending": "",
        "ResourceRid": "",
        "ResourceThroughput": 100,
        "ResourceTs": 0,
        "Type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
       }
 }

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select throughput_settings from azure_cosmosdb_mongo_database
[
 {
  "throughput_settings": {
   "AutoscaleSettingsMaxThroughput": 1000,
   "AutoscaleSettingsTargetMaxThroughput": 0,
   "AutoscaleSettingsThroughputPolicy": {},
   "ID": "/subscriptions/abcd7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/demo/providers/Microsoft.DocumentDB/databaseAccounts/demo-insight-acc/mongodbDatabases/test-db/throughputSettings/default",
   "Location": "",
   "Name": "Nlrk",
   "ResourceEtag": "",
   "ResourceMinimumThroughput": "1000",
   "ResourceOfferReplacePending": "",
   "ResourceRid": "",
   "ResourceThroughput": 100,
   "ResourceTs": 0,
   "Type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
  }
 }
]
```
</details>
