### PR TITLE
feat: add power state to VMSS virtual machines

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -45,7 +45,7 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "power_state",
-				Description: "Specifies the power state of the vm.",
+				Description: "Specifies the power state of the VM.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getComputeVirtualMachineInstanceView,
 				Transform:   transform.FromField("Statuses").Transform(getPowerState),

--- a/azure/table_azure_compute_virtual_machine_scale_set_vm.go
+++ b/azure/table_azure_compute_virtual_machine_scale_set_vm.go
@@ -58,7 +58,7 @@ func tableAzureComputeVirtualMachineScaleSetVm(_ context.Context) *plugin.Table 
 			},
 			{
 				Name:        "power_state",
-				Description: "Specifies the power state of the vm.",
+				Description: "Specifies the power state of the VM.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getAzureComputeVirtualMachineScaleSetVmInstanceView,
 				Transform:   transform.FromField("Statuses").Transform(getPowerState),

--- a/docs/tables/azure_compute_virtual_machine_scale_set_vm.md
+++ b/docs/tables/azure_compute_virtual_machine_scale_set_vm.md
@@ -109,7 +109,7 @@ select
   nsg.name,
   jsonb_pretty(security_rules)
 from
-  azure.azure_compute_virtual_machine_scale_set_vm as vm,
+  azure_compute_virtual_machine_scale_set_vm as vm,
   jsonb_array_elements(vm.virtual_machine_network_profile) as vm_nic,
   azure_network_security_group as nsg,
   jsonb_array_elements(nsg.network_interfaces) as nsg_int
@@ -131,4 +131,23 @@ from
 where
   lower(json_extract(vm_nic.value, '$.id')) = lower(json_extract(nsg_int.value, '$.id'))
   and vm.name = 'warehouse-01';
+```
+
+### View power state of virtual machines
+Determine the power state of virtual machines in all scale sets.
+
+```sql+postgres
+select
+  vm.name,
+  vm.power_state
+from
+  azure_compute_virtual_machine_scale_set_vm as vm;
+```
+
+```sql+sqlite
+select
+  vm.name,
+  vm.power_state
+from
+  azure_compute_virtual_machine_scale_set_vm as vm;
 ```


### PR DESCRIPTION
This PR add power state to the `azure_compute_virtual_machine_scale_set_vm` table.

Largely inspired from the code of the `azure_compute_virtual_machine` table.