### PR TITLE
Add column `disable_local_auth` to table `azure_cosmosdb_account`. Closes #735

### DIFF
--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"strings"
 
-	// "github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2021-04-01-preview/documentdb"
-
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-06-15/documentdb"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"

--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -3,8 +3,7 @@ package azure
 import (
 	"context"
 	"strings"
-
-	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2021-04-01-preview/documentdb"
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-06-15/documentdb"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 
@@ -140,6 +139,13 @@ func tableAzureCosmosDBAccount(_ context.Context) *plugin.Table {
 				Description: "Specifies whether to enable/disable Virtual Network ACL rules.",
 				Type:        proto.ColumnType_BOOL,
 				Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.IsVirtualNetworkFilterEnabled"),
+				Default:     false,
+			},
+			{
+				Name:        "disable_local_auth",
+				Description: "Specifies whether CosmosDB account is using AAD and RBAC.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.DisableLocalAuth"),
 				Default:     false,
 			},
 			{

--- a/azure/table_azure_cosmosdb_account.go
+++ b/azure/table_azure_cosmosdb_account.go
@@ -3,6 +3,9 @@ package azure
 import (
 	"context"
 	"strings"
+
+	// "github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2021-04-01-preview/documentdb"
+
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-06-15/documentdb"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -143,7 +146,7 @@ func tableAzureCosmosDBAccount(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "disable_local_auth",
-				Description: "Specifies whether CosmosDB account is using AAD and RBAC.",
+				Description: "Disable local authentication and ensure only MSI and AAD can be used exclusively for authentication. Defaults to false.",
 				Type:        proto.ColumnType_BOOL,
 				Transform:   transform.FromField("DatabaseAccount.DatabaseAccountGetProperties.DisableLocalAuth"),
 				Default:     false,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
      a.id as resource,
      case
        when disable_local_auth then 'ok'
        else 'alarm'
      end as status,
      case
        when disable_local_auth then a.name || ' is using AAD and RBAC.'
        else a.name || ' is not using AAD and RBAC.'
      end as reason
    from
      azure_cosmosdb_account as a,
      azure_subscription as sub
    where
      sub.subscription_id = a.subscription_id;
[
 {
  "reason": "turbot-test-20200125-create-update is using AAD and RBAC.",
  "resource": "/subscriptions/dddddddd-bbbb-7777777777c/resourceGroups/turbot-test-20200125-create-update/providers/Microsoft.DocumentDB/databaseAccounts/turbot-test-20200125-create-update",
  "status": "ok"
 }
]
```
</details>
