### PR TITLE
Fixed azure_postgresql_flexible_server does not appear to provide fullyQualifiedDomainName Closes #753

### DIFF
--- a/azure/table_azure_postgresql_flexible_server.go
+++ b/azure/table_azure_postgresql_flexible_server.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -66,6 +67,7 @@ func tableAzurePostgreSqlFlexibleServer(_ context.Context) *plugin.Table {
 				Name:        "server_properties",
 				Description: "Properties of the server.",
 				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ServerProperties").Transform(extractPostgresFlexibleServerProperties),
 			},
 			{
 				Name:        "flexible_server_configurations",
@@ -244,4 +246,12 @@ func extractpostgreSQLFlexibleServersconfiguration(i postgresqlflexibleservers.C
 	}
 
 	return postgreSQLFlexibleServersconfiguration
+}
+
+func extractPostgresFlexibleServerProperties(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	conf := d.HydrateItem.(postgresqlflexibleservers.Server)
+	if conf.ServerProperties != nil {
+		return structToMap(reflect.ValueOf(*conf.ServerProperties)), nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(server_properties) from azure_postgresql_flexible_server
+--------+-----------------------------------------------------------------------+
| name   | jsonb_pretty                                                          |
+--------+-----------------------------------------------------------------------+
| test63 | {                                                                     |
|        |     "Tags": null,                                                     |
|        |     "State": "Ready",                                                 |
|        |     "Backup": {                                                       |
|        |         "geoRedundantBackup": "Disabled",                             |
|        |         "backupRetentionDays": 7                                      |
|        |     },                                                                |
|        |     "Network": {                                                      |
|        |     },                                                                |
|        |     "Storage": {                                                      |
|        |         "storageSizeGB": 32                                           |
|        |     },                                                                |
|        |     "Version": "16",                                                  |
|        |     "CreateMode": null,                                               |
|        |     "MinorVersion": "2",                                              |
|        |     "PointInTimeUTC": null,                                           |
|        |     "AvailabilityZone": "2",                                          |
|        |     "HighAvailability": {                                             |
|        |         "mode": "Disabled"                                            |
|        |     },                                                                |
|        |     "MaintenanceWindow": {                                            |
|        |         "dayOfWeek": 0,                                               |
|        |         "startHour": 0,                                               |
|        |         "startMinute": 0,                                             |
|        |         "customWindow": "Disabled"                                    |
|        |     },                                                                |
|        |     "AdministratorLogin": "test",                                     |
|        |     "SourceServerResourceID": null,                                   |
|        |     "FullyQualifiedDomainName": "test63.postgres.database.azure.com", |
|        |     "AdministratorLoginPassword": null                                |
|        | }                                                                     |
+--------+-----------------------------------------------------------------------+
```
</details>
