### PR TITLE
Fixed azure_role_assignment table to return all role assignments when scope is not specified in the query Closes #866

### DIFF
--- a/azure/table_azure_role_assignment.go
+++ b/azure/table_azure_role_assignment.go
@@ -147,7 +147,6 @@ func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, h *plugin.
 // listRoleAssignmentsByScope retrieves role assignments for a specific scope
 func listRoleAssignmentsByScope(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, authorizationClient *armauthorization.RoleAssignmentsClient) (interface{}, error) {
 	scope := d.EqualsQualString("scope")
-	plugin.Logger(ctx).Info("Fetching role assignments for scope:", scope)
 
 	defaultFilter := "atScope()" // filter all result
 	// Tenant ID is not a required parameter to make the API call.
@@ -187,7 +186,8 @@ func listRoleAssignmentsByScope(ctx context.Context, d *plugin.QueryData, _ *plu
 		for _, roleAssignment := range scopeRes.Value {
 			d.StreamListItem(ctx, roleAssignment)
 
-			// Stop streaming if the row limit is reached
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			// if there is a limit, it will return the number of rows required to reach this limit
 			if d.RowsRemaining(ctx) == 0 {
 				return nil, nil
 			}
@@ -212,7 +212,8 @@ func listAllRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		for _, roleAssignment := range res.Value {
 			d.StreamListItem(ctx, roleAssignment)
 
-			// Stop streaming if the row limit is reached
+			// Check if context has been cancelled or if the limit has been hit (if specified)
+			// if there is a limit, it will return the number of rows required to reach this limit
 			if d.RowsRemaining(ctx) == 0 {
 				return nil, nil
 			}

--- a/azure/table_azure_role_assignment.go
+++ b/azure/table_azure_role_assignment.go
@@ -37,12 +37,19 @@ func tableAzureIamRoleAssignment(_ context.Context) *plugin.Table {
 			// Ref: https://github.com/Azure/azure-rest-api-specs/issues/28255
 			// We will uncomment it once the issue is resolved.
 
-			// KeyColumns: []*plugin.KeyColumn{
-			// 	{
-			// 		Name:    "principal_id",
-			// 		Require: plugin.Optional,
-			// 	},
-			// },
+			KeyColumns: []*plugin.KeyColumn{
+				// When specifying the `scope` value as a query parameter in the WHERE clause,
+				// ensure that it begins with a "/" (forward slash).
+				// If omitted, the query will return empty results due to Steampipe level filtering.
+				// This is because the API response includes a leading "/" in the scope values.
+				// Example values:
+				// - "/subscriptions/<sub_id>"
+				// - "/subscriptions/<sub_id>/resourceGroups/<rg_name>"
+				{
+					Name:    "scope",
+					Require: plugin.Optional,
+				},
+			},
 		},
 		Columns: azureColumns([]*plugin.Column{
 			{
@@ -115,7 +122,7 @@ func tableAzureIamRoleAssignment(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	session, err := GetNewSessionUpdated(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("azure_role_assignment.listIamRoleAssignments", "session_error", err)
@@ -128,10 +135,25 @@ func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		return nil, err
 	}
 
+	// Check if a specific scope is provided
+	if d.EqualsQualString("scope") != "" {
+		return listRoleAssignmentsByScope(ctx, d, h, authorizationClient)
+	}
+
+	// If no scope is provided, fetch all role assignments for the subscription
+	return listAllRoleAssignments(ctx, d, h, authorizationClient)
+}
+
+// listRoleAssignmentsByScope retrieves role assignments for a specific scope
+func listRoleAssignmentsByScope(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, authorizationClient *armauthorization.RoleAssignmentsClient) (interface{}, error) {
+	scope := d.EqualsQualString("scope")
+	plugin.Logger(ctx).Info("Fetching role assignments for scope:", scope)
+
 	defaultFilter := "atScope()" // filter all result
 	// Tenant ID is not a required parameter to make the API call.
-	option := &armauthorization.RoleAssignmentsClientListForScopeOptions{
-		Filter:   &defaultFilter,
+	// List by scope input
+	listForScopeOptions := &armauthorization.RoleAssignmentsClientListForScopeOptions{
+		Filter: &defaultFilter,
 	}
 
 	// For the time being, the optional qualifiers have been commented out
@@ -154,25 +176,50 @@ func listIamRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	// 	option.Filter = &filter
 	// }
 
-	result := authorizationClient.NewListForScopePager("/subscriptions/"+session.SubscriptionID, option)
-
-	for result.More() {
-		res, err := result.NextPage(ctx)
+	response := authorizationClient.NewListForScopePager(scope, listForScopeOptions)
+	for response.More() {
+		scopeRes, err := response.NextPage(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("azure_role_assignment.listIamRoleAssignments", "api_error", err)
+			plugin.Logger(ctx).Error("azure_role_assignment.listRoleAssignmentsByScope", "api_error", err)
 			return nil, err
 		}
-		for _, roleAssignment := range res.Value {
+
+		for _, roleAssignment := range scopeRes.Value {
 			d.StreamListItem(ctx, roleAssignment)
-			// Check if context has been cancelled or if the limit has been hit (if specified)
-			// if there is a limit, it will return the number of rows required to reach this limit
+
+			// Stop streaming if the row limit is reached
 			if d.RowsRemaining(ctx) == 0 {
 				return nil, nil
 			}
 		}
 	}
 
-	return nil, err
+	return nil, nil
+}
+
+// listAllRoleAssignments retrieves all role assignments for the subscription
+func listAllRoleAssignments(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, authorizationClient *armauthorization.RoleAssignmentsClient) (interface{}, error) {
+
+	result := authorizationClient.NewListForSubscriptionPager(&armauthorization.RoleAssignmentsClientListForSubscriptionOptions{})
+
+	for result.More() {
+		res, err := result.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("azure_role_assignment.listAllRoleAssignments", "api_error", err)
+			return nil, err
+		}
+
+		for _, roleAssignment := range res.Value {
+			d.StreamListItem(ctx, roleAssignment)
+
+			// Stop streaming if the row limit is reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
 }
 
 //// HYDRATE FUNCTIONS

--- a/docs/tables/azure_role_assignment.md
+++ b/docs/tables/azure_role_assignment.md
@@ -89,3 +89,90 @@ where
   ra.scope like '/subscriptions/%'
   and json_extract(perm.value, '$.actions') = '["*"]';
 ```
+
+### Role assignments at the resource group scope
+Retrieve all role assignments that grant permissions at a specific resource group level.
+
+```sql+postgres
+select
+  name,
+  scope,
+  type,
+  principal_id.
+  principal_type
+from
+  azure_role_assignment
+where
+  scope = '/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/my-rg'
+```
+
+```sql+sqlite
+select
+  name,
+  scope,
+  type,
+  principal_id.
+  principal_type
+from
+  azure_role_assignment
+where
+  scope = '/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/my-rg'
+```
+
+### Role assignments at the management group scope
+List all role assignments that apply at the management group level, determining access across multiple subscriptions.
+
+```sql+postgres
+select
+  name,
+  scope,
+  type,
+  principal_id.
+  principal_type
+from
+  azure_role_assignment
+where
+  scope = '/providers/Microsoft.Management/managementGroups/12345678-90ab-cdef-1234-567890abcdef'
+```
+
+```sql+sqlite
+select
+  name,
+  scope,
+  type,
+  principal_id.
+  principal_type
+from
+  azure_role_assignment
+where
+  scope = '/providers/Microsoft.Management/managementGroups/12345678-90ab-cdef-1234-567890abcdef'
+```
+
+### Role assignments at the storage account scope
+Identify role assignments that provide permissions at a storage account level, enabling access control for storage resources.
+
+```sql+postgres
+select
+  name,
+  scope,
+  type,
+  principal_id.
+  principal_type
+from
+  azure_role_assignment
+where
+  scope = '/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/nist-test_group/providers/Microsoft.Storage/storageAccounts/testimmutablecontainer'
+```
+
+```sql+sqlite
+select
+  name,
+  scope,
+  type,
+  principal_id.
+  principal_type
+from
+  azure_role_assignment
+where
+  scope = '/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/nist-test_group/providers/Microsoft.Storage/storageAccounts/testimmutablecontainer'
+```


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select scope, principal_id, principal_type from azure_role_assignment where scope like '%resourceGroups%';
+-------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+------------------+
| scope                                                                                                                                                 | principal_id                         | principal_type   |
+-------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+------------------+
| /subscriptions/************************************/resourceGroups/demo                                                                               | bbc01a2e-85c3-421f-bb6b-f69874e0e788 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/demo                                                                               | 9f97c346-ab5c-4112-8270-a9570bd98538 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.Storage/storageAccounts/tailpipelog53                   | 6cffa1f4-49e5-4200-b15f-2fca4d445692 | User             |
| /subscriptions/************************************/resourceGroups/turbottest85362                                                                    | 669311e9-1ac9-40df-88ea-39f8d269c8ac | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.Storage/storageAccounts/tailpipetestsa                  | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.Storage/storageAccounts/tailpipelog53                   | 6cffa1f4-49e5-4200-b15f-2fca4d445692 | User             |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.KeyVault/vaults/CertVault3                              | a937f718-88e3-46d9-8b09-7fdf14aa8aa5 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/demo/providers/Microsoft.Storage/storageAccounts/testtailpipelogs                  | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/demo                                                                               | 5137b8d3-8040-421e-b3cd-f30ac06b6636 | User             |
| /subscriptions/************************************/resourceGroups/test-ved-delete_group/providers/Microsoft.Compute/virtualMachines/test-ved-delete  | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/demo                                                                               | 5137b8d3-8040-421e-b3cd-f30ac06b6636 | User             |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.KeyVault/vaults/CertVault3                              | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/demo                                                                               | 5137b8d3-8040-421e-b3cd-f30ac06b6636 | User             |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.Storage/storageAccounts/tailpipetestsa                  | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.KeyVault/vaults/CertVault3                              | 2cbaa7fd-26a0-4117-aed1-dedbe7ae16e7 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.Storage/storageAccounts/tailpipelog53                   | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/new-rg/providers/Microsoft.Storage/storageAccounts/tailpipetest                    | 06fd46b0-a867-49a1-a4f1-f7768465caba | User             |
| /subscriptions/************************************/resourceGroups/new-rg                                                                             | 90a76561-7df7-44fc-9b49-101401c22e74 | User             |
| /subscriptions/************************************/resourceGroups/nist-test_group/providers/Microsoft.Storage/storageAccounts/testimmutablecontainer | a87db2f7-7b10-44bd-afc5-f6ac248a78c1 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/nist-test_group                                                                    | e8fdc22d-09bf-4a2c-baa8-1d86b65becf7 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/nist-test_group                                                                    | 3c37d2b5-4223-4c7a-9904-9057544990d4 | ServicePrincipal |
| /subscriptions/************************************/resourceGroups/nist-test_group/providers/Microsoft.Storage/storageAccounts/testimmutablecontainer | fca2972e-500b-48a7-92dd-3c8e5940f3ca | ServicePrincipal |
+-------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+------------------+
```
</details>
