### PR TITLE
Add server_security_alert_policy column to azure_mysql_server table closes #649

### DIFF
--- a/docs/tables/azure_mysql_server.md
+++ b/docs/tables/azure_mysql_server.md
@@ -193,3 +193,18 @@ from
   azure_mysql_server,
   jsonb_array_elements(vnet_rules) as rules;
 ```
+
+### Get the security alert policy for a particular server
+
+```sql
+select
+  name,
+  id,
+  type,
+  server_security_alert_policy
+from
+  azure_mysql_server
+where
+  resource_group = 'demo'
+  and name = 'server-test-for-pr';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select
  name,
  id,
  type,
  server_security_alert_policy
from
  azure_mysql_server
where
  resource_group = 'demo'
  and name = 'server-test-for-pr';
[
 {
  "id": "/subscriptions/d46d7416-1111-4771-1111-529d4c11111v/resourceGroups/demo/providers/Microsoft.DBforMySQL/servers/server-test-for-pr",
  "name": "server-test-for-pr",
  "server_security_alert_policy": {
   "disabledAlerts": [
    ""
   ],
   "emailAccountAdmins": false,
   "emailAddresses": [
    ""
   ],
   "retentionDays": 0,
   "state": "Enabled",
   "storageAccountAccessKey": "",
   "storageEndpoint": ""
  },
  "type": "Microsoft.DBforMySQL/servers"
 }
]

```
</details>
