### PR TITLE
Fixed azure_mysql_flexible_server fails when the server is stopped Closes #859

### DIFF
--- a/azure/table_azure_mysql_flexible_server.go
+++ b/azure/table_azure_mysql_flexible_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -339,6 +340,43 @@ func listMySQLFlexibleServersConfigurations(ctx context.Context, d *plugin.Query
 		return nil, err
 	}
 
+	// Return nil for the specific states of the flexible server where the 
+	// API does not allow any operations to be performed.
+
+	// Since it is challenging to test all possible states("Disabled", "Dropping", "Ready", "Starting", "Stopped", "Stopping", "Updating") of the flexible server, 
+	// we have added a check to restrict 
+	// API calls for the "Stopping" and "Stopped" states based on current testing.
+
+	// This logic may need to be updated in the future if the API behavior changes or if additional states need to be handled.
+
+	// 1. Stopping: 
+		// Error: azure: GET https://management.azure.com/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
+		// --------------------------------------------------------------------------------
+		// RESPONSE 503: 503 Service Unavailable
+		// ERROR CODE: ServiceBusy
+		// --------------------------------------------------------------------------------
+		// {
+		//   "error": {
+		//     "code": "ServiceBusy",
+		//     "message": "Service is temporarily busy and the operation cannot be performed. Please try again later."
+		//   }
+		// }
+	// 2. Stopped
+		// Error: azure: GET https://management.azure.com/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
+		// --------------------------------------------------------------------------------
+		// RESPONSE 409: 409 Conflict
+		// ERROR CODE: ServerUnavailableForOperation
+		// --------------------------------------------------------------------------------
+		// {
+		//   "error": {
+		// 	"code": "ServerUnavailableForOperation",
+		// 	"message": "Operation 'GetServerParameters' cannot be performed as server 'test53' is currently in state 'Stopped'."
+		//   }
+		// }
+	// 3. Starting: We are not getting any error
+	if server.Properties != nil && helpers.StringSliceContains([]string{"Stopping", "Stopped", "Updating"},  string(*server.Properties.State)) {
+		return nil, nil
+	}
 	pager := client.NewListByServerPager(resourceGroup, serverName, nil)
 
 	var mySQLFlexibleServersConfigurations []map[string]interface{}

--- a/azure/table_azure_mysql_flexible_server.go
+++ b/azure/table_azure_mysql_flexible_server.go
@@ -350,7 +350,7 @@ func listMySQLFlexibleServersConfigurations(ctx context.Context, d *plugin.Query
 	// This logic may need to be updated in the future if the API behavior changes or if additional states need to be handled.
 
 	// 1. Stopping: 
-		// Error: azure: GET https://management.azure.com/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
+		// Error: azure: GET https://management.azure.com/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
 		// --------------------------------------------------------------------------------
 		// RESPONSE 503: 503 Service Unavailable
 		// ERROR CODE: ServiceBusy
@@ -362,7 +362,7 @@ func listMySQLFlexibleServersConfigurations(ctx context.Context, d *plugin.Query
 		//   }
 		// }
 	// 2. Stopped
-		// Error: azure: GET https://management.azure.com/subscriptions/d46d7416-f95f-4771-bbb5-529d4c76659c/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
+		// Error: azure: GET https://management.azure.com/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
 		// --------------------------------------------------------------------------------
 		// RESPONSE 409: 409 Conflict
 		// ERROR CODE: ServerUnavailableForOperation


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

**Before Fix:**  
```
> select name, state from azure_mysql_flexible_server;
+--------+---------+
| name   | state   |
+--------+---------+
| test53 | Stopped |
```

```
> select * from azure_mysql_flexible_server;

Error: azure: GET https://management.azure.com/subscriptions/xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53/configurations
--------------------------------------------------------------------------------
RESPONSE 409: 409 Conflict
ERROR CODE: ServerUnavailableForOperation
--------------------------------------------------------------------------------
{
  "error": {
    "code": "ServerUnavailableForOperation",
    "message": "Operation 'GetServerParameters' cannot be performed as server 'test53' is currently in state 'Stopped'."
  }
}
--------------------------------------------------------------------------------
 (SQLSTATE HV000)

+------+----+------+-------+---------+---------------------+-------------------+-----------------------+-------------+-----------------------+-----------------------------+----------------------+----------+-----------------------+------------------+------------------+->
| name | id | type | state | version | administrator_login | availability_zone | backup_retention_days | create_mode | earliest_restore_date | fully_qualified_domain_name | geo_redundant_backup | location | public_network_access | replica_capacity | replication_role | >
+------+----+------+-------+---------+---------------------+-------------------+-----------------------+-------------+-----------------------+-----------------------------+----------------------+----------+-----------------------+------------------+------------------+->
+------+----+------+-------+---------+---------------------+-------------------+-----------------------+-------------+-----------------------+-----------------------------+----------------------+----------+-----------------------+------------------+------------------+->
```


**After fix:**

```
> select name, state from azure_mysql_flexible_server;
+--------+-------+
| name   | state |
+--------+-------+
| test53 | Ready |
+--------+-------+
> select * from azure_mysql_flexible_server;
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+-------+---------+---------------------+-------------------+-----------------------+------>
| name   | id                                                                                                                              | type                                 | state | version | administrator_login | availability_zone | backup_retention_days | creat>
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+-------+---------+---------------------+-------------------+-----------------------+------>
| test53 | /subscriptions/xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53 | Microsoft.DBforMySQL/flexibleServers | Ready | 8.0.21  | partha              | 1                 | 7                     | <null>
|        |                                                                                                                                 |                                      |       |         |                     |                   |                       |      >

```


```
> select name, state from azure_mysql_flexible_server;
+--------+----------+
| name   | state    |
+--------+----------+
| test53 | Stopping |
+--------+----------+
> select * from azure_mysql_flexible_server;
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+----------+---------+---------------------+-------------------+-----------------------+--->
| name   | id                                                                                                                              | type                                 | state    | version | administrator_login | availability_zone | backup_retention_days | cr>
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+----------+---------+---------------------+-------------------+-----------------------+--->
| test53 | /subscriptions/xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53 | Microsoft.DBforMySQL/flexibleServers | Stopping | 8.0.21  | partha              | 1                 | 7                     | <n>
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+----------+---------+---------------------+-------------------+-----------------------+--->

```


```
> select name, state from azure_mysql_flexible_server;
+--------+---------+
| name   | state   |
+--------+---------+
| test53 | Stopped |
+--------+---------+
> select * from azure_mysql_flexible_server;
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+---------+---------+---------------------+-------------------+-----------------------+---->
| name   | id                                                                                                                              | type                                 | state   | version | administrator_login | availability_zone | backup_retention_days | cre>
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+---------+---------+---------------------+-------------------+-----------------------+---->
| test53 | /subscriptions/xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxxxxx/resourceGroups/new-rg/providers/Microsoft.DBforMySQL/flexibleServers/test53 | Microsoft.DBforMySQL/flexibleServers | Stopped | 8.0.21  | partha              | 1                 | 7                     | <nu>
+--------+---------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+---------+---------+---------------------+-------------------+-----------------------+----
```

</details>
