### PR TITLE
Add CreationTime details in access_keys column in table azure_storage_account closes #964

### DIFF
--- a/azure/table_azure_storage_account.go
+++ b/azure/table_azure_storage_account.go
@@ -922,7 +922,6 @@ func listAzureStorageAccountAccessKeys(ctx context.Context, d *plugin.QueryData,
 			}
 			if key.CreationTime != nil {
 				keyMap["CreationTime"] = key.CreationTime.ToTime().Format(time.RFC3339)
-				keyMap["LastRotated"] = key.CreationTime.ToTime().Format(time.RFC3339)
 			}
 			keysMap = append(keysMap, keyMap)
 		}


### PR DESCRIPTION
…

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(access_keys) from azure_storage_account limit 1
+---------------+--------------------------------------------------------------------------------------------------------------+
| name          | jsonb_pretty                                                                                                 |
+---------------+--------------------------------------------------------------------------------------------------------------+
| tailpipelog53 | [                                                                                                            |
|               |     {                                                                                                        |
|               |         "Value": "xxxxxxxxxxx", |
|               |         "KeyName": "key1",                                                                                   |
|               |         "Permissions": "FULL",                                                                               |
|               |         "CreationTime": "2024-12-13T07:43:09Z"                                                               |
|               |     },                                                                                                       |
|               |     {                                                                                                        |
|               |         "Value": "xxxxxxxxxxx", |
|               |         "KeyName": "key2",                                                                                   |
|               |         "Permissions": "FULL",                                                                               |
|               |         "CreationTime": "2024-12-13T07:43:09Z"                                                               |
|               |     }                                                                                                        |
|               | ]                                                                                                            |
+---------------+--------------------------------------------------------------------------------------------------------------+
```
</details>
