### PR TITLE
Fixed table azure_storage_account throws no such host error for premium type storage account and added a new column key_policy Closes #919

### DIFF
--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -526,7 +526,7 @@ func tableAzureStorageAccount(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "key_policy",
-				Description: "KeyPolicy assigned to the storage account..",
+				Description: "KeyPolicy assigned to the storage account.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Account.AccountProperties.KeyPolicy"),
 			},


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, key_policy from azure_storage_account
+------------------------+----------------------------------+
| name                   | key_policy                       |
+------------------------+----------------------------------+
| testcompliancemod      | <null>                           |
| premiumtable           | <null>                           |
| pyddgroup81fd          | <null>                           |
| testimmutablecontainer | <null>                           |
| testpremiumpartha      | {"keyExpirationPeriodInDays":60} |
| demob349               | {"keyExpirationPeriodInDays":60} |
| tets5666linuxgroupaf20 | <null>                           |
| tailpipelog53          | <null>                           |
+------------------------+----------------------------------+
```
</details>
