### PR TITLE
feat: add support_plan to azure_kubernetes_cluster table

### DIFF
--- a/azure/table_azure_kubernetes_cluster.go
+++ b/azure/table_azure_kubernetes_cluster.go
@@ -135,7 +135,7 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 				Name:        "aad_profile",
 				Description: "Profile of Azure Active Directory configuration.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Properties.AadProfile"),
+				Transform:   transform.FromField("Properties.AADProfile"),
 			},
 			{
 				Name:        "addon_profiles",

--- a/azure/table_azure_kubernetes_cluster.go
+++ b/azure/table_azure_kubernetes_cluster.go
@@ -212,6 +212,7 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 				Name:        "sku",
 				Description: "The managed cluster SKU.",
 				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("SKU"),
 			},
 			{
 				Name:        "windows_profile",

--- a/azure/table_azure_kubernetes_cluster.go
+++ b/azure/table_azure_kubernetes_cluster.go
@@ -3,7 +3,7 @@ package azure
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 
@@ -57,115 +57,115 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 				Name:        "azure_portal_fqdn",
 				Description: "FQDN for the master pool which used by proxy config.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.AzurePortalFQDN"),
+				Transform:   transform.FromField("Properties.AzurePortalFQDN"),
 			},
 			{
 				Name:        "disk_encryption_set_id",
 				Description: "ResourceId of the disk encryption set to use for enabling encryption at rest.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.DiskEncryptionSetID"),
+				Transform:   transform.FromField("Properties.DiskEncryptionSetID"),
 			},
 			{
 				Name:        "dns_prefix",
 				Description: "DNS prefix specified when creating the managed cluster.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.DNSPrefix"),
+				Transform:   transform.FromField("Properties.DNSPrefix"),
 			},
 			{
 				Name:        "enable_pod_security_policy",
 				Description: "Whether to enable Kubernetes pod security policy (preview).",
 				Type:        proto.ColumnType_BOOL,
-				Transform:   transform.FromField("ManagedClusterProperties.EnablePodSecurityPolicy"),
+				Transform:   transform.FromField("Properties.EnablePodSecurityPolicy"),
 			},
 			{
 				Name:        "enable_rbac",
 				Description: "Whether to enable Kubernetes Role-Based Access Control.",
 				Type:        proto.ColumnType_BOOL,
-				Transform:   transform.FromField("ManagedClusterProperties.EnableRBAC"),
+				Transform:   transform.FromField("Properties.EnableRBAC"),
 			},
 			{
 				Name:        "fqdn",
 				Description: "FQDN for the master pool.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.Fqdn"),
+				Transform:   transform.FromField("Properties.Fqdn"),
 			},
 			{
 				Name:        "fqdn_subdomain",
 				Description: "FQDN subdomain specified when creating private cluster with custom private dns zone.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.FqdnSubdomain"),
+				Transform:   transform.FromField("Properties.FqdnSubdomain"),
 			},
 			{
 				Name:        "kubernetes_version",
 				Description: "Version of Kubernetes specified when creating the managed cluster.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.KubernetesVersion"),
+				Transform:   transform.FromField("Properties.KubernetesVersion"),
 			},
 			{
 				Name:        "support_plan",
 				Description: "The support plan for the Managed Cluster.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.SupportPlan"),
+				Transform:   transform.FromField("Properties.SupportPlan"),
 			},
 			{
 				Name:        "max_agent_pools",
 				Description: "The max number of agent pools for the managed cluster.",
 				Type:        proto.ColumnType_INT,
-				Transform:   transform.FromField("ManagedClusterProperties.MaxAgentPools"),
+				Transform:   transform.FromField("Properties.MaxAgentPools"),
 			},
 			{
 				Name:        "node_resource_group",
 				Description: "Name of the resource group containing agent pool nodes.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.NodeResourceGroup"),
+				Transform:   transform.FromField("Properties.NodeResourceGroup"),
 			},
 			{
 				Name:        "private_fqdn",
 				Description: "FQDN of private cluster.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.PrivateFQDN"),
+				Transform:   transform.FromField("Properties.PrivateFQDN"),
 			},
 			{
 				Name:        "provisioning_state",
 				Description: "The current deployment or provisioning state.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ManagedClusterProperties.ProvisioningState"),
+				Transform:   transform.FromField("Properties.ProvisioningState"),
 			},
 			{
 				Name:        "aad_profile",
 				Description: "Profile of Azure Active Directory configuration.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.AadProfile"),
+				Transform:   transform.FromField("Properties.AadProfile"),
 			},
 			{
 				Name:        "addon_profiles",
 				Description: "Profile of managed cluster add-on.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.AddonProfiles"),
+				Transform:   transform.FromField("Properties.AddonProfiles"),
 			},
 			{
 				Name:        "agent_pool_profiles",
 				Description: "Properties of the agent pool.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.AgentPoolProfiles"),
+				Transform:   transform.FromField("Properties.AgentPoolProfiles"),
 			},
 			{
 				Name:        "api_server_access_profile",
 				Description: "Access profile for managed cluster API server.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.APIServerAccessProfile"),
+				Transform:   transform.FromField("Properties.APIServerAccessProfile"),
 			},
 			{
 				Name:        "auto_scaler_profile",
 				Description: "Parameters to be applied to the cluster-autoscaler when enabled.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.AutoScalerProfile"),
+				Transform:   transform.FromField("Properties.AutoScalerProfile"),
 			},
 			{
 				Name:        "auto_upgrade_profile",
 				Description: "Profile of auto upgrade configuration.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.AutoUpgradeProfile"),
+				Transform:   transform.FromField("Properties.AutoUpgradeProfile"),
 			},
 			{
 				Name:        "identity",
@@ -176,37 +176,37 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 				Name:        "identity_profile",
 				Description: "Identities associated with the cluster.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.IdentityProfile"),
+				Transform:   transform.FromField("Properties.IdentityProfile"),
 			},
 			{
 				Name:        "linux_profile",
 				Description: "Profile for Linux VMs in the container service cluster.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.LinuxProfile"),
+				Transform:   transform.FromField("Properties.LinuxProfile"),
 			},
 			{
 				Name:        "network_profile",
 				Description: "Profile of network configuration.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.NetworkProfile"),
+				Transform:   transform.FromField("Properties.NetworkProfile"),
 			},
 			{
 				Name:        "pod_identity_profile",
 				Description: "Profile of managed cluster pod identity.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.PodIdentityProfile"),
+				Transform:   transform.FromField("Properties.PodIdentityProfile"),
 			},
 			{
 				Name:        "power_state",
 				Description: "Represents the Power State of the cluster.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.PowerState"),
+				Transform:   transform.FromField("Properties.PowerState"),
 			},
 			{
 				Name:        "service_principal_profile",
 				Description: "Information about a service principal identity for the cluster to use for manipulating Azure APIs.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.ServicePrincipalProfile"),
+				Transform:   transform.FromField("Properties.ServicePrincipalProfile"),
 			},
 			{
 				Name:        "sku",
@@ -217,7 +217,7 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 				Name:        "windows_profile",
 				Description: "Profile for Windows VMs in the container service cluster.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ManagedClusterProperties.WindowsProfile"),
+				Transform:   transform.FromField("Properties.WindowsProfile"),
 			},
 
 			// Steampipe standard columns
@@ -259,42 +259,31 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listKubernetesClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	plugin.Logger(ctx).Trace("azure_kubernetes_cluster.listKubernetesClusters")
+
+	session, err := GetNewSessionUpdated(ctx, d)
 	if err != nil {
+		plugin.Logger(ctx).Error("aazure_kubernetes_cluster.listAzureDataProtectionBackupJobs", "session_error", err)
 		return nil, err
 	}
-	subscriptionID := session.SubscriptionID
 
-	client := containerservice.NewManagedClustersClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
-	client.Authorizer = session.Authorizer
-
-	// Apply Retry rule
-	ApplyRetryRules(ctx, &client, d.Connection)
-
-	result, err := client.List(ctx)
+	clientFactory, err := armcontainerservice.NewManagedClustersClient(session.SubscriptionID, session.Cred, session.ClientOptions)
 	if err != nil {
+		plugin.Logger(ctx).Error("azure_kubernetes_cluster.listKubernetesClusters", "client_error", err)
 		return nil, err
 	}
-	for _, cluster := range result.Values() {
-		d.StreamListItem(ctx, cluster)
-		// Check if context has been cancelled or if the limit has been hit (if specified)
-		// if there is a limit, it will return the number of rows required to reach this limit
-		if d.RowsRemaining(ctx) == 0 {
+
+	pager := clientFactory.NewListPager(&armcontainerservice.ManagedClustersClientListOptions{})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aazure_kubernetes_cluster.listKubernetesClusters", "api_error", err)
 			return nil, nil
 		}
-	}
 
-	for result.NotDone() {
-		// Wait for rate limiting
-		d.WaitForListRateLimit(ctx)
+		for _, v := range page.Value {
+			d.StreamListItem(ctx, v)
 
-		err = result.NextWithContext(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, cluster := range result.Values() {
-			d.StreamListItem(ctx, cluster)
 			// Check if context has been cancelled or if the limit has been hit (if specified)
 			// if there is a limit, it will return the number of rows required to reach this limit
 			if d.RowsRemaining(ctx) == 0 {
@@ -303,30 +292,30 @@ func listKubernetesClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		}
 	}
 
-	return nil, err
+	return nil, nil
 }
 
 //// HYDRATE FUNCTIONS
 
 func getKubernetesCluster(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getKubernetesCluster")
+	plugin.Logger(ctx).Trace("azure_kubernetes_cluster.getKubernetesCluster")
 
-	session, err := GetNewSession(ctx, d, "MANAGEMENT")
+	session, err := GetNewSessionUpdated(ctx, d)
 	if err != nil {
+		plugin.Logger(ctx).Error("aazure_kubernetes_cluster.getKubernetesCluster", "session_error", err)
 		return nil, err
 	}
-	subscriptionID := session.SubscriptionID
 
-	client := containerservice.NewManagedClustersClientWithBaseURI(session.ResourceManagerEndpoint, subscriptionID)
-	client.Authorizer = session.Authorizer
-
-	// Apply Retry rule
-	ApplyRetryRules(ctx, &client, d.Connection)
+	clientFactory, err := armcontainerservice.NewManagedClustersClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_kubernetes_cluster.getKubernetesCluster", "client_error", err)
+		return nil, err
+	}
 
 	resourceName := d.EqualsQuals["name"].GetStringValue()
 	resourceGroupName := d.EqualsQuals["resource_group"].GetStringValue()
 
-	op, err := client.Get(ctx, resourceGroupName, resourceName)
+	op, err := clientFactory.Get(ctx, resourceGroupName, resourceName, &armcontainerservice.ManagedClustersClientGetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/azure/table_azure_kubernetes_cluster.go
+++ b/azure/table_azure_kubernetes_cluster.go
@@ -102,6 +102,12 @@ func tableAzureKubernetesCluster(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("ManagedClusterProperties.KubernetesVersion"),
 			},
 			{
+				Name:        "support_plan",
+				Description: "The support plan for the Managed Cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ManagedClusterProperties.SupportPlan"),
+			},
+			{
 				Name:        "max_agent_pools",
 				Description: "The max number of agent pools for the managed cluster.",
 				Type:        proto.ColumnType_INT,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, support_plan from azure_kubernetes_cluster
+----------------------+--------------------+
| name                 | support_plan       |
+----------------------+--------------------+
| bdai-poc-aks-weu-aks | KubernetesOfficial |
+----------------------+--------------------+
```
</details>
