### PR TITLE
Fix tiny typo: s/evens/events

### DIFF
--- a/docs/tables/azure_monitor_activity_log_event.md
+++ b/docs/tables/azure_monitor_activity_log_event.md
@@ -204,7 +204,7 @@ from
 
 ## Filter examples
 
-### List evens by resource group
+### List events by resource group
 Discover the segments that are active within a specific resource group in Azure Monitor's activity log. This can be particularly useful for tracking and managing operations, resources, and statuses associated with specific events.
 
 ```sql+postgres


### PR DESCRIPTION
Just a typo fix in the header of some markdown.