### PR TITLE
Fixed the table `azure_subnet` to correctly populate the `ip_configurations` column value Closes #815

### DIFF
--- a/azure-test/tests/azure_subnet/test-get-expected.json
+++ b/azure-test/tests/azure_subnet/test-get-expected.json
@@ -7,7 +7,8 @@
         "name": "delegation",
         "properties": {
           "serviceName": "Microsoft.ContainerInstance/containerGroups"
-        }
+        },
+        "type": "Microsoft.Network/virtualNetworks/subnets/delegations"
       }
     ],
     "id": "{{ output.resource_id.value }}",

--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -327,40 +327,40 @@ func getIpConfiguration(ctx context.Context, ipConfig *network.IPConfiguration, 
 
 	// Extract the properties unless we are not getting the top label properties
 	if configuration.ID != nil {
-		resourceData["ID"] = *configuration.ID
+		resourceData["id"] = *configuration.ID
 	}
 	if configuration.Plan != nil {
-		resourceData["Plan"] = *configuration.Plan
+		resourceData["plan"] = *configuration.Plan
 	}
 	if configuration.Properties != nil {
-		resourceData["Properties"] = configuration.Properties
+		resourceData["properties"] = configuration.Properties
 	}
 	if configuration.Kind != nil {
-		resourceData["Kind"] = *configuration.Kind
+		resourceData["kind"] = *configuration.Kind
 	}
 	if configuration.ManagedBy != nil {
-		resourceData["ManagedBy"] = *configuration.ManagedBy
+		resourceData["managedBy"] = *configuration.ManagedBy
 	}
 	if configuration.Sku != nil {
-		resourceData["Sku"] = *configuration.Sku
+		resourceData["sku"] = *configuration.Sku
 	}
 	if configuration.Identity != nil {
-		resourceData["Identity"] = *configuration.Identity
+		resourceData["identity"] = *configuration.Identity
 	}
 	if configuration.Name != nil {
-		resourceData["Name"] = *configuration.Name
+		resourceData["name"] = *configuration.Name
 	}
 	if configuration.Type != nil {
-		resourceData["Type"] = *configuration.Type
+		resourceData["type"] = *configuration.Type
 	}
 	if configuration.Location != nil {
-		resourceData["Location"] = *configuration.Location
+		resourceData["location"] = *configuration.Location
 	}
 	if configuration.ExtendedLocation != nil {
-		resourceData["ExtendedLocation"] = *configuration.ExtendedLocation
+		resourceData["extendedLocation"] = *configuration.ExtendedLocation
 	}
 	if configuration.Tags != nil {
-		resourceData["Tags"] = configuration.Tags
+		resourceData["tags"] = configuration.Tags
 	}
 
 	return &resourceData, nil

--- a/azure/table_azure_subnet.go
+++ b/azure/table_azure_subnet.go
@@ -313,19 +313,20 @@ func getIpConfiguration(ctx context.Context, ipConfig *network.IPConfiguration, 
 	}
 
 	configurationId := *ipConfig.ID
-	plugin.Logger(ctx).Error("Resource ID:", configurationId)
 
+	// API version is required to make the API call.
+	// https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id?view=rest-resources-2021-04-01#code-try-0
 	apiVersion := "2021-04-01"
 
 	configuration, err := client.GetByID(ctx, configurationId, apiVersion)
 	if err != nil {
-		plugin.Logger(ctx).Error("azure_resource.getResource", "api_error", err)
+		plugin.Logger(ctx).Error("azure_subnet.getIpConfiguration", "api_error", err)
 		return nil, err
 	}
 
 	resourceData := make(map[string]interface{})
 
-	// Extract the properties unless we are not getting the top label properties
+	// Extract the properties unless the top-level properties are not being retrieved.
 	if configuration.ID != nil {
 		resourceData["id"] = *configuration.ID
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_subnet []

PRETEST: tests/azure_subnet

TEST: tests/azure_subnet
Running terraform
data.azurerm_client_config.current: Reading...
data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MDZmZDQ2YjAtYTg2Ny00OWExLWE0ZjEtZjc3Njg0NjVjYWJhO3N1YnNjcmlwdGlvbklkPWQ0NmQ3NDE2LWY5NWYtNDc3MS1iYmI1LTUyOWQ0Yzc2NjU5Yzt0ZW5hbnRJZD1jZGZmZDcwOC03ZGEwLTRjZWEtYWJlYi0wYTRjMzM0ZDdmNjQ=]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westus"
      + name     = "turbottest51213"
    }

  # azurerm_subnet.named_test_resource will be created
  + resource "azurerm_subnet" "named_test_resource" {
      + address_prefixes                               = [
          + "10.0.1.0/24",
        ]
      + default_outbound_access_enabled                = true
      + enforce_private_link_endpoint_network_policies = (known after apply)
      + enforce_private_link_service_network_policies  = (known after apply)
      + id                                             = (known after apply)
      + name                                           = "turbottest51213"
      + private_endpoint_network_policies              = (known after apply)
      + private_endpoint_network_policies_enabled      = (known after apply)
      + private_link_service_network_policies_enabled  = (known after apply)
      + resource_group_name                            = "turbottest51213"
      + virtual_network_name                           = "turbottest51213"

      + delegation {
          + name = "delegation"

          + service_delegation {
              + actions = [
                  + "Microsoft.Network/virtualNetworks/subnets/join/action",
                  + "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
                ]
              + name    = "Microsoft.ContainerInstance/containerGroups"
            }
        }
    }

  # azurerm_virtual_network.named_test_resource will be created
  + resource "azurerm_virtual_network" "named_test_resource" {
      + address_space       = [
          + "10.0.0.0/16",
        ]
      + dns_servers         = (known after apply)
      + guid                = (known after apply)
      + id                  = (known after apply)
      + location            = "westus"
      + name                = "turbottest51213"
      + resource_group_name = "turbottest51213"
      + subnet              = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest51213"
  + subscription_id    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Still creating... [10s elapsed]
azurerm_resource_group.named_test_resource: Creation complete after 14s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213]
azurerm_virtual_network.named_test_resource: Creating...
azurerm_virtual_network.named_test_resource: Creation complete after 10s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213]
azurerm_subnet.named_test_resource: Creating...
azurerm_subnet.named_test_resource: Creation complete after 8s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213"
resource_aka_lower = "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest51213/providers/microsoft.network/virtualnetworks/turbottest51213/subnets/turbottest51213"
resource_id = "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213"
resource_name = "turbottest51213"
subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

Running SQL query: test-get-query.sql

Time: 1.8s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) azure_subnet.azure: Time: 1.5s. Fetched: 1. Hydrates: 0. Quals: name=turbottest51213, resource_group=turbottest51213, virtual_network_name=turbottest51213.

[
  {
    "address_prefix": "10.0.1.0/24",
    "delegations": [
      {
        "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213/delegations/delegation",
        "name": "delegation",
        "properties": {
          "serviceName": "Microsoft.ContainerInstance/containerGroups"
        },
        "type": "Microsoft.Network/virtualNetworks/subnets/delegations"
      }
    ],
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213",
    "name": "turbottest51213",
    "resource_group": "turbottest51213",
    "type": "Microsoft.Network/subnets",
    "virtual_network_name": "turbottest51213"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 2.0s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) azure_subnet.azure: Time: 1.7s. Fetched: 1. Hydrates: 0. Quals: name=turbottest51213, resource_group=turbottest51213, virtual_network_name=turbottest51213.

[
  {
    "akas": [
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213",
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest51213/providers/microsoft.network/virtualnetworks/turbottest51213/subnets/turbottest51213"
    ],
    "name": "turbottest51213",
    "title": "turbottest51213"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 3.2s. Rows returned: 1. Rows fetched: 7. Hydrate calls: 0.

Scans:
  1) azure_subnet.azure: Time: 2.8s. Fetched: 7. Hydrates: 0. Quals: name=turbottest51213.

[
  {
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213",
    "name": "turbottest51213"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

Time: 2.2s. Rows returned: 0.
[]
✔ PASSED

Running SQL query: test-turbot-query.sql

Time: 2.7s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) azure_subnet.azure: Time: 2.0s. Fetched: 1. Hydrates: 0. Quals: name=turbottest51213, resource_group=turbottest51213, virtual_network_name=turbottest51213.

[
  {
    "akas": [
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest51213/providers/Microsoft.Network/virtualNetworks/turbottest51213/subnets/turbottest51213",
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest51213/providers/microsoft.network/virtualnetworks/turbottest51213/subnets/turbottest51213"
    ],
    "name": "turbottest51213",
    "title": "turbottest51213"
  }
]
✔ PASSED

TEARDOWN: tests/azure_subnet

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

I have the connected devices as follows:

![Screenshot 2024-08-20 at 12 13 13 PM](https://github.com/user-attachments/assets/58ad5222-a14f-47c5-a421-0b9784b8ebb4)

Here is the result for the subnet.
```
> select name, jsonb_pretty(ip_configurations) from azure_subnet where name = 'turbottest38108'
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name            | jsonb_pretty                                                                                                                                                                                       |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| turbottest38108 | [                                                                                                                                                                                                  |
|                 |     {                                                                                                                                                                                              |
|                 |         "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest38108/providers/Microsoft.Network/loadBalancers/test53/frontendIPConfigurations/test53",               |
|                 |         "name": "test53",                                                                                                                                                                          |
|                 |         "type": "Microsoft.Network/loadBalancers/frontendIPConfigurations",                                                                                                                        |
|                 |         "properties": {                                                                                                                                                                            |
|                 |             "subnet": {                                                                                                                                                                            |
|                 |                 "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest38108/providers/Microsoft.Network/virtualNetworks/turbottest38108/subnets/turbottest38108"     |
|                 |             },                                                                                                                                                                                     |
|                 |             "privateIPAddress": "10.0.2.5",                                                                                                                                                        |
|                 |             "provisioningState": "Succeeded",                                                                                                                                                      |
|                 |             "privateIPAddressVersion": "IPv4",                                                                                                                                                     |
|                 |             "privateIPAllocationMethod": "Dynamic"                                                                                                                                                 |
|                 |         }                                                                                                                                                                                          |
|                 |     },                                                                                                                                                                                             |
|                 |     {                                                                                                                                                                                              |
|                 |         "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest38108/providers/Microsoft.Network/networkInterfaces/turbottest38108/ipConfigurations/turbottest38108", |
|                 |         "name": "turbottest38108",                                                                                                                                                                 |
|                 |         "type": "Microsoft.Network/networkInterfaces/ipConfigurations",                                                                                                                            |
|                 |         "properties": {                                                                                                                                                                            |
|                 |             "subnet": {                                                                                                                                                                            |
|                 |                 "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest38108/providers/Microsoft.Network/virtualNetworks/turbottest38108/subnets/turbottest38108"     |
|                 |             },                                                                                                                                                                                     |
|                 |             "primary": true,                                                                                                                                                                       |
|                 |             "privateIPAddress": "10.0.2.4",                                                                                                                                                        |
|                 |             "provisioningState": "Succeeded",                                                                                                                                                      |
|                 |             "privateIPAddressVersion": "IPv4",                                                                                                                                                     |
|                 |             "privateIPAllocationMethod": "Dynamic"                                                                                                                                                 |
|                 |         }                                                                                                                                                                                          |
|                 |     }                                                                                                                                                                                              |
|                 | ]                                                                                                                                                                                                  |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```
</details>
