### PR TITLE
Fix the GetConfig of azure_app_service_web_app_slot table to correctly return data instead of an empty row

### DIFF
--- a/azure/table_azure_app_service_web_app_slot.go
+++ b/azure/table_azure_app_service_web_app_slot.go
@@ -40,6 +40,7 @@ func tableAzureAppServiceWebAppSlot(_ context.Context) *plugin.Table {
 				Name:        "name",
 				Description: "Resource Name.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name").Transform(lastPathElement),
 			},
 			{
 				Name:        "app_name",
@@ -438,20 +439,11 @@ func getAppServiceWebAppSlot(ctx context.Context, d *plugin.QueryData, h *plugin
 
 func getConfigurationSlot(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Debug("getConfigurationSlot")
-	var appName, resourceGroupName, slotName string
-	if h.Item != nil {
-		data := h.Item.(*SlotInfo)
-		appName = *data.AppName
-		slotName = *data.Name
-		resourceGroupName = *data.SiteProperties.ResourceGroup
-	} else {
-		return nil, nil
-	}
 
-	// Restrict the API call for other apps if the app name is specified in the query paramater
-	if d.EqualsQualString("app_name") != "" && d.EqualsQualString("app_name") != appName {
-		return nil, nil
-	}
+	data := h.Item.(*SlotInfo)
+	appName := *data.AppName
+	slotName := *data.Name
+	resourceGroupName := *data.SiteProperties.ResourceGroup
 
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
 	if err != nil {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select name,app_name, resource_group, site_config_resource from azure_app_service_web_app_slot where name = 'slot-1' and app_name = 'web-app-test-mr' and resource_group = 'demo'
[
 {
  "app_name": "web-app-test-mr",
  "name": "slot-1",
  "resource_group": "demo",
  "site_config_resource": {
   "alwaysOn": false,
   "appCommandLine": "",
   "autoHealEnabled": false,
   "defaultDocuments": [
    "Default.htm",
    "Default.html",
    "Default.asp",
    "index.htm",
    "index.html",
    "iisstart.htm",
    "default.aspx",
    "index.php",
    "hostingstart.html"
   ],
   "detailedErrorLoggingEnabled": false,
   "experiments": {
    "rampUpRules": []
   },
   "ftpsState": "FtpsOnly",
   "http20Enabled": false,
   "httpLoggingEnabled": false,
   "ipSecurityRestrictions": [
    {
     "action": "Allow",
     "description": "Allow all access",
     "ipAddress": "Any",
     "name": "Allow all",
     "priority": 2147483647
    }
   ],
   "linuxFxVersion": "NODE|18-lts",
   "loadBalancing": "LeastRequests",
   "localMySqlEnabled": false,
   "logsDirectorySizeLimit": 35,
   "managedPipelineMode": "Integrated",
   "minTlsVersion": "1.2",
   "netFrameworkVersion": "v4.0",
   "nodeVersion": "",
   "numberOfWorkers": 1,
   "phpVersion": "",
   "powerShellVersion": "",
   "preWarmedInstanceCount": 0,
   "publishingUsername": "$web-app-test-mr__slot-1",
   "pythonVersion": "",
   "remoteDebuggingEnabled": false,
   "remoteDebuggingVersion": "VS2019",
   "requestTracingEnabled": false,
   "scmIpSecurityRestrictions": [
    {
     "action": "Allow",
     "description": "Allow all access",
     "ipAddress": "Any",
     "name": "Allow all",
     "priority": 2147483647
    }
   ],
   "scmIpSecurityRestrictionsUseMain": false,
   "scmMinTlsVersion": "1.2",
   "scmType": "None",
   "use32BitWorkerProcess": true,
   "virtualApplications": [
    {
     "physicalPath": "site\\wwwroot",
     "preloadEnabled": false,
     "virtualPath": "/"
    }
   ],
   "vnetName": "",
   "vnetPrivatePortsCount": 0,
   "vnetRouteAllEnabled": false,
   "webSocketsEnabled": false
  }
 }
]

```
</details>
