### PR TITLE
Harden GitHub Actions: set explicit permissions

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-project.yml@main

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci_lint_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/golangci-lint.yml@main

--- a/.github/workflows/registry-publish-ghcr.yml
+++ b/.github/workflows/registry-publish-ghcr.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   registry_publish_workflow_ghcr:
     uses: turbot/steampipe-workflows/.github/workflows/registry-publish-ghcr-large-runners.yml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/stale.yml@main

--- a/.github/workflows/steampipe-anywhere.yml
+++ b/.github/workflows/steampipe-anywhere.yml
@@ -11,6 +11,9 @@ on:
         description: "The version to release (must be prefixed with 'v')"
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   anywhere_publish_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/steampipe-anywhere-azure.yml@main

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,6 +4,10 @@ on:
     - cron: "30 22 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   sync_labels_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/sync-labels.yml@main


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.