### PR TITLE
Fixed intrusion_detection_mode returning always null in azure_firewall_policy table and extracted the FirewallPolicyPropertiesFormat to use other columns Closes #608

### DIFF
--- a/azure-test/tests/azure_firewall_policy/variables.tf
+++ b/azure-test/tests/azure_firewall_policy/variables.tf
@@ -13,8 +13,7 @@ variable "azure_environment" {
 
 variable "azure_subscription" {
   type    = string
-  default = "d46d7416-f95f-4771-bbb5-529d4c76659c"
-  # default     = "3510ae4d-530b-497d-8f30-53b9616fc6c1"
+  default     = "3510ae4d-530b-497d-8f30-53b9616fc6c1"
   description = "Azure subscription used for the test."
 }
 

--- a/azure/table_azure_firewall_policy.go
+++ b/azure/table_azure_firewall_policy.go
@@ -297,7 +297,7 @@ func extractAzureFirewallProperties(ctx context.Context, d *transform.TransformD
 		}
 		if firewall.FirewallPolicyPropertiesFormat.Sku != nil {
 			if firewall.FirewallPolicyPropertiesFormat.Sku.Tier != "" {
-				properties["SKUTire"] = firewall.FirewallPolicyPropertiesFormat.Sku.Tier
+				properties["SKUTier"] = firewall.FirewallPolicyPropertiesFormat.Sku.Tier
 			}
 		}
 	}

--- a/azure/table_azure_firewall_policy.go
+++ b/azure/table_azure_firewall_policy.go
@@ -64,7 +64,7 @@ func tableAzureFirewallPolicy(_ context.Context) *plugin.Table {
 				Name:        "sku_tier",
 				Description: "Tier of Firewall Policy. Possible values include: 'FirewallPolicySkuTierStandard', 'FirewallPolicySkuTierPremium'.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromP(extractAzureFirewallProperties, "SKUTire"),
+				Transform:   transform.FromP(extractAzureFirewallProperties, "SKUTier"),
 			},
 			{
 				Name:        "threat_intel_mode",


### PR DESCRIPTION
**Note:** If the firewall policy tier is `Premium` Policy, the data in the `intrusion_detection_mode` column will be there otherwise it will be remains null.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_firewall_policy []

PRETEST: tests/azure_firewall_policy

TEST: tests/azure_firewall_policy
Running terraform
data.azurerm_client_config.current: Reading...
data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MDZmZDQ2YjAtYTg2Ny00OWExLWE0ZjEtZjc3Njg0NjVjYWJhO3N1YnNjcmlwdGlvbklkPWQ0NmQ3NDE2LWY5NWYtNDc3MS1iYmI1LTUyOWQ0Yzc2NjU5Yzt0ZW5hbnRJZD1jZGZmZDcwOC03ZGEwLTRjZWEtYWJlYi0wYTRjMzM0ZDdmNjQ=]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_firewall_policy.named_test_resource will be created
  + resource "azurerm_firewall_policy" "named_test_resource" {
      + child_policies           = (known after apply)
      + firewalls                = (known after apply)
      + id                       = (known after apply)
      + location                 = "westus"
      + name                     = "turbottest73824"
      + resource_group_name      = "turbottest73824"
      + rule_collection_groups   = (known after apply)
      + sku                      = (known after apply)
      + tags                     = {
          + "name" = "turbottest73824"
        }
      + threat_intelligence_mode = "Alert"
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westus"
      + name     = "turbottest73824"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest73824"
  + subscription_id    = "da34234r-f95f-4771-bbb5-34fewr45323fg"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 5s [id=/subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824]
azurerm_firewall_policy.named_test_resource: Creating...
azurerm_firewall_policy.named_test_resource: Still creating... [10s elapsed]
azurerm_firewall_policy.named_test_resource: Creation complete after 18s [id=/subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824/providers/Microsoft.Network/firewallPolicies/turbottest73824]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 30, in data "null_data_source" "resource":
  30: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824/providers/Microsoft.Network/firewallPolicies/turbottest73824"
resource_aka_lower = "azure:///subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourcegroups/turbottest73824/providers/microsoft.network/firewallpolicies/turbottest73824"
resource_id = "/subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824/providers/Microsoft.Network/firewallPolicies/turbottest73824"
resource_name = "turbottest73824"
subscription_id = "da34234r-f95f-4771-bbb5-34fewr45323fg"

Running SQL query: test-get-query.sql
[
  {
    "id": "/subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824/providers/Microsoft.Network/firewallPolicies/turbottest73824",
    "name": "turbottest73824",
    "provisioning_state": "Succeeded",
    "resource_group": "turbottest73824",
    "type": "Microsoft.Network/FirewallPolicies"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824/providers/Microsoft.Network/firewallPolicies/turbottest73824",
    "name": "turbottest73824"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourceGroups/turbottest73824/providers/Microsoft.Network/firewallPolicies/turbottest73824",
      "azure:///subscriptions/da34234r-f95f-4771-bbb5-34fewr45323fg/resourcegroups/turbottest73824/providers/microsoft.network/firewallpolicies/turbottest73824"
    ],
    "name": "turbottest73824",
    "tags": {
      "name": "turbottest73824"
    },
    "title": "turbottest73824"
  }
]
✔ PASSED

POSTTEST: tests/azure_firewall_policy

TEARDOWN: tests/azure_firewall_policy

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select provisioning_state, intrusion_detection_mode, sku_tier, threat_intel_mode, base_policy, child_policies, dns_settings, firewalls, intrusion_detection_configuration, rule_collection_groups, threat_intel_whitelist_ip_addresses, threat_intel_whitelist_fqdns, transport_security_certificate_authority from azure_firewall_policy
+--------------------+--------------------------+----------+-------------------+-------------+----------------+--------------+-----------+-----------------------------------+------------------------+---->
| provisioning_state | intrusion_detection_mode | sku_tier | threat_intel_mode | base_policy | child_policies | dns_settings | firewalls | intrusion_detection_configuration | rule_collection_groups | thr>
+--------------------+--------------------------+----------+-------------------+-------------+----------------+--------------+-----------+-----------------------------------+------------------------+---->
| Succeeded          | Alert                    | Premium  | Alert             | <null>      | []             | <null>       | []        | <null>                            | []                     | [] >
| Succeeded          | <null>                   | Basic    | Alert             | <null>      | []             | <null>       | []        | <null>                            | []                     | [] >
| Succeeded          | <null>                   | Standard | Alert             | <null>      | []             | <null>       | []        | <null>                            | []                     | [] >
+--------------------+--------------------------+----------+-------------------+-------------+----------------+--------------+-----------+-----------------------------------+------------------------+----
```
</details>
