### PR TITLE
Add identity column to azure_kusto_cluster table closes #647

### DIFF
--- a/azure/table_azure_kusto_cluster.go
+++ b/azure/table_azure_kusto_cluster.go
@@ -132,6 +132,11 @@ func tableAzureKustoCluster(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("ClusterProperties.URI"),
 			},
 			{
+				Name:        "identity",
+				Description: "The identity of the cluster, if configured.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "language_extensions",
 				Description: "List of the cluster's language extensions.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/azure_kusto_cluster.md
+++ b/docs/tables/azure_kusto_cluster.md
@@ -45,3 +45,16 @@ from
 where
   state = 'Running';
 ```
+
+### List the kusto clusters with system-assigned identity
+
+```sql
+select
+  name,
+  id,
+  state
+from
+  azure_kusto_cluster
+where
+  identity ->> 'type' = 'SystemAssigned';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select
  name,
  id,
  state
from
  azure_kusto_cluster
where
  identity ->> 'type' = 'SystemAssigned';
+--------------+------------------------------------------------------------------------------------------------------------------------------------------------+----------+
| name         | id                                                                                                                                             | state    |
+--------------+------------------------------------------------------------------------------------------------------------------------------------------------+----------+
| cluster-test | /subscriptions/11111111-f95f-4771-1111-111111111111/resourceGroups/kp-test-k8-compliance_group/providers/Microsoft.Kusto/Clusters/cluster-test | Creating |
+--------------+------------------------------------------------------------------------------------------------------------------------------------------------+----------+
```
</details>
