### PR TITLE
Add table azure_kubernetes_service_version Closes #606

### DIFF
--- a/azure/plugin.go
+++ b/azure/plugin.go
@@ -102,6 +102,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"azure_key_vault_managed_hardware_security_module":            tableAzureKeyVaultManagedHardwareSecurityModule(ctx),
 			"azure_key_vault_secret":                                      tableAzureKeyVaultSecret(ctx),
 			"azure_kubernetes_cluster":                                    tableAzureKubernetesCluster(ctx),
+			"azure_kubernetes_service_version":                            tableAzureAKSOrchestractor(ctx),
 			"azure_kusto_cluster":                                         tableAzureKustoCluster(ctx),
 			"azure_lb":                                                    tableAzureLoadBalancer(ctx),
 			"azure_lb_backend_address_pool":                               tableAzureLoadBalancerBackendAddressPool(ctx),

--- a/azure/table_azure_kubernetes_service_version.go
+++ b/azure/table_azure_kubernetes_service_version.go
@@ -18,7 +18,6 @@ func tableAzureAKSOrchestractor(_ context.Context) *plugin.Table {
 		Description: "Azure Kubernetes Service Version",
 		List: &plugin.ListConfig{
 			Hydrate: listAKSOrchestractors,
-			// KeyColumns: plugin.AllColumns([]string{"region", "resource_type"}),
 			KeyColumns: plugin.KeyColumnSlice{
 				{
 					Name:    "location",

--- a/azure/table_azure_kubernetes_service_version.go
+++ b/azure/table_azure_kubernetes_service_version.go
@@ -21,7 +21,7 @@ func tableAzureAKSOrchestractor(_ context.Context) *plugin.Table {
 			// KeyColumns: plugin.AllColumns([]string{"region", "resource_type"}),
 			KeyColumns: plugin.KeyColumnSlice{
 				{
-					Name:    "region",
+					Name:    "location",
 					Require: plugin.Required,
 				},
 				{
@@ -95,10 +95,10 @@ func tableAzureAKSOrchestractor(_ context.Context) *plugin.Table {
 
 			// Azure standard columns
 			{
-				Name:        "region",
+				Name:        "location",
 				Description: ColumnDescriptionRegion,
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromQual("region"),
+				Transform:   transform.FromQual("location"),
 			},
 		}),
 	}
@@ -126,7 +126,7 @@ type OrchestratorInfo struct {
 //// LIST FUNCTION
 
 func listAKSOrchestractors(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	region := d.EqualsQualString("region")
+	location := d.EqualsQualString("location")
 	resourceType := d.EqualsQualString("resource_type")
 
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
@@ -140,7 +140,7 @@ func listAKSOrchestractors(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	containerserviceClient := containerservice.NewContainerServicesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	containerserviceClient.Authorizer = session.Authorizer
 
-	result, err := containerserviceClient.ListOrchestrators(ctx, region, resourceType)
+	result, err := containerserviceClient.ListOrchestrators(ctx, location, resourceType)
 	if err != nil {
 		plugin.Logger(ctx).Error("azure_kubernetes_service_version.listAKSOrchestractors", "api_error", err)
 		return nil, err

--- a/azure/table_azure_kubernetes_service_version.go
+++ b/azure/table_azure_kubernetes_service_version.go
@@ -128,6 +128,11 @@ func listAKSOrchestractors(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	location := d.EqualsQualString("location")
 	resourceType := d.EqualsQualString("resource_type")
 
+	// Empty Check
+	if location == "" {
+		return nil, nil
+	}
+
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
 	if err != nil {
 		plugin.Logger(ctx).Error("azure_kubernetes_service_version.listAKSOrchestractors", "session_error", err)

--- a/azure/table_azure_kubernetes_service_version.go
+++ b/azure/table_azure_kubernetes_service_version.go
@@ -1,0 +1,168 @@
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-09-01/containerservice"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+//// TABLE DEFINITION ////
+
+func tableAzureAKSOrchestractor(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "azure_kubernetes_service_version",
+		Description: "Azure Kubernetes Service Version",
+		List: &plugin.ListConfig{
+			Hydrate: listAKSOrchestractors,
+			// KeyColumns: plugin.AllColumns([]string{"region", "resource_type"}),
+			KeyColumns: plugin.KeyColumnSlice{
+				{
+					Name:    "region",
+					Require: plugin.Required,
+				},
+				{
+					Name:    "resource_type",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		Columns: azureColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Type:        proto.ColumnType_STRING,
+				Description: "Name of the orchestrator version profile list result.",
+			},
+			{
+				Name:        "id",
+				Description: "Id of the orchestrator version profile list result.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromGo(),
+			},
+			{
+				Name:        "type",
+				Description: "Type of the orchestrator version profile list result.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "orchestrator_type",
+				Description: "The orchestrator type.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "orchestrator_version",
+				Description: "Orchestrator version (major, minor, patch).",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "default",
+				Description: "Installed by default if version is not specified.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "is_preview",
+				Description: "Whether Kubernetes version is currently in preview.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "resource_type",
+				Description: "Whether Kubernetes version is currently in preview.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("resource_type"),
+			},
+			{
+				Name:        "upgrades",
+				Description: "The list of available upgrade versions.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ID").Transform(idToAkas),
+			},
+
+			// Azure standard columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("region"),
+			},
+		}),
+	}
+}
+
+type OrchestratorInfo struct {
+	// ID - READ-ONLY; Id of the orchestrator version profile list result.
+	ID *string `json:"id,omitempty"`
+	// Name - READ-ONLY; Name of the orchestrator version profile list result.
+	Name *string `json:"name,omitempty"`
+	// Type - READ-ONLY; Type of the orchestrator version profile list result.
+	Type *string `json:"type,omitempty"`
+	// OrchestratorType - Orchestrator type.
+	OrchestratorType *string `json:"orchestratorType,omitempty"`
+	// OrchestratorVersion - Orchestrator version (major, minor, patch).
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	// Default - Installed by default if version is not specified.
+	Default *bool `json:"default,omitempty"`
+	// IsPreview - Whether Kubernetes version is currently in preview.
+	IsPreview *bool `json:"isPreview,omitempty"`
+	// Upgrades - The list of available upgrade versions.
+	Upgrades *[]containerservice.OrchestratorProfile `json:"upgrades,omitempty"`
+}
+
+//// LIST FUNCTION
+
+func listAKSOrchestractors(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	region := d.EqualsQualString("region")
+	resourceType := d.EqualsQualString("resource_type")
+
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_kubernetes_service_version.listAKSOrchestractors", "session_error", err)
+		return nil, err
+	}
+
+	subscriptionID := session.SubscriptionID
+
+	containerserviceClient := containerservice.NewContainerServicesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+	containerserviceClient.Authorizer = session.Authorizer
+
+	result, err := containerserviceClient.ListOrchestrators(ctx, region, resourceType)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_kubernetes_service_version.listAKSOrchestractors", "api_error", err)
+		return nil, err
+	}
+
+	for _, op := range *result.Orchestrators {
+		d.StreamListItem(ctx, &OrchestratorInfo{
+			ID:                  result.ID,
+			Name:                result.Name,
+			Type:                result.Type,
+			OrchestratorType:    op.OrchestratorType,
+			OrchestratorVersion: op.OrchestratorVersion,
+			Default:             op.Default,
+			IsPreview:           op.IsPreview,
+			Upgrades:            op.Upgrades,
+		})
+		// Check if context has been cancelled or if the limit has been hit (if specified)
+		// if there is a limit, it will return the number of rows required to reach this limit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	return nil, err
+}

--- a/azure/table_azure_kubernetes_service_version.go
+++ b/azure/table_azure_kubernetes_service_version.go
@@ -37,7 +37,7 @@ func tableAzureAKSOrchestractor(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "id",
-				Description: "Id of the orchestrator version profile list result.",
+				Description: "ID of the orchestrator version profile list result.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromGo(),
 			},

--- a/docs/tables/azure_kubernetes_service_version.md
+++ b/docs/tables/azure_kubernetes_service_version.md
@@ -2,7 +2,7 @@
 
 Azure AKS (Azure Kubernetes Service) orchestrator is a managed container orchestration service provided by Microsoft Azure. It simplifies the deployment, management, and scaling of containerized applications using Kubernetes. AKS allows you to deploy and manage containerized applications without the need to manage the underlying infrastructure. It provides automated Kubernetes upgrades, built-in monitoring and diagnostics, and seamless integration with other Azure services. AKS enables developers and DevOps teams to focus on application development and deployment, while Azure takes care of the underlying Kubernetes infrastructure.
 
-**Note:** You must need to pass the `location` in where clause to query this table.
+**Note:** You need to pass the `location` in the where clause to query this table.
 
 ## Examples
 

--- a/docs/tables/azure_kubernetes_service_version.md
+++ b/docs/tables/azure_kubernetes_service_version.md
@@ -2,7 +2,7 @@
 
 Azure AKS (Azure Kubernetes Service) orchestrator is a managed container orchestration service provided by Microsoft Azure. It simplifies the deployment, management, and scaling of containerized applications using Kubernetes. AKS allows you to deploy and manage containerized applications without the need to manage the underlying infrastructure. It provides automated Kubernetes upgrades, built-in monitoring and diagnostics, and seamless integration with other Azure services. AKS enables developers and DevOps teams to focus on application development and deployment, while Azure takes care of the underlying Kubernetes infrastructure.
 
-**Note:** You must need to pass the `region` in where clause to query this table.
+**Note:** You must need to pass the `location` in where clause to query this table.
 
 ## Examples
 
@@ -18,7 +18,7 @@ select
 from
   azure_kubernetes_service_version
 where
-  region = 'eastus2';
+  location = 'eastus2';
 ```
 
 ### List major kubernetes versions
@@ -34,7 +34,7 @@ from
 where
   orchestrator_version = 'major'
 and
-  region = 'eastus2';
+  location = 'eastus2';
 ```
 
 ### List kubernetes orchestrator type
@@ -51,7 +51,7 @@ from
 where
   orchestrator_type = 'Kubernetes'
 and
-  region = 'eastus2';
+  location = 'eastus2';
 ```
 
 ### List kubernetes versions that are not in preview
@@ -68,7 +68,7 @@ from
 where
   not is_preview
 and
-  region = 'eastus2';
+  location = 'eastus2';
 ```
 
 ### Get upgrade details of each kubernetes version
@@ -83,5 +83,5 @@ from
   azure_kubernetes_service_version,
   jsonb_array_elements(upgrades) as u
 where
-  region = 'eastus2';
+  location = 'eastus2';
 ```

--- a/docs/tables/azure_kubernetes_service_version.md
+++ b/docs/tables/azure_kubernetes_service_version.md
@@ -1,0 +1,87 @@
+# Table: azure_kubernetes_service_version
+
+Azure AKS (Azure Kubernetes Service) orchestrator is a managed container orchestration service provided by Microsoft Azure. It simplifies the deployment, management, and scaling of containerized applications using Kubernetes. AKS allows you to deploy and manage containerized applications without the need to manage the underlying infrastructure. It provides automated Kubernetes upgrades, built-in monitoring and diagnostics, and seamless integration with other Azure services. AKS enables developers and DevOps teams to focus on application development and deployment, while Azure takes care of the underlying Kubernetes infrastructure.
+
+**Note:** You must need to pass the `region` in where clause to query this table.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  type,
+  orchestrator_type,
+  orchestrator_version
+from
+  azure_kubernetes_service_version
+where
+  region = 'eastus2';
+```
+
+### List major kubernetes versions
+
+```sql
+select
+  name,
+  id,
+  orchestrator_type,
+  orchestrator_version
+from
+  azure_kubernetes_service_version
+where
+  orchestrator_version = 'major'
+and
+  region = 'eastus2';
+```
+
+### List kubernetes orchestrator type
+
+```sql
+select
+  name,
+  id,
+  type,
+  orchestrator_type,
+  is_preview
+from
+  azure_kubernetes_service_version
+where
+  orchestrator_type = 'Kubernetes'
+and
+  region = 'eastus2';
+```
+
+### List kubernetes versions that are not in preview
+
+```sql
+select
+  name,
+  id,
+  orchestrator_type,
+  orchestrator_version,
+  is_preview
+from
+  azure_kubernetes_service_version
+where
+  not is_preview
+and
+  region = 'eastus2';
+```
+
+### Get upgrade details of each kubernetes version
+
+```sql
+select
+  name,
+  u ->> 'orchestratorType' as orchestrator_type,
+  u ->> 'orchestratorVersion' as orchestrator_version,
+  u ->> 'isPreview' as is_preview
+from
+  azure_kubernetes_service_version,
+  jsonb_array_elements(upgrades) as u
+where
+  region = 'eastus2';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  type,
  orchestrator_type,
  orchestrator_version
from
  azure_kubernetes_service_version
where
  region = 'eastus2';
+---------+--------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------+---------------->
| name    | id                                                                                                                       | type                                               | orchestrator_ty>
+---------+--------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------+---------------->
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
| default | /subscriptions/g33456tr-f95f-4771-bbb5-529d4c345633/providers/Microsoft.ContainerService/locations/eastus2/orchestrators | Microsoft.ContainerService/locations/orchestrators | Kubernetes     >
+---------+--------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------+---------------->

```
</details>
