### PR TITLE
Fixed the error invalid memory address or nil pointer dereference for the column `power_state` in the table azure_compute_virtual_machine

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -699,7 +699,11 @@ func getPowerState(ctx context.Context, d *transform.TransformData) (interface{}
 	if !ok {
 		return nil, fmt.Errorf("Conversion failed for virtual machine statuses")
 	}
-	
+
+	// In some cases, we are encountering a situation where 'statuses' is a non-nil pointer
+	// that points to a nil value. This could happen due to incomplete or inconsistent data
+	// returned by the API. To handle this scenario, we need to check if 'statuses' points
+	// to a nil value and return nil if it does.
 	if statuses == nil {
 		return nil, nil
 	}

--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -705,7 +705,7 @@ func getPowerState(ctx context.Context, d *transform.TransformData) (interface{}
 	// returned by the API. To handle this scenario, we need to check if 'statuses' points
 	// to a nil value and return nil if it does.
 	if statuses == nil {
-		return nil, nil
+		return "", nil
 	}
 
 	return getStatusFromCode(statuses, "PowerState"), nil

--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -699,6 +699,10 @@ func getPowerState(ctx context.Context, d *transform.TransformData) (interface{}
 	if !ok {
 		return nil, fmt.Errorf("Conversion failed for virtual machine statuses")
 	}
+	
+	if statuses == nil {
+		return nil, nil
+	}
 
 	return getStatusFromCode(statuses, "PowerState"), nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, power_state from azure_compute_virtual_machine
+-----------------+-------------+
| name            | power_state |
+-----------------+-------------+
| tets-delete     | deallocated |
| test-power      | running     |
| turbottest95054 | running     |
+-----------------+-------------+
```
</details>
