### PR TITLE
Fix legacy_usage_detail column in azure_consumption_usage table to correcty return 'MeterDetails' metadata instead of null closes #952

### DIFF
--- a/azure/table_azure_consumption_usage.go
+++ b/azure/table_azure_consumption_usage.go
@@ -166,7 +166,17 @@ func listConsumptionUsage(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	}
 	expand := ""
 	if d.EqualsQualString("expand") != "" {
-		expand = d.EqualsQualString("expand")
+		// The expand parameter needs to be prefixed with "properties/" for each field
+		expandFields := strings.Split(d.EqualsQualString("expand"), ",")
+		var prefixedFields []string
+		for _, field := range expandFields {
+			field = strings.TrimSpace(field)
+			if !strings.HasPrefix(field, "properties/") {
+				field = "properties/" + field
+			}
+			prefixedFields = append(prefixedFields, field)
+		}
+		expand = strings.Join(prefixedFields, ",")
 	}
 
 	/**

--- a/azure/utils.go
+++ b/azure/utils.go
@@ -74,7 +74,27 @@ func structToMap(val reflect.Value) map[string]interface{} {
 		field := val.Type().Field(i)
 		fieldValue := val.Field(i)
 
-		// Check if field is a struct and not a zero value
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Handle pointer fields
+		if fieldValue.Kind() == reflect.Ptr {
+			if !fieldValue.IsNil() {
+				elem := fieldValue.Elem()
+				if elem.Kind() == reflect.Struct {
+					result[field.Name] = structToMap(elem)
+				} else {
+					result[field.Name] = elem.Interface()
+				}
+			} else {
+				result[field.Name] = nil
+			}
+			continue
+		}
+
+		// Handle struct fields
 		if fieldValue.Kind() == reflect.Struct && !fieldValue.IsZero() {
 			result[field.Name] = structToMap(fieldValue)
 		} else if !fieldValue.IsZero() {


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
