### PR TITLE
Add column time_created to azure_compute_virtual_machine table closes #830

### DIFF
--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -72,6 +72,12 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VirtualMachineProperties.ProvisioningState"),
 			},
 			{
+				Name:        "time_created",
+				Description: "Specifies the time at which the virtual machine resource was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("VirtualMachineProperties.TimeCreated").Transform(convertDateToTime),
+			},
+			{
 				Name:        "vm_id",
 				Description: "Specifies an unique ID for VM, which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS and can be read using platform BIOS commands.",
 				Type:        proto.ColumnType_STRING,
@@ -343,12 +349,6 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Description: "Specifies the security related profile settings for the virtual machine.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("VirtualMachineProperties.SecurityProfile"),
-			},
-			{
-				Name:        "time_created",
-				Description: "Specifies the time at which the Virtual Machine resource was created.",
-				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("VirtualMachineProperties.TimeCreated").Transform(convertDateToTime),
 			},
 			{
 				Name:        "win_rm",

--- a/azure/table_azure_compute_virtual_machine.go
+++ b/azure/table_azure_compute_virtual_machine.go
@@ -345,6 +345,12 @@ func tableAzureComputeVirtualMachine(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VirtualMachineProperties.SecurityProfile"),
 			},
 			{
+				Name:        "time_created",
+				Description: "Specifies the time at which the Virtual Machine resource was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("VirtualMachineProperties.TimeCreated").Transform(convertDateToTime),
+			},
+			{
 				Name:        "win_rm",
 				Description: "Specifies the windows remote management listeners. This enables remote windows powershell.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select name, statuses, time_created from azure_compute_virtual_machine
{
 "rows": [
  {
   "name": "test-delete-me",
   "statuses": [
    {
     "code": "ProvisioningState/succeeded",
     "displayStatus": "Provisioning succeeded",
     "level": "Info",
     "time": "2024-08-27T08:41:11.2737688Z"
    },
    {
     "code": "PowerState/deallocated",
     "displayStatus": "VM deallocated",
     "level": "Info"
    }
   ],
   "time_created": "2024-08-27T14:06:36+05:30"
  }
 ],
 "metadata": {
  "duration_ms": 2777,
  "scans": null,
  "scan_count": 1,
  "rows_returned": 1,
  "uncached_rows_fetched": 1,
  "cached_rows_fetched": 0,
  "hydrate_calls": 1,
  "connection_count": 1
 }
}

Time: 2.8s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.
```
</details>
