### PR TITLE
fix: use standard API for Azure VMs in VMSS with flexible orchestration mode

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -48,6 +48,12 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "virtual_machine_scale_set",
+				Description: "Scale set details for virtual machines managed in flexible orchestration mode.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("VirtualMachineProperties.VirtualMachineScaleSet"),
+			},
+			{
 				Name:        "power_state",
 				Description: "Specifies the power state of the VM.",
 				Type:        proto.ColumnType_STRING,

--- a/azure/table_azure_compute_virtual_machine_scale_set.go
+++ b/azure/table_azure_compute_virtual_machine_scale_set.go
@@ -126,6 +126,12 @@ func tableAzureComputeVirtualMachineScaleSet(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VirtualMachineScaleSetProperties.ScaleInPolicy"),
 			},
 			{
+				Name:        "orchestration_mode",
+				Description: "The orchestration mode of the Virtual Machine Scale Set.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromGo(),
+			},
+			{
 				Name:        "tags_src",
 				Description: "Resource tags.",
 				Type:        proto.ColumnType_JSON,

--- a/azure/table_azure_compute_virtual_machine_scale_set_vm.go
+++ b/azure/table_azure_compute_virtual_machine_scale_set_vm.go
@@ -328,13 +328,24 @@ func getAzureComputeVirtualMachineScaleSetVmInstanceView(ctx context.Context, d 
 		return nil, err
 	}
 	subscriptionID := session.SubscriptionID
-	client := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
-	client.Authorizer = session.Authorizer
 
-	op, err := client.GetInstanceView(ctx, resourceGroupName, virtualMachine.ScaleSetName, instanceId)
-	if err != nil {
-		return nil, err
+	if h.ParentItem.(compute.VirtualMachineScaleSet).OrchestrationMode == compute.Flexible {
+		client := compute.NewVirtualMachinesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+		client.Authorizer = session.Authorizer
+
+		op, err := client.InstanceView(ctx, resourceGroupName, *virtualMachine.Name)
+		if err != nil {
+			return nil, err
+		}
+		return op, nil
+	} else {
+		client := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
+		client.Authorizer = session.Authorizer
+
+		op, err := client.GetInstanceView(ctx, resourceGroupName, virtualMachine.ScaleSetName, instanceId)
+		if err != nil {
+			return nil, err
+		}
+		return op, nil
 	}
-
-	return op, nil
 }

--- a/azure/table_azure_compute_virtual_machine_scale_set_vm.go
+++ b/azure/table_azure_compute_virtual_machine_scale_set_vm.go
@@ -325,16 +325,22 @@ func getAzureComputeVirtualMachineScaleSetVmInstanceView(ctx context.Context, d 
 
 	session, err := GetNewSession(ctx, d, "MANAGEMENT")
 	if err != nil {
+		plugin.Logger(ctx).Error("Error", "getAzureComputeVirtualMachineScaleSetVmInstanceView", err)
 		return nil, err
 	}
 	subscriptionID := session.SubscriptionID
 
+	// When VMs are managed by scale sets in flexible orchestration mode,
+	// standard Azure VM APIs must be must be used.
+	// See https://learn.microsoft.com/en-us/answers/questions/1418158/rest-api-request-returns-badrequest-for-vmss
+	// and https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes?WT.mc_id=modinfra-31635-pierrer#what-has-changed-with-flexible-orchestration-mode
 	if h.ParentItem.(compute.VirtualMachineScaleSet).OrchestrationMode == compute.Flexible {
 		client := compute.NewVirtualMachinesClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
 		client.Authorizer = session.Authorizer
 
 		op, err := client.InstanceView(ctx, resourceGroupName, *virtualMachine.Name)
 		if err != nil {
+			plugin.Logger(ctx).Error("Error", "getAzureComputeVirtualMachineScaleSetVmInstanceView", err)
 			return nil, err
 		}
 		return op, nil
@@ -344,6 +350,7 @@ func getAzureComputeVirtualMachineScaleSetVmInstanceView(ctx context.Context, d 
 
 		op, err := client.GetInstanceView(ctx, resourceGroupName, virtualMachine.ScaleSetName, instanceId)
 		if err != nil {
+			plugin.Logger(ctx).Error("Error", "getAzureComputeVirtualMachineScaleSetVmInstanceView", err)
 			return nil, err
 		}
 		return op, nil


### PR DESCRIPTION
If VMs are managed by VMSS in flexible orchestration mode, the standard VM API must be used: https://learn.microsoft.com/en-us/answers/questions/1418158/rest-api-request-returns-badrequest-for-vmss

Without this change, the following error occurs when trying to read `power_state` of such VMs:
```
# steampipe query 'select power_state from azure_compute_virtual_machine_scale_set_vm'                                                 11:24:09

Error: azure: compute.VirtualMachineScaleSetVMsClient#GetInstanceView: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidParameter" Message="Virtual Machine Scale Set VM instanceId must be a number." Target="instanceId" (SQLSTATE HV000)

+-------------+
| power_state |
+-------------+
+-------------+
```

With this change, this returns the power state properly:

```
# steampipe query 'select power_state from azure_compute_virtual_machine_scale_set_vm'
+-------------+
| power_state |
+-------------+
| running     |
+-------------+

```