### PR TITLE
Add column public_network_access and data_access_auth_mode to table azure_compute_disk. Closes #843

### DIFF
--- a/azure/table_azure_compute_disk.go
+++ b/azure/table_azure_compute_disk.go
@@ -175,6 +175,18 @@ func tableAzureComputeDisk(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DiskProperties.NetworkAccessPolicy"),
 			},
 			{
+				Name:        "public_network_access",
+				Description: "Public network access for the disk can be enabled or disabled",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DiskProperties.PublicNetworkAccess"),
+			},
+			{
+				Name:        "data_access_auth_mode",
+				Description: "The mode to use for data access to the disk",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DiskProperties.DataAccessAuthMode"),
+			},
+			{
 				Name:        "creation_data_option",
 				Description: "This enumerates the possible sources of a disk's creation",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
### Compliance queries dependent on these columns:
  Needed for cis_v300 section 8.5 and 8.6
```
> select name, public_network_access, data_access_auth_mode from azure_compute_disk
+-----------------+-----------------------+-----------------------+
| name            | public_network_access | data_access_auth_mode |
+-----------------+-----------------------+-----------------------+
| disk-123        | Disabled              | AzureActiveDirectory  |
| turbottest76149 | Enabled               |                       |
+-----------------+-----------------------+-----------------------+

select
      disk.id as resource,
      case
        when network_access_policy in ('DenyAll','AllowPrivate') and public_network_access = 'Disabled' then 'ok'
        else 'alarm'
      end as status,
      case
        when network_access_policy in ('DenyAll','AllowPrivate') and public_network_access = 'Disabled' then disk.name || ' network access disabled.'
        else disk.name || ' network access enabled.'
      end as reason
    from
      azure_compute_disk disk,
      azure_subscription sub
    where
      sub.subscription_id = disk.subscription_id;
+-------------------------------------------------------------------------------------------------------------------+--------+--------------------------->
| resource                                                                                                          | status | reason                    >
+-------------------------------------------------------------------------------------------------------------------+--------+--------------------------->
| /subscriptions/ddddddddddddddddddddddddddddd/resourceGroups/DEMO/providers/Microsoft.Compute/disks/test-pc | ok     | test-pc network access dis>
+-------------------------------------------------------------------------------------------------------------------+--------+--------------------------->


select
      disk.id as resource,
      case
        when data_access_auth_mode = 'AzureActiveDirectory' then 'ok'
        else 'alarm'
      end as status,
      case
        when data_access_auth_mode = 'AzureActiveDirectory' then disk.name || ' data authentication mode enabled.'
        else disk.name || ' data authentication mode disabled.'
      end as reason
    from
      azure_compute_disk disk,
      azure_subscription sub
    where
      sub.subscription_id = disk.subscription_id;
+-------------------------------------------------------------------------------------------------------------------+--------+--------------------------->
| resource                                                                                                          | status | reason                    >
+-------------------------------------------------------------------------------------------------------------------+--------+--------------------------->
| /subscriptions/ddddddddddddddddddddddddddddd/resourceGroups/DEMO/providers/Microsoft.Compute/disks/test-pc | ok     | test-pc data authenticatio>
+-------------------------------------------------------------------------------------------------------------------+--------+--------------------------->

select id,name,network_access_policy,data_access_auth_mode from azure_compute_disk
+--------------------------------------------------------------------------------------------------------------------+----------+-----------------------+-----------------------+
| id                                                                                                                 | name     | network_access_policy | data_access_auth_mode |
+--------------------------------------------------------------------------------------------------------------------+----------+-----------------------+-----------------------+
| /subscriptions/ddddddddddddddddddddddddddddd/resourceGroups/DEMO/providers/Microsoft.Compute/disks/disk-123 | disk-123 | DenyAll               | AzureActiveDirectory  |
+--------------------------------------------------------------------------------------------------------------------+----------+-----------------------+-----------------------+

```
</details>
