### PR TITLE
Update incorrect Column Type for Network Access Fields in azure_application_insight Table. Closes #768

### DIFF
--- a/azure/table_azure_application_insight.go
+++ b/azure/table_azure_application_insight.go
@@ -138,6 +138,18 @@ func tableAzureApplicationInsight(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "public_network_access_for_ingestion",
+				Description: "The network access type for accessing Application Insights ingestion.",
+				Transform:   transform.FromField("ApplicationInsightsComponentProperties.PublicNetworkAccessForIngestion"),
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "public_network_access_for_query",
+				Description: "The network access type for accessing Application Insights query.",
+				Transform:   transform.FromField("ApplicationInsightsComponentProperties.PublicNetworkAccessForQuery"),
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "application_type",
 				Description: "Type of application being monitored.",
 				Transform:   transform.FromField("ApplicationInsightsComponentProperties.ApplicationType"),
@@ -159,18 +171,6 @@ func tableAzureApplicationInsight(_ context.Context) *plugin.Table {
 				Name:        "private_link_scoped_resources",
 				Description: "List of linked private link scope resources.",
 				Transform:   transform.FromField("ApplicationInsightsComponentProperties.PrivateLinkScopedResources"),
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "public_network_access_for_ingestion",
-				Description: "The network access type for accessing Application Insights ingestion.",
-				Transform:   transform.FromField("ApplicationInsightsComponentProperties.PublicNetworkAccessForIngestion"),
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "public_network_access_for_query",
-				Description: "The network access type for accessing Application Insights query.",
-				Transform:   transform.FromField("ApplicationInsightsComponentProperties.PublicNetworkAccessForQuery"),
 				Type:        proto.ColumnType_JSON,
 			},
 


### PR DESCRIPTION
# Results
<details>
  <summary>Results</summary>
  
```
When it was json column:-
select public_network_access_for_ingestion,public_network_access_for_query from azure_application_insight
+-------------------------------------+---------------------------------+
| public_network_access_for_ingestion | public_network_access_for_query |
+-------------------------------------+---------------------------------+
| "Enabled"                           | "Enabled"                       |
+-------------------------------------+---------------------------------+

After changing the column type to string:-
select public_network_access_for_ingestion,public_network_access_for_query from azure_application_insight
+-------------------------------------+---------------------------------+
| public_network_access_for_ingestion | public_network_access_for_query |
+-------------------------------------+---------------------------------+
| Enabled                             | Enabled                         |
+-------------------------------------+---------------------------------+

```
</details>

