### PR TITLE
Add table azure_alert_management Closes #665

### DIFF
--- a/azure/plugin.go
+++ b/azure/plugin.go
@@ -31,6 +31,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"azure_ad_group":                                              tableAzureAdGroup(ctx),
 			"azure_ad_service_principal":                                  tableAzureAdServicePrincipal(ctx),
 			"azure_ad_user":                                               tableAzureAdUser(ctx),
+			"azure_alert_management":                                      tableAzureAlertMangement(ctx),
 			"azure_api_management":                                        tableAzureAPIManagement(ctx),
 			"azure_app_configuration":                                     tableAzureAppConfiguration(ctx),
 			"azure_app_service_environment":                               tableAzureAppServiceEnvironment(ctx),

--- a/azure/table_azure_alert_management.go
+++ b/azure/table_azure_alert_management.go
@@ -1,0 +1,416 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/alertsmanagement/mgmt/2019-03-01/alertsmanagement"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+//// TABLE DEFINITION ////
+
+func tableAzureAlertMangement(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "azure_alert_management",
+		Description: "Azure Alert Management Service",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"id"}),
+			Hydrate:    getAlertManagement,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"ResourceNotFound", "InvalidApiVersionParameter", "ResourceGroupNotFound"}),
+			},
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listAlertManagements,
+			KeyColumns: plugin.KeyColumnSlice{
+				{
+					Name:    "target_resource",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "target_resource_type",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "resource_group",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "alert_rule",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "smart_group_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "sort_order",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "custom_time_range",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "sort_by",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "monitor_service",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "monitor_condition",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "severity",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "alert_state",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "time_range",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		Columns: azureColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Type:        proto.ColumnType_STRING,
+				Description: "A friendly name that identifies an Alert management service.",
+			},
+			{
+				Name:        "id",
+				Description: "Azure resource Id",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromGo(),
+			},
+			{
+				Name:        "type",
+				Description: "Type of the resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "sort_order",
+				Description: "Sort order of the alert management.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("sort_order"),
+			},
+			{
+				Name:        "sort_by",
+				Description: "Sort the query results by input field,  Default value is 'lastModifiedDateTime'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("sort_by"),
+			},
+			{
+				Name:        "custom_time_range",
+				Description: "Filter by custom time range in the format <start-time>/<end-time>  where time is in (ISO-8601 format)'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("custom_time_range"),
+			},
+			{
+				Name:        "time_range",
+				Description: "Filter by time range. Possible values are '1h', '1d', '7d' or '30d'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("time_range"),
+			},
+			{
+				Name:        "severity",
+				Description: "Severity of alert Sev0 being highest and Sev4 being lowest. Possible values include: 'Sev0', 'Sev1', 'Sev2', 'Sev3', 'Sev4'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.Severity"),
+			},
+			{
+				Name:        "signal_type",
+				Description: "The type of signal the alert is based on, which could be metrics, logs or activity logs. Possible values include: 'Metric', 'Log', 'Unknown'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.SignalType"),
+			},
+			{
+				Name:        "alert_state",
+				Description: "Alert object state, which can be modified by the user. Possible values include: 'AlertStateNew', 'AlertStateAcknowledged', 'AlertStateClosed'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.AlertState"),
+			},
+			{
+				Name:        "monitor_condition",
+				Description: "Can be 'Fired' or 'Resolved', which represents whether the underlying conditions have crossed the defined alert rule thresholds. Possible values include: 'Fired', 'Resolved'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.MonitorCondition"),
+			},
+			{
+				Name:        "target_resource",
+				Description: "Target ARM resource, on which alert got created.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.TargetResource"),
+			},
+			{
+				Name:        "target_resource_name",
+				Description: "Name of the target ARM resource name, on which alert got created.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.TargetResourceName"),
+			},
+			{
+				Name:        "target_resource_type",
+				Description: "Resource type of target ARM resource, on which alert got created.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.TargetResourceType"),
+			},
+			{
+				Name:        "monitor_service",
+				Description: "Monitor service on which the rule(monitor) is set. Possible values include: 'ApplicationInsights', 'ActivityLogAdministrative', 'ActivityLogSecurity', 'ActivityLogRecommendation', 'ActivityLogPolicy', 'ActivityLogAutoscale', 'LogAnalytics', 'Nagios', 'Platform', 'SCOM', 'ServiceHealth', 'SmartDetector', 'VMInsights', 'Zabbix', 'ResourceHealth'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.MonitorService"),
+			},
+			{
+				Name:        "alert_rule",
+				Description: "Rule(monitor) which fired alert instance. Depending on the monitor service, this would be ARM id or name of the rule.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.AlertRule"),
+			},
+			{
+				Name:        "source_created_id",
+				Description: "Unique Id created by monitor service for each alert instance. This could be used to track the issue at the monitor service, in case of Nagios, Zabbix, SCOM etc.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.SourceCreatedID"),
+			},
+			{
+				Name:        "smart_group_id",
+				Description: "Unique Id of the smart group.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.SmartGroupID"),
+			},
+			{
+				Name:        "smart_grouping_reason",
+				Description: "Verbose reason describing the reason why this alert instance is added to a smart group.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.SmartGroupingReason"),
+			},
+			{
+				Name:        "start_date_time",
+				Description: "Creation time(ISO-8601 format) of alert instance.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("Properties.Essentials.StartDateTime").Transform(convertDateToTime),
+			},
+			{
+				Name:        "last_modified_date_time",
+				Description: "Last modification time(ISO-8601 format) of alert instance.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("Properties.Essentials.LastModifiedDateTime").Transform(convertDateToTime),
+			},
+			{
+				Name:        "monitor_condition_resolved_date_time",
+				Description: "Resolved time(ISO-8601 format) of alert instance. This will be updated when monitor service resolves the alert instance because the rule condition is no longer met.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("Properties.Essentials.MonitorConditionResolvedDateTime").Transform(convertDateToTime),
+			},
+			{
+				Name:        "last_modified_user_name",
+				Description: "User who last modified the alert, in case of monitor service updates user would be 'system', otherwise name of the user.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Essentials.LastModifiedUserName"),
+			},
+			{
+				Name:        "context",
+				Description: "The context of the alert management.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.Context"),
+			},
+			{
+				Name:        "egress_config",
+				Description: "The egress config for the context management.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.EgressConfig"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ID").Transform(idToAkas),
+			},
+
+			// Azure standard columns
+			{
+				Name:        "resource_group",
+				Description: ColumnDescriptionResourceGroup,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("resource_group"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listAlertManagements(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	alertManagementClient := alertsmanagement.NewAlertsClientWithBaseURI(session.ResourceManagerEndpoint, "subscriptions/"+subscriptionID, subscriptionID, "")
+	alertManagementClient.Authorizer = session.Authorizer
+
+	plugin.Logger(ctx).Error("111111111111")
+
+	var targetResource, targetResourceType, targetResourceGroup, alertRule, smartGroupID, sortOrder, selectParameter, customTimeRange string
+	var includeContext, includeEgressConfig bool = true, true
+	var pageCount *int32
+	var sortBy alertsmanagement.AlertsSortByFields
+	var timeRange alertsmanagement.TimeRange
+	var monitorService alertsmanagement.MonitorService
+	var monitorCondition alertsmanagement.MonitorCondition
+	var severity alertsmanagement.Severity
+	var alertState alertsmanagement.AlertState
+
+	targetResource = d.EqualsQualString("target_resource")
+	targetResourceType = d.EqualsQualString("target_resource_type")
+	targetResourceGroup = d.EqualsQualString("resource_group")
+	alertRule = d.EqualsQualString("alert_rule")
+	smartGroupID = d.EqualsQualString("smart_group_id")
+	sortOrder = d.EqualsQualString("sort_order")
+	customTimeRange = d.EqualsQualString("custom_time_range")
+	sortBy = getShortOrderValue(d.EqualsQualString("sort_by"))
+	monitorService = getMonitorServiceValue(d.EqualsQualString("monitor_service"))
+	monitorCondition = getMonitorConditionValue(d.EqualsQualString("monitor_condition"))
+	severity = getSeverityValue(d.EqualsQualString("severity"))
+	alertState = getAlertStateValue(d.EqualsQualString("alert_state"))
+	timeRange = getAlertTimeRangeValue(d.EqualsQualString("time_range"))
+
+	result, err := alertManagementClient.GetAll(ctx, targetResource, targetResourceType, targetResourceGroup, monitorService, monitorCondition, severity, alertState, alertRule, smartGroupID, &includeContext, &includeEgressConfig, pageCount, sortBy, sortOrder, selectParameter, timeRange, customTimeRange)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, alertManagement := range result.Values() {
+		d.StreamListItem(ctx, alertManagement)
+		// Check if context has been cancelled or if the limit has been hit (if specified)
+		// if there is a limit, it will return the number of rows required to reach this limit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	for result.NotDone() {
+		err = result.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, alertManagement := range result.Values() {
+			d.StreamListItem(ctx, alertManagement)
+
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			// if there is a limit, it will return the number of rows required to reach this limit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+func getAlertManagement(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	alertId := d.EqualsQuals["id"].GetStringValue()
+	if len(alertId) < 1 {
+		return nil, nil
+	}
+
+	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID := session.SubscriptionID
+
+	alertManagementClient := alertsmanagement.NewAlertsClientWithBaseURI(session.ResourceManagerEndpoint, "", subscriptionID, "")
+	alertManagementClient.Authorizer = session.Authorizer
+
+	op, err := alertManagementClient.GetByID(ctx, alertId)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+//// INPUT PARAMETER FUNCTION
+
+func getShortOrderValue(s string) alertsmanagement.AlertsSortByFields {
+	sortByFields := alertsmanagement.PossibleAlertsSortByFieldsValues()
+	for _, i := range sortByFields {
+		if s == fmt.Sprint(i) {
+			return i
+		}
+	}
+	return ""
+}
+
+func getMonitorServiceValue(s string) alertsmanagement.MonitorService {
+	svc := alertsmanagement.PossibleMonitorServiceValues()
+	for _, i := range svc {
+		if s == fmt.Sprint(i) {
+			return i
+		}
+	}
+	return ""
+}
+
+func getMonitorConditionValue(s string) alertsmanagement.MonitorCondition {
+	con := alertsmanagement.PossibleMonitorConditionValues()
+	for _, i := range con {
+		if s == fmt.Sprint(i) {
+			return i
+		}
+	}
+	return ""
+}
+
+func getSeverityValue(s string) alertsmanagement.Severity {
+	sev := alertsmanagement.PossibleSeverityValues()
+	for _, i := range sev {
+		if s == fmt.Sprint(i) {
+			return i
+		}
+	}
+	return ""
+}
+
+func getAlertStateValue(s string) alertsmanagement.AlertState {
+	alt := alertsmanagement.PossibleAlertStateValues()
+	for _, i := range alt {
+		if s == fmt.Sprint(i) {
+			return i
+		}
+	}
+	return ""
+}
+
+func getAlertTimeRangeValue(s string) alertsmanagement.TimeRange {
+	t := alertsmanagement.PossibleTimeRangeValues()
+	for _, i := range t {
+		if s == fmt.Sprint(i) {
+			return i
+		}
+	}
+	return ""
+}

--- a/docs/tables/azure_alert_management.md
+++ b/docs/tables/azure_alert_management.md
@@ -1,0 +1,107 @@
+# Table: azure_alert_management
+
+Azure Alert Management is a service and set of tools within Microsoft Azure that allows you to monitor and respond to issues across your applications and infrastructure. It provides a centralized way to set up and manage alerts for various Azure resources, including virtual machines, databases, web applications, and more. Azure Alert Management helps you stay informed about the health and performance of your Azure resources and take appropriate actions when predefined conditions are met.
+
+**Important notes:**
+
+- This table offers access to alert management details for the past 30 days. If no value is specified in the query parameter (`time_range`) within the WHERE clause, the default value will be set to `1d`(One Day).
+- For improved performance, it is advised that you use the optional qual to limit the result set.
+- This table supports optional quals. Queries with optional quals are optimised to use Alert Management filters. Optional quals are supported for the following columns:
+
+  - `target_resource`: Filter by the target resource (full ARM ID). The default value selects all resources.
+  - `target_resource_type`: Filter by target resource type. The default value selects all resource types.
+  - `resource_group`: Filter by target resource group name. The default value selects all resource groups.
+  - `alert_rule`: Filter by a specific alert rule. The default value selects all rules.
+  - `smart_group_id`: Filter the alerts list by the Smart Group ID. The default value is none.
+  - `sort_order`: Sort the query results in ascending or descending order. The default value is 'desc' for time fields and 'asc' for others.
+  - `custom_time_range`: Filter by a custom time range in the format (ISO-8601 format). Permissible values are within 30 days from the query time. Either `timeRange` or `customTimeRange` can be used, but not both. The default is none.
+  - `sort_by`: Sort the query results by input field. The default value is 'lastModifiedDateTime'. For available fields, refer to the [API documentation](https://learn.microsoft.com/en-us/rest/api/monitor/alertsmanagement/alerts/get-all?tabs=HTTP#alertssortbyfields).
+  - `monitor_service`: Filter by the monitor service that generates the alert instance. The default value selects all services. For available services, refer to the [API documentation](https://learn.microsoft.com/en-us/rest/api/monitor/alertsmanagement/alerts/get-all?tabs=HTTP#monitorservice).
+  - `monitor_condition`: Filter by the monitor condition, which is either 'Fired' or 'Resolved'. The default value selects all conditions.
+  - `severity`: Filter by severity. The default value selects all severities. For details, refer to the [severity documentation](https://learn.microsoft.com/en-us/rest/api/monitor/alertsmanagement/alerts/get-all?tabs=HTTP#severity).
+  - `alert_state`: Filter by the state of the alert instance. The default value selects all states. For details, refer to the [alert state documentation](https://learn.microsoft.com/en-us/rest/api/monitor/alertsmanagement/alerts/get-all?tabs=HTTP#alertstate).
+  - `time_range`: Filter by the time range, choosing from the listed values in the [API documentation](https://learn.microsoft.com/en-us/rest/api/monitor/alertsmanagement/alerts/get-all?tabs=HTTP#timerange). The default value is 1 day.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  type,
+  target_resource,
+  signal_type,
+  alert_state,
+  monitor_condition
+from
+  azure_alert_management;
+```
+
+### List fired alerts
+
+```sql
+select
+  name,
+  id,
+  type,
+  signal_type,
+  alert_state,
+  monitor_service,
+  monitor_condition
+from
+  azure_alert_management
+where
+  monitor_condition = 'Fired';
+```
+
+### List alerts with in last 7 days
+
+```sql
+select
+  name,
+  id,
+  target_resource,
+  target_resource_type,
+  alert_rule,
+  time_range
+from
+  azure_alert_management
+where
+  time_range = '7d';
+```
+
+### List critical alerts
+
+```sql
+select
+  name,
+  id,
+  target_resource,
+  target_resource_type,
+  severity,
+  alert_state,
+  monitor_service
+from
+  azure_alert_management
+where
+  severity = 'Sev0';
+```
+
+### List alerts of VMInsights monitoring service
+
+```sql
+select
+  name,
+  id,
+  target_resource,
+  monitor_service,
+  alert_rule,
+  alert_state,
+  source_created_id
+from
+  azure_alert_management
+where
+  monitor_service = 'VMInsights';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from azure_alert_management where time_range = '7d' and resource_group = 'turbot_rg'
Warning: failed to start 6 plugins using an incompatible sdk version, (required by 6 connections). To update, please run: steampipe plugin update twilio ibm chaos urlscan reddit zendesk
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+------------+---------+-------------------+------------+----------+--------->
| name               | id                                                                                                                                   | type                              | sort_order | sort_by | custom_time_range | time_range | severity | signal_t>
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+------------+---------+-------------------+------------+----------+--------->
| Delete Backup Data | /subscriptions/gdyr56jd-f95f-4771-bbb5-hsjfbg456938/providers/Microsoft.AlertsManagement/alerts/92ee9cfc-9276-c1bb-1072-18628b580008 | Microsoft.AlertsManagement/alerts | <null>     | <null>  | <null>            | 7d         | Sev0     | Log     >
|                    |                                                                                                                                      |                                   |            |         |                   |            |          |         >
| Delete Backup Data | /subscriptions/gdyr56jd-f95f-4771-bbb5-hsjfbg456938/providers/Microsoft.AlertsManagement/alerts/322283b2-6ca4-4095-fa09-88cee5000008 | Microsoft.AlertsManagement/alerts | <null>     | <null>  | <null>            | 7d         | Sev0     | Log     >
|                    |                                                                                                                                      |                                   |            |         |                   |            |          |         >
| Backup Failure     | /subscriptions/gdyr56jd-f95f-4771-bbb5-hsjfbg456938/providers/Microsoft.AlertsManagement/alerts/a6e4b154-34a5-84ae-c4c4-b86e0e920008 | Microsoft.AlertsManagement/alerts | <null>     | <null>  | <null>            | 7d         | Sev1     | Log     >
|                    |                                                                                                                                      |                                   |            |         |                   |            |          |         >
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+------------+---------+-------------------+------------+----------+--------->

> select * from azure_alert_management
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+---------->
| name               | id                                                                                                                                   | type                              | sort_orde>
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+---------->
| Delete Backup Data | /subscriptions/gdyr56jd-f95f-4771-bbb5-hsjfbg456938/providers/Microsoft.AlertsManagement/alerts/92ee9cfc-9276-c1bb-1072-18628b580008 | Microsoft.AlertsManagement/alerts | <null>   >
|                    |                                                                                                                                      |                                   |          >
+--------------------+--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------+---------->
```
</details>
