### PR TITLE
Add table service logging details in table azure_storage_account Closes #612

### DIFF
--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/monitor/mgmt/insights"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-04-01/storage"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/queue/queues"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/accounts"

--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -296,7 +296,7 @@ func tableAzureStorageAccount(_ context.Context) *plugin.Table {
 			{
 				Name:        "table_logging_retention_policy",
 				Description: "The retention policy.",
-				Type:        proto.ColumnType_STRING,
+				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAzureStorageAccountTableProperties,
 				Transform:   transform.FromField("Logging.RetentionPolicy"),
 			},

--- a/docs/tables/azure_storage_account.md
+++ b/docs/tables/azure_storage_account.md
@@ -17,7 +17,6 @@ from
   azure_storage_account;
 ```
 
-
 ### List storage accounts with versioning disabled
 
 ```sql
@@ -29,7 +28,6 @@ from
 where
   not blob_versioning_enabled;
 ```
-
 
 ### List storage accounts with blob soft delete disabled
 
@@ -44,7 +42,6 @@ where
   not blob_soft_delete_enabled;
 ```
 
-
 ### List storage accounts that allow blob public access
 
 ```sql
@@ -57,7 +54,6 @@ where
   allow_blob_public_access;
 ```
 
-
 ### List storage accounts with encryption in transit disabled
 
 ```sql
@@ -69,7 +65,6 @@ from
 where
   not enable_https_traffic_only;
 ```
-
 
 ### List storage accounts that do not have a cannot-delete lock
 
@@ -89,7 +84,6 @@ where
   );
 ```
 
-
 ### List storage accounts with queue logging enabled
 
 ```sql
@@ -105,7 +99,6 @@ where
   and queue_logging_read
   and queue_logging_write;
 ```
-
 
 ### List storage accounts without lifecycle
 
@@ -143,4 +136,27 @@ where
   status_of_primary = 'available'
   and status_of_secondary != 'available'
   and sku_name in ('Standard_GRS', 'Standard_RAGRS')
+```
+
+### Get table properties of storage accounts
+
+```sql
+select
+  name,
+  table_properties -> 'Cors' as table_logging_cors,
+  table_properties -> 'Logging' -> 'Read' as table_logging_read,
+  table_properties -> 'Logging' -> 'Write' as table_logging_write,
+  table_properties -> 'Logging' -> 'Delete' as table_logging_delete,
+  table_properties -> 'Logging' ->> 'Version' as table_logging_version,
+  table_properties -> 'Logging' -> 'RetentionPolicy' as table_logging_retention_policy,
+  table_properties -> 'HourMetrics' -> 'Enabled' as table_hour_metrics_enabled,
+  table_properties -> 'HourMetrics' -> 'IncludeAPIs' as table_hour_metrics_include_ap_is,
+  table_properties -> 'HourMetrics' ->> 'Version' as table_hour_metrics_version,
+  table_properties -> 'HourMetrics' -> 'RetentionPolicy' as table_hour_metrics_retention_policy,
+  table_properties -> 'MinuteMetrics' -> 'Enabled' as table_minute_metrics_enabled,
+  table_properties -> 'MinuteMetrics' -> 'IncludeAPIs' as table_minute_metrics_include_ap_is,
+  table_properties -> 'MinuteMetrics' ->> 'Version' as table_minute_metrics_version,
+  table_properties -> 'MinuteMetrics' -> 'RetentionPolicy' as table_minute_metrics_retention_policy
+from
+  azure_storage_account;
 ```

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,9 @@ require (
 	cloud.google.com/go v0.65.0 // indirect
 	cloud.google.com/go/storage v1.10.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.0.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.10 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
@@ -37,6 +40,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
@@ -83,6 +87,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pegasus-kv/thrift v0.13.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
@@ -92,6 +97,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/tkrajina/go-reflector v0.5.6 // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
@@ -125,5 +131,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.25.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,12 @@ github.com/Azure/azure-sdk-for-go v45.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v47.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v58.0.0+incompatible h1:Cw16jiP4dI+CK761aq44ol4RV5dUiIIXky1+EKpoiVM=
 github.com/Azure/azure-sdk-for-go v58.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
+github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.0.1 h1:bFa9IcjvrCber6gGgDAUZ+I2bO8J7s8JxXmu9fhi2ss=
+github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.0.1/go.mod h1:l3wvZkG9oW07GLBW5Cd0WwG5asOfJ8aqE8raUvNzLpk=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/Azure/azure-storage-blob-go v0.12.0 h1:7bFXA1QB+lOK2/ASWHhp6/vnxjaeeZq6t8w1Jyp0Iaw=
 github.com/Azure/azure-storage-blob-go v0.12.0/go.mod h1:A0u4VjtpgZJ7Y7um/+ix2DHBuEKFC6sEIlj0xc13a4Q=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
@@ -449,6 +455,8 @@ github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b h1:wJSBFlabo96ySl
 github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b/go.mod h1:YIyOMT17IKD8FbLO8RfCJZd2qAZiOnIfuYePIeESwWc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -457,7 +465,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQSepKdE=
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/tombuildsstuff/giovanni v0.15.1 h1:CVRaLOJ7C/eercCrKIsarfJ4SZoGMdBL9Q2deFDUXco=


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/azure_storage_account []

PRETEST: tests/azure_storage_account

TEST: tests/azure_storage_account
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "turbottest33803"
      + tags     = (known after apply)
    }

  # azurerm_storage_account.named_test_resource will be created
  + resource "azurerm_storage_account" "named_test_resource" {
      + access_tier                       = "Cool"
      + account_encryption_source         = "Microsoft.Storage"
      + account_kind                      = "StorageV2"
      + account_replication_type          = "LRS"
      + account_tier                      = "Standard"
      + account_type                      = (known after apply)
      + enable_advanced_threat_protection = false
      + enable_blob_encryption            = true
      + enable_file_encryption            = true
      + id                                = (known after apply)
      + is_hns_enabled                    = false
      + location                          = "eastus"
      + name                              = "turbottest33803"
      + primary_access_key                = (sensitive value)
      + primary_blob_connection_string    = (sensitive value)
      + primary_blob_endpoint             = (known after apply)
      + primary_blob_host                 = (known after apply)
      + primary_connection_string         = (sensitive value)
      + primary_dfs_endpoint              = (known after apply)
      + primary_dfs_host                  = (known after apply)
      + primary_file_endpoint             = (known after apply)
      + primary_file_host                 = (known after apply)
      + primary_location                  = (known after apply)
      + primary_queue_endpoint            = (known after apply)
      + primary_queue_host                = (known after apply)
      + primary_table_endpoint            = (known after apply)
      + primary_table_host                = (known after apply)
      + primary_web_endpoint              = (known after apply)
      + primary_web_host                  = (known after apply)
      + resource_group_name               = "turbottest33803"
      + secondary_access_key              = (sensitive value)
      + secondary_blob_connection_string  = (sensitive value)
      + secondary_blob_endpoint           = (known after apply)
      + secondary_blob_host               = (known after apply)
      + secondary_connection_string       = (sensitive value)
      + secondary_dfs_endpoint            = (known after apply)
      + secondary_dfs_host                = (known after apply)
      + secondary_file_endpoint           = (known after apply)
      + secondary_file_host               = (known after apply)
      + secondary_location                = (known after apply)
      + secondary_queue_endpoint          = (known after apply)
      + secondary_queue_host              = (known after apply)
      + secondary_table_endpoint          = (known after apply)
      + secondary_table_host              = (known after apply)
      + secondary_web_endpoint            = (known after apply)
      + secondary_web_host                = (known after apply)
      + tags                              = {
          + "name" = "turbottest33803"
        }

      + identity {
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = (known after apply)
        }

      + network_rules {
          + bypass                     = (known after apply)
          + default_action             = (known after apply)
          + ip_rules                   = (known after apply)
          + virtual_network_subnet_ids = (known after apply)
        }

      + queue_properties {
          + cors_rule {
              + allowed_headers    = (known after apply)
              + allowed_methods    = (known after apply)
              + allowed_origins    = (known after apply)
              + exposed_headers    = (known after apply)
              + max_age_in_seconds = (known after apply)
            }

          + hour_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }

          + logging {
              + delete                = (known after apply)
              + read                  = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
              + write                 = (known after apply)
            }

          + minute_metrics {
              + enabled               = (known after apply)
              + include_apis          = (known after apply)
              + retention_policy_days = (known after apply)
              + version               = (known after apply)
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest33803"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Creation complete after 2s [id=/subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803]
azurerm_storage_account.named_test_resource: Creating...
azurerm_storage_account.named_test_resource: Still creating... [10s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [20s elapsed]
azurerm_storage_account.named_test_resource: Still creating... [30s elapsed]
azurerm_storage_account.named_test_resource: Creation complete after 30s [id=/subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803]

Warning: Version constraints inside provider configuration blocks are deprecated

  on variables.tf line 22, in provider "azurerm":
  22:   version         = "=1.36.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803"
resource_aka_lower = "azure:///subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourcegroups/turbottest33803/providers/microsoft.storage/storageaccounts/turbottest33803"
resource_id = "/subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803"
resource_name = "turbottest33803"

Running SQL query: test-get-query.sql
[
  {
    "access_tier": "Cool",
    "id": "/subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
    "kind": "StorageV2",
    "name": "turbottest33803",
    "sku_name": "Standard_LRS",
    "sku_tier": "Standard"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_tier": "Cool",
    "id": "/subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
    "name": "turbottest33803"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "/subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
    "name": "turbottest33803"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "azure:///subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourceGroups/turbottest33803/providers/Microsoft.Storage/storageAccounts/turbottest33803",
      "azure:///subscriptions/43297rwq-f95f-4771-bbb5-529d4c43297r/resourcegroups/turbottest33803/providers/microsoft.storage/storageaccounts/turbottest33803"
    ],
    "tags": {
      "name": "turbottest33803"
    },
    "title": "turbottest33803"
  }
]
✔ PASSED

POSTTEST: tests/azure_storage_account

TEARDOWN: tests/azure_storage_account

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(table_properties) from azure_storage_account
+------------------------+------------------------------+
| name                   | jsonb_pretty                 |
+------------------------+------------------------------+
| testimmutablecontainer | {                            |
|                        |     "Cors": null,            |
|                        |     "Logging": {             |
|                        |         "Read": true,        |
|                        |         "Write": true,       |
|                        |         "Delete": true,      |
|                        |         "Version": "1.0",    |
|                        |         "RetentionPolicy": { |
|                        |             "Days": null,    |
|                        |             "Enabled": false |
|                        |         }                    |
|                        |     },                       |
|                        |     "HourMetrics": {         |
|                        |         "Enabled": true,     |
|                        |         "Version": "1.0",    |
|                        |         "IncludeAPIs": true, |
|                        |         "RetentionPolicy": { |
|                        |             "Days": 7,       |
|                        |             "Enabled": true  |
|                        |         }                    |
|                        |     },                       |
|                        |     "MinuteMetrics": {       |
|                        |         "Enabled": false,    |
|                        |         "Version": "1.0",    |
|                        |         "IncludeAPIs": null, |
|                        |         "RetentionPolicy": { |
|                        |             "Days": null,    |
|                        |             "Enabled": false |
|                        |         }                    |
|                        |     }                        |
|                        | }                            |
+------------------------+------------------------------+
```
</details>
