### PR TITLE
Add table azure_compute_virtual_machine_size Closes #826

### DIFF
--- a/azure/plugin.go
+++ b/azure/plugin.go
@@ -79,6 +79,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"azure_compute_virtual_machine_scale_set":                      tableAzureComputeVirtualMachineScaleSet(ctx),
 			"azure_compute_virtual_machine_scale_set_network_interface":    tableAzureComputeVirtualMachineScaleSetNetworkInterface(ctx),
 			"azure_compute_virtual_machine_scale_set_vm":                   tableAzureComputeVirtualMachineScaleSetVm(ctx),
+			"azure_compute_virtual_machine_size":                           tableAzureComputeVirtualMachineSize(ctx),
 			"azure_consumption_usage":                                      tableAzureConsumptionUsage(ctx),
 			"azure_container_group":                                        tableAzureContainerGroup(ctx),
 			"azure_container_registry":                                     tableAzureContainerRegistry(ctx),

--- a/azure/table_azure_compute_virtual_machine_size.go
+++ b/azure/table_azure_compute_virtual_machine_size.go
@@ -27,13 +27,13 @@ func tableAzureComputeVirtualMachineSize(_ context.Context) *plugin.Table {
 				Name:        "name",
 				Description: "The name of the virtual machine size.",
 				Type:        proto.ColumnType_STRING,
-				Transform: transform.FromField("VirtualMachineSize.Name"),
+				Transform:   transform.FromField("VirtualMachineSize.Name"),
 			},
 			{
 				Name:        "number_of_cores",
 				Description: "The number of cores supported by the virtual machine size.",
 				Type:        proto.ColumnType_INT,
-				Transform: transform.FromField("VirtualMachineSize.NumberOfCores"),
+				Transform:   transform.FromField("VirtualMachineSize.NumberOfCores"),
 			},
 			{
 				Name:        "os_disk_size_in_mb",

--- a/azure/table_azure_compute_virtual_machine_size.go
+++ b/azure/table_azure_compute_virtual_machine_size.go
@@ -111,6 +111,12 @@ func listComputeVirtualMachineSizes(ctx context.Context, d *plugin.QueryData, h 
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
+			// In Azure, resource providers are services that allow you to interact with resources (like virtual machines). 
+			// The relevant resource provider for Virtual Machines is `Microsoft.Compute`. 
+			// If this provider is not registered, or if it's not available in the specified region, you might encounter the error.
+                        // You can use the command (`az provider show --namespace Microsoft.Compute`) to check the availability of the service in the specified location.
+                        // Look for the `locations/vmSizes` resource type in the command result to verify it's availability.
+			
 			if strings.Contains(strings.ToLower(err.Error()), "no registered resource provider found for location") {
 				plugin.Logger(ctx).Error("azure_compute_virtual_machine_size.listComputeVirtualMachineSizes", "no registered resource provider found", err.Error())
 				return nil, nil

--- a/azure/table_azure_compute_virtual_machine_size.go
+++ b/azure/table_azure_compute_virtual_machine_size.go
@@ -1,0 +1,134 @@
+package azure
+
+import (
+	"context"
+	"strings"
+
+	sub "github.com/Azure/azure-sdk-for-go/profiles/latest/subscription/mgmt/subscription"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION ////
+
+func tableAzureComputeVirtualMachineSize(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "azure_compute_virtual_machine_size",
+		Description: "Azure Compute Virtual Machine Size",
+		List: &plugin.ListConfig{
+			ParentHydrate: listLocations,
+			Hydrate:       listComputeVirtualMachineSizes,
+		},
+		Columns: azureColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name of the virtual machine size.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField("VirtualMachineSize.Name"),
+			},
+			{
+				Name:        "number_of_cores",
+				Description: "The number of cores supported by the virtual machine size.",
+				Type:        proto.ColumnType_INT,
+				Transform: transform.FromField("VirtualMachineSize.NumberOfCores"),
+			},
+			{
+				Name:        "os_disk_size_in_mb",
+				Description: "The OS disk size, in MB, allowed by the virtual machine size.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("VirtualMachineSize.OSDiskSizeInMB"),
+			},
+			{
+				Name:        "resource_disk_size_in_mb",
+				Description: "The resource disk size, in MB, allowed by the virtual machine size.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("VirtualMachineSize.ResourceDiskSizeInMB"),
+			},
+			{
+				Name:        "memory_in_mb",
+				Description: "The amount of memory, in MB, supported by the virtual machine size.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("VirtualMachineSize.MemoryInMB"),
+			},
+			{
+				Name:        "max_data_disk_count",
+				Description: "The maximum number of data disks that can be attached to the virtual machine size.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("VirtualMachineSize.MaxDataDiskCount"),
+			},
+
+			// Standard steampipe columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("VirtualMachineSize.Name"),
+			},
+
+			// Azure standard columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Location").Transform(toLower),
+			},
+		}),
+	}
+}
+
+type VMSizeInfo struct {
+	*armcompute.VirtualMachineSize
+	Location string
+}
+
+//// LIST FUNCTION ////
+
+func listComputeVirtualMachineSizes(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	if h.Item == nil {
+		return nil, nil
+	}
+
+	locationDetails := h.Item.(sub.Location)
+
+	session, err := GetNewSessionUpdated(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_compute_virtual_machine_size.listComputeVirtualMachineSizes", "session_error", err)
+		return nil, err
+	}
+
+	session.ClientOptions.APIVersion = "2024-07-01"
+
+	clientFactory, err := armcompute.NewVirtualMachineSizesClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	pager := clientFactory.NewListPager(*locationDetails.Name, &armcompute.VirtualMachineSizesClientListOptions{})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "no registered resource provider found for location") {
+				plugin.Logger(ctx).Error("azure_compute_virtual_machine_size.listComputeVirtualMachineSizes", "no registered resource provider found", err.Error())
+				return nil, nil
+			}
+			plugin.Logger(ctx).Error("azure_compute_virtual_machine_size.listComputeVirtualMachineSizes", "api_error", err)
+			return nil, err
+		}
+
+		for _, virtualMachineSize := range page.Value {
+			d.StreamListItem(ctx, VMSizeInfo{virtualMachineSize, *locationDetails.Name})
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			// if there is a limit, it will return the number of rows required to reach this limit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+

--- a/docs/tables/azure_compute_virtual_machine_size.md
+++ b/docs/tables/azure_compute_virtual_machine_size.md
@@ -1,0 +1,137 @@
+---
+title: "Steampipe Table: azure_compute_virtual_machine_size - Query Azure Virtual Machine Sizes using SQL"
+description: "Allows users to query available virtual machine sizes in Azure, providing details on cores, memory, disk sizes, and more."
+---
+
+# Table: azure_compute_virtual_machine_size - Query Azure Virtual Machine Sizes using SQL
+
+Azure virtual machine sizes determine the computing resources, such as memory, CPU cores, and disk capacity, available to your virtual machines (VMs). The `azure_compute_virtual_machine_size` table in Steampipe allows you to query and explore the different virtual machine sizes available in Azure, enabling you to compare memory, disk sizes, and other attributes to choose the right VM for your workload.
+
+## Table Usage Guide
+
+The `azure_compute_virtual_machine_size` table is useful for cloud architects, administrators, and DevOps engineers who need insights into the available VM sizes in Azure. You can query attributes like the number of cores, memory, and disk sizes to make informed decisions about the resources required for your virtual machines.
+
+## Examples
+
+### Basic VM size information
+Retrieve basic information about the virtual machine sizes, including name, region, and number of cores.
+
+```sql+postgres
+select
+  name,
+  region,
+  number_of_cores,
+  memory_in_mb
+from
+  azure_compute_virtual_machine_size;
+```
+
+```sql+sqlite
+select
+  name,
+  region,
+  number_of_cores,
+  memory_in_mb
+from
+  azure_compute_virtual_machine_size;
+```
+
+### List VM sizes with high memory
+Identify VM sizes that have more than a specified amount of memory (e.g., 32 GB).
+
+```sql+postgres
+select
+  name,
+  memory_in_mb,
+  number_of_cores
+from
+  azure_compute_virtual_machine_size
+where
+  memory_in_mb > 32768;
+```
+
+```sql+sqlite
+select
+  name,
+  memory_in_mb,
+  number_of_cores
+from
+  azure_compute_virtual_machine_size
+where
+  memory_in_mb > 32768;
+```
+
+### List VM sizes with large OS disk size
+Fetch VM sizes that support large OS disk sizes (e.g., over 500 GB).
+
+```sql+postgres
+select
+  name,
+  os_disk_size_in_mb,
+  max_data_disk_count
+from
+  azure_compute_virtual_machine_size
+where
+  os_disk_size_in_mb > 512000;
+```
+
+```sql+sqlite
+select
+  name,
+  os_disk_size_in_mb,
+  max_data_disk_count
+from
+  azure_compute_virtual_machine_size
+where
+  os_disk_size_in_mb > 512000;
+```
+
+### List VM sizes by core count
+Retrieve a list of VM sizes based on the number of cores available.
+
+```sql+postgres
+select
+  name,
+  number_of_cores,
+  region
+from
+  azure_compute_virtual_machine_size
+where
+  number_of_cores >= 8;
+```
+
+```sql+sqlite
+select
+  name,
+  number_of_cores,
+  region
+from
+  azure_compute_virtual_machine_size
+where
+  number_of_cores >= 8;
+```
+
+### List VM sizes with a specific data disk count
+Identify VM sizes that support a certain number of data disks.
+
+```sql+postgres
+select
+  name,
+  max_data_disk_count,
+  resource_disk_size_in_mb
+from
+  azure_compute_virtual_machine_size
+where
+  max_data_disk_count >= 8;
+```
+
+```sql+sqlite
+select
+  name,
+  max_data_disk_count,
+  resource_disk_size_in_mb
+from
+  azure_compute_virtual_machine_size
+where
+  max_data_disk_count >= 8;
+```

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	cloud.google.com/go/storage v1.36.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.10 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 h1:sUFnFjzDUie80h24I7mrKtw
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0/go.mod h1:52JbnQTp15qg5mRkMBHwp0j0ZFwHJ42Sx3zVV5RE9p0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0 h1:/Di3vB4sNeQ+7A8efjUVENvyB945Wruvstucqp7ZArg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0/go.mod h1:gM3K25LQlsET3QR+4V74zxCsFAy0r6xMNN9n80SZn+4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0 h1:0nGmzwBv5ougvzfGPCO2ljFRHvun57KpNrVCMrlk0ns=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0/go.mod h1:gYq8wyDgv6JLhGbAU6gg8amCPgQWRE+aCvrV2gyzdfs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dataprotection/armdataprotection v1.0.0 h1:VFqjVi532z3gdltbAkYrPl9Ez0czn3ZPM+bjmvLq6fk=


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from azure_compute_virtual_machine_size
+---------------------------+-----------------+--------------------+--------------------------+--------------+---------------------+---------------------------+--------------------+-------------------+--------------------------------------+--------------------+----------------------------------------------------->
| name                      | number_of_cores | os_disk_size_in_mb | resource_disk_size_in_mb | memory_in_mb | max_data_disk_count | title                     | region             | cloud_environment | subscription_id                      | sp_connection_name | sp_ctx                                              >
+---------------------------+-----------------+--------------------+--------------------------+--------------+---------------------+---------------------------+--------------------+-------------------+--------------------------------------+--------------------+----------------------------------------------------->
| Standard_E64_v4           | 64              | 1047552            | 0                        | 516096       | 32                  | Standard_E64_v4           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E64s_v4          | 64              | 1047552            | 0                        | 516096       | 32                  | Standard_E64s_v4          | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E2_v5            | 2               | 1047552            | 0                        | 16384        | 4                   | Standard_E2_v5            | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E4_v5            | 4               | 1047552            | 0                        | 32768        | 8                   | Standard_E4_v5            | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E4-2s_v3         | 4               | 1047552            | 65536                    | 32768        | 8                   | Standard_E4-2s_v3         | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E8_v5            | 8               | 1047552            | 0                        | 65536        | 16                  | Standard_E8_v5            | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E4s_v3           | 4               | 1047552            | 65536                    | 32768        | 8                   | Standard_E4s_v3           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E16_v5           | 16              | 1047552            | 0                        | 131072       | 32                  | Standard_E16_v5           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E20_v5           | 20              | 1047552            | 0                        | 163840       | 32                  | Standard_E20_v5           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E32_v5           | 32              | 1047552            | 0                        | 262144       | 32                  | Standard_E32_v5           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E48_v5           | 48              | 1047552            | 0                        | 393216       | 32                  | Standard_E48_v5           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E64_v5           | 64              | 1047552            | 0                        | 524288       | 32                  | Standard_E64_v5           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E96_v5           | 96              | 1047552            | 0                        | 688128       | 32                  | Standard_E96_v5           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_A8m_v2           | 8               | 1047552            | 81920                    | 65536        | 16                  | Standard_A8m_v2           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E104i_v5         | 104             | 1047552            | 0                        | 688128       | 64                  | Standard_E104i_v5         | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_D64_v3           | 64              | 1047552            | 1638400                  | 262144       | 32                  | Standard_D64_v3           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E4-2ds_v4        | 4               | 1047552            | 153600                   | 32768        | 8                   | Standard_E4-2ds_v4        | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_F2               | 2               | 1047552            | 32768                    | 4096         | 8                   | Standard_F2               | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_L80s_v2          | 80              | 1047552            | 819200                   | 655360       | 32                  | Standard_L80s_v2          | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_F8               | 8               | 1047552            | 131072                   | 16384        | 32                  | Standard_F8               | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_A0               | 1               | 1047552            | 20480                    | 768          | 1                   | Standard_A0               | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>
| Standard_E32_v3           | 32              | 1047552            | 819200                   | 262144       | 32                  | Standard_E32_v3           | eastus2            | AzurePublicCloud  | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | azure              | {"connection_name":"azure","steampipe":{"sdk_version>

```
</details>
