### PR TITLE
Added missing columns nat_gateway, service_public_ip_address, ip_configuration, and linked_public_ip_address to the table `azure_public_ip` Closes #828

### DIFF
--- a/azure-test/tests/azure_public_ip/variables.tf
+++ b/azure-test/tests/azure_public_ip/variables.tf
@@ -42,7 +42,7 @@ resource "azurerm_public_ip" "named_test_resource" {
   resource_group_name = azurerm_resource_group.named_test_resource.name
   location            = azurerm_resource_group.named_test_resource.location
   allocation_method   = "Static"
-
+  sku = "Basic"
   tags = {
     name = var.resource_name
   }

--- a/azure/table_azure_public_ip.go
+++ b/azure/table_azure_public_ip.go
@@ -105,12 +105,6 @@ func tableAzurePublicIP(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.IPAddress"),
 			},
 			{
-				Name:        "delete_option",
-				Description: "Specify what happens to the public IP address when the VM using it is deleted. Possible values include: 'Delete', 'Detach'.",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.DeleteOption"),
-			},
-			{
 				Name:        "ip_configuration_id",
 				Description: "Contains the IP configuration ID",
 				Type:        proto.ColumnType_STRING,

--- a/azure/table_azure_public_ip.go
+++ b/azure/table_azure_public_ip.go
@@ -105,6 +105,12 @@ func tableAzurePublicIP(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.IPAddress"),
 			},
 			{
+				Name:        "delete_option",
+				Description: "Specify what happens to the public IP address when the VM using it is deleted. Possible values include: 'Delete', 'Detach'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.DeleteOption"),
+			},
+			{
 				Name:        "ip_configuration_id",
 				Description: "Contains the IP configuration ID",
 				Type:        proto.ColumnType_STRING,
@@ -145,6 +151,30 @@ func tableAzurePublicIP(_ context.Context) *plugin.Table {
 				Description: "A list of tags associated with the public IP address",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.IPTags"),
+			},
+			{
+				Name:        "nat_gateway",
+				Description: "The NatGateway for the Public IP address.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.NatGateway"),
+			},
+			{
+				Name:        "service_public_ip_address",
+				Description: "The service public IP address of the public IP address resource.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.ServicePublicIPAddress"),
+			},
+			{
+				Name:        "ip_configuration",
+				Description: "The IP configuration associated with the public IP address.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.IPConfiguration"),
+			},
+			{
+				Name:        "linked_public_ip_address",
+				Description: "The linked public IP address of the public IP address resource.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("PublicIPAddressPropertiesFormat.LinkedPublicIPAddress"),
 			},
 			{
 				Name:        "zones",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/azure_public_ip []

PRETEST: tests/azure_public_ip

TEST: tests/azure_public_ip
Running terraform
data.azurerm_client_config.current: Reading...
data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9MDZmZDQ2YjAtYTg2Ny00OWExLWE0ZjEtZjc3Njg0NjVjYWJhO3N1YnNjcmlwdGlvbklkPWQ0NmQ3NDE2LWY5NWYtNDc3MS1iYmI1LTUyOWQ0Yzc2NjU5Yzt0ZW5hbnRJZD1jZGZmZDcwOC03ZGEwLTRjZWEtYWJlYi0wYTRjMzM0ZDdmNjQ=]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_public_ip.named_test_resource will be created
  + resource "azurerm_public_ip" "named_test_resource" {
      + allocation_method       = "Static"
      + ddos_protection_mode    = "VirtualNetworkInherited"
      + fqdn                    = (known after apply)
      + id                      = (known after apply)
      + idle_timeout_in_minutes = 4
      + ip_address              = (known after apply)
      + ip_version              = "IPv4"
      + location                = "westus"
      + name                    = "turbottest95004"
      + resource_group_name     = "turbottest95004"
      + sku                     = "Basic"
      + sku_tier                = "Regional"
      + tags                    = {
          + "name" = "turbottest95004"
        }
    }

  # azurerm_resource_group.named_test_resource will be created
  + resource "azurerm_resource_group" "named_test_resource" {
      + id       = (known after apply)
      + location = "westus"
      + name     = "turbottest95004"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka       = (known after apply)
  + resource_aka_lower = (known after apply)
  + resource_id        = (known after apply)
  + resource_name      = "turbottest95004"
  + subscription_id    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
azurerm_resource_group.named_test_resource: Creating...
azurerm_resource_group.named_test_resource: Still creating... [10s elapsed]
azurerm_resource_group.named_test_resource: Creation complete after 12s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004]
azurerm_public_ip.named_test_resource: Creating...
azurerm_public_ip.named_test_resource: Creation complete after 8s [id=/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 29, in data "null_data_source" "resource":
  29: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004"
resource_aka_lower = "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest95004/providers/microsoft.network/publicipaddresses/turbottest95004"
resource_id = "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004"
resource_name = "turbottest95004"
subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

Running SQL query: test-get-query.sql

Time: 1.6s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) azure_public_ip.azure: Time: 1.4s. Fetched: 1. Hydrates: 0. Quals: name=turbottest95004, resource_group=turbottest95004.

[
  {
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004",
    "name": "turbottest95004",
    "region": "westus",
    "resource_group": "turbottest95004",
    "type": "Microsoft.Network/publicIPAddresses"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 1.5s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) azure_public_ip.azure: Time: 1.2s. Fetched: 1. Hydrates: 0. Quals: name=turbottest95004, resource_group=turbottest95004.

[
  {
    "akas": [
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004",
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest95004/providers/microsoft.network/publicipaddresses/turbottest95004"
    ],
    "name": "turbottest95004",
    "public_ip_allocation_method": "Static",
    "sku_name": "Basic",
    "tags": {
      "name": "turbottest95004"
    },
    "title": "turbottest95004"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 1.9s. Rows returned: 1. Rows fetched: 4. Hydrate calls: 0.

Scans:
  1) azure_public_ip.azure: Time: 1.7s. Fetched: 4. Hydrates: 0. Quals: name=turbottest95004.

[
  {
    "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004",
    "name": "turbottest95004"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

Time: 1.4s. Rows returned: 0.
[]
✔ PASSED

Running SQL query: test-turbot-query.sql

Time: 2.3s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) azure_public_ip.azure: Time: 2.1s. Fetched: 1. Hydrates: 0. Quals: name=turbottest95004, resource_group=turbottest95004.

[
  {
    "akas": [
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/turbottest95004/providers/Microsoft.Network/publicIPAddresses/turbottest95004",
      "azure:///subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/turbottest95004/providers/microsoft.network/publicipaddresses/turbottest95004"
    ],
    "name": "turbottest95004",
    "tags": {
      "name": "turbottest95004"
    },
    "title": "turbottest95004"
  }
]
✔ PASSED

POSTTEST: tests/azure_public_ip

TEARDOWN: tests/azure_public_ip

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, ip_configuration_id from azure_public_ip
+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name    | ip_configuration_id                                                                                                                                                                    |
+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tesgss  | /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.Network/applicationGateways/test64443/frontendIPConfigurations/appGwPublicFrontendIpIPv4 |
| ewrwerw | /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.Network/applicationGateways/test5333/frontendIPConfigurations/appGwPublicFrontendIpIPv4  |
+---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

> select name, delete_option, nat_gateway, service_public_ip_address, ip_configuration, linked_public_ip_address from azure_public_ip
+----------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------>
| name     | delete_option | nat_gateway                                                                                                                             | service_public_ip_address | ip_configuration                                                                                                       >
+----------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------>
| tesgss   |               | <null>                                                                                                                                  | <null>                    | {"id":"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.Network/applicatio>
| test6633 |               | {"id":"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.Network/natGateways/test55522233"} | <null>                    | <null>                                                                                                                 >
| ewrwerw  |               | <null>                                                                                                                                  | <null>                    | {"id":"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.Network/applicatio>
+----------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------>

```
</details>
