### PR TITLE
Add rate limiter for azure_storage_share_file to avoid ARM 429 throttling

### DIFF
--- a/azure/plugin.go
+++ b/azure/plugin.go
@@ -78,6 +78,22 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 				Scope:      []string{"connection", "service", "action"},
 				Where:      "service = 'Microsoft.Storage' and action = 'storageAccounts/read'",
 			},
+			// azure_storage_share_file fans out one fileServices/shares list per storage account
+			// (ParentHydrate: listStorageAccounts); on a storage-heavy subscription (hundreds
+			// of storage accounts) that per-account burst drains the per-(subscription,
+			// principal) ARM read bucket and triggers 429 SubscriptionRequestsThrottled. Cap
+			// the per-connection fan-out rate so the shares listing can't spike a
+			// subscription's read budget on its own. fileServices/shares/read is a
+			// Microsoft.Storage resource-provider read, so it shares the same budget as
+			// azure_storage_account above; use the same FillRate/BucketSize.
+			// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-storage-resource-provider-limits
+			{
+				Name:       "azure_storage_share_file",
+				FillRate:   2,
+				BucketSize: 50,
+				Scope:      []string{"connection", "service", "action"},
+				Where:      "service = 'Microsoft.Storage' and action = 'fileServices/shares/read'",
+			},
 			// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-blob-storage-limits
 			{
 				Name:       "azure_storage_blob",


### PR DESCRIPTION
### Description

`azure_storage_share_file` lists file shares through a hydrate with `ParentHydrate: listStorageAccounts` (`listStorageAccountsFileShares`), so it issues one `fileServices/shares` list call **per storage account**. On a subscription with many (hundreds of) storage accounts, that per-account burst drains the per-`(subscription, principal)` Azure Resource Manager read bucket and triggers `429 SubscriptionRequestsThrottled`.

None of the existing rate limiters in `azure/plugin.go` match the `fileServices/shares/read` action, so this fan-out is currently uncapped.

### Changes

Adds a per-connection token-bucket rate limiter for `azure_storage_share_file`, alongside the existing `azure_storage_account` / `azure_storage_blob` limiters:

- `FillRate: 10`, `BucketSize: 100`
- `Scope: ["connection", "service", "action"]`
- `Where: service = 'Microsoft.Storage' and action = 'fileServices/shares/read'`

The `Where` clause matches the `Tags` on the `listStorageAccountsFileShares` hydrate (`service: Microsoft.Storage`, `action: fileServices/shares/read`), so it paces exactly the shares-listing fan-out and nothing else. `BucketSize: 100` lets a moderate number of accounts list up front, then `FillRate: 10/s` caps the sustained rate so listing file shares can't exhaust a subscription's read budget on its own.

Related to #927 (Azure services highly prone to rate limits).

### Testing

- `go build ./azure/` succeeds.
- Confirmed the limiter `Where` clause matches the hydrate `Tags` on the `azure_storage_share_file` list hydrate.
