### PR TITLE
Fixed missing web_application_firewall_configuration details in table azure_application_gateway Closes #765

### DIFF
--- a/azure/table_azure_application_gateway.go
+++ b/azure/table_azure_application_gateway.go
@@ -420,7 +420,7 @@ func getWebApplicationFirewallConfiguration(ctx context.Context, d *plugin.Query
 		return nil, nil
 	}
 	policyId := firewallPolicy.ID
-	rgName := strings.Split(*policyId, "/")[4]
+	resourceGroup := strings.Split(*policyId, "/")[4]
 	policyname := strings.Split(*policyId, "/")[len(strings.Split(*policyId, "/"))-1]
 
 	// Create session
@@ -433,7 +433,7 @@ func getWebApplicationFirewallConfiguration(ctx context.Context, d *plugin.Query
 	client := network.NewWebApplicationFirewallPoliciesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = session.Authorizer
 
-	op, err := client.Get(ctx, rgName, policyname)
+	op, err := client.Get(ctx, resourceGroup, policyname)
 	if err != nil {
 		plugin.Logger(ctx).Error("azure_application_gateway.getWebApplicationFirewallConfiguration", "api_error", err)
 		return nil, err


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(web_application_firewall_configuration) from azure_application_gateway;
+----------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| name     | jsonb_pretty                                                                                                                                             |
+----------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| test2223 | <null>                                                                                                                                                   |
| testgw3  | {                                                                                                                                                        |
|          |     "CustomRules": [                                                                                                                                     |
|          |     ],                                                                                                                                                   |
|          |     "ManagedRules": {                                                                                                                                    |
|          |         "exclusions": [                                                                                                                                  |
|          |         ],                                                                                                                                               |
|          |         "managedRuleSets": [                                                                                                                             |
|          |             {                                                                                                                                            |
|          |                 "ruleSetType": "OWASP",                                                                                                                  |
|          |                 "ruleSetVersion": "3.2",                                                                                                                 |
|          |                 "ruleGroupOverrides": [                                                                                                                  |
|          |                 ]                                                                                                                                        |
|          |             }                                                                                                                                            |
|          |         ]                                                                                                                                                |
|          |     },                                                                                                                                                   |
|          |     "HTTPListeners": null,                                                                                                                               |
|          |     "ResourceState": null,                                                                                                                               |
|          |     "PathBasedRules": null,                                                                                                                              |
|          |     "PolicySettings": {                                                                                                                                  |
|          |         "mode": "Detection",                                                                                                                             |
|          |         "state": "Disabled",                                                                                                                             |
|          |         "requestBodyCheck": true,                                                                                                                        |
|          |         "fileUploadLimitInMb": 100,                                                                                                                      |
|          |         "maxRequestBodySizeInKb": 128                                                                                                                    |
|          |     },                                                                                                                                                   |
|          |     "ProvisioningState": "Succeeded",                                                                                                                    |
|          |     "ApplicationGateways": [                                                                                                                             |
|          |         {                                                                                                                                                |
|          |             "id": "/subscriptions/************************************/resourceGroups/turbot_rg/providers/Microsoft.Network/applicationGateways/testgw3" |
|          |         }                                                                                                                                                |
|          |     ]                                                                                                                                                    |
|          | }                                                                                                                                                        |
+----------+----------------------------------------------------------------------------------------------------------------------------------------------------------+

```
</details>
