### PR TITLE
Fixed `error failed with panic reflect: call of reflect.Value.FieldByName on ptr Value` for the tables `azure_data_protection_backup_vault` and `azure_security_center_contact` Closes #916

### DIFF
--- a/azure/table_azure_data_protection_backup_vault.go
+++ b/azure/table_azure_data_protection_backup_vault.go
@@ -147,9 +147,6 @@ func listAzureDataProtectionBackupVaults(ctx context.Context, d *plugin.QueryDat
 		return nil, err
 	}
 
-	// Apply Retry rule
-	ApplyRetryRules(ctx, &clientFactory, d.Connection)
-
 	input := &armdataprotection.BackupVaultsClientGetInSubscriptionOptions{}
 
 	pager := clientFactory.NewGetInSubscriptionPager(input)

--- a/azure/table_azure_security_center_contact.go
+++ b/azure/table_azure_security_center_contact.go
@@ -121,9 +121,6 @@ func listSecurityCenterContacts(ctx context.Context, d *plugin.QueryData, _ *plu
 		return nil, err
 	}
 
-	// Apply Retry rule
-	ApplyRetryRules(ctx, &clientFactory, d.Connection)
-
 	pager := clientFactory.NewListPager(&armsecurity.ContactsClientListOptions{})
 	for pager.More() {
 		page, err := pager.NextPage(ctx)


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
