### PR TITLE
Add dhcp_options column to azure_virtual_network table 

### DIFF
--- a/azure/table_azure_virtual_network.go
+++ b/azure/table_azure_virtual_network.go
@@ -100,7 +100,7 @@ func tableAzureVirtualNetwork(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "dhcp_options",
-				Description: "A list of dns in a Virtual Network",
+				Description: "DHCP Properties of the Virtual Network, contains DNS properties",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("VirtualNetworkPropertiesFormat.DhcpOptions"),
 			},


### PR DESCRIPTION
Add to table azure_virtual_network the dns information

the code added adds a column recovering the field VirtualNetworkPropertiesFormat.DhcpOptions.DNSServers
```
{ 
  Name:        "dns", 
  Description: "A list of dns in a Virtual Network", 
  Type:        proto.ColumnType_JSON, 
  Transform:   transform.FromField("VirtualNetworkPropertiesFormat.DhcpOptions.DNSServers"), 
},
```

this outputs via query 
`select name, dns from azure_all.azure_virtual_network`
| name          | dns
| vnet-name | ["10.0.0.1","10.0.0.2","10.0.0.3"]