### PR TITLE
Fixed the table azure_role_assignment to return the result with any of the connection type Closes #808

### DIFF
--- a/azure/table_azure_role_assignment.go
+++ b/azure/table_azure_role_assignment.go
@@ -121,7 +121,6 @@ func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		plugin.Logger(ctx).Error("azure_role_assignment.listIamRoleAssignments", "session_error", err)
 		return nil, err
 	}
-	// subscriptionID := session.SubscriptionID
 
 	authorizationClient, err := armauthorization.NewRoleAssignmentsClient(session.SubscriptionID, session.Cred, session.ClientOptions)
 	if err != nil {
@@ -130,9 +129,8 @@ func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	}
 
 	defaultFilter := "atScope()" // filter all result
-
+	// Tenant ID is not a required parameter to make the API call.
 	option := &armauthorization.RoleAssignmentsClientListForScopeOptions{
-		TenantID: &session.TenantID,
 		Filter:   &defaultFilter,
 	}
 


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from azure_via_sp_secret.azure_role_assignment where principal_id = '8fa25977-0bc7-4257-8633-aea72df9db53'
+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------->
| name                                 | id                                                                                                                                                                           | scope              >
+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------->
| d565a7db-6b2b-47c9-932d-9a5bea00e578 | /providers/Microsoft.Management/managementGroups/cdffd708-7da0-4cea-abeb-0a4c334d7f64/providers/Microsoft.Authorization/roleAssignments/d565a7db-6b2b-47c9-932d-9a5bea00e578 | /providers/Microsof>
| ed12b46d-86dc-4855-be88-34225ed9b0b0 | /subscriptions/**********-****-****-****-************/providers/Microsoft.Authorization/roleAssignments/ed12b46d-86dc-4855-be88-34225ed9b0b0                                 | /subscriptions/d46d>
+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------->
```
</details>
