### PR TITLE
feat: add azure_redis_enterprise_(cluster|database) tables

### DIFF
--- a/azure/plugin.go
+++ b/azure/plugin.go
@@ -270,6 +270,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"azure_recovery_services_backup_job":                           tableAzureRecoveryServicesBackupJob(ctx),
 			"azure_recovery_services_vault":                                tableAzureRecoveryServicesVault(ctx),
 			"azure_redis_cache":                                            tableAzureRedisCache(ctx),
+			"azure_redis_enterprise_cluster":                               tableAzureRedisEnterpriseCluster(ctx),
+			"azure_redis_enterprise_database":                              tableAzureRedisEnterpriseDatabase(ctx),
 			"azure_resource":                                               tableAzureResourceResource(ctx),
 			"azure_resource_group":                                         tableAzureResourceGroup(ctx),
 			"azure_resource_link":                                          tableAzureResourceLink(ctx),

--- a/azure/table_azure_redis_enterprise_cluster.go
+++ b/azure/table_azure_redis_enterprise_cluster.go
@@ -1,0 +1,262 @@
+package azure
+
+import (
+	"context"
+
+	armredisenterprise "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v4"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAzureRedisEnterpriseCluster(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "azure_redis_enterprise_cluster",
+		Description: "Azure Redis Enterprise Cluster",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"name", "resource_group"}),
+			Hydrate:    getRedisEnterpriseCluster,
+			Tags: map[string]string{
+				"service": "Microsoft.Cache",
+				"action":  "redisEnterprise/read",
+			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"ResourceNotFound", "ResourceGroupNotFound", "400", "404"}),
+			},
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listRedisEnterpriseClusters,
+			Tags: map[string]string{
+				"service": "Microsoft.Cache",
+				"action":  "redisEnterprise/read",
+			},
+		},
+		Columns: azureColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name of the resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "id",
+				Description: "The unique id identifying the resource in subscription.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ID"),
+			},
+			{
+				Name:        "type",
+				Description: "The type of the resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "kind",
+				Description: "Distinguishes the kind of cluster. Possible values: Redis, RedisEnterprise.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Kind").Transform(ptrToString),
+			},
+			{
+				Name:        "provisioning_state",
+				Description: "Current provisioning status of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.ProvisioningState").Transform(ptrToString),
+			},
+			{
+				Name:        "resource_state",
+				Description: "Current resource status of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.ResourceState").Transform(ptrToString),
+			},
+			{
+				Name:        "redis_version",
+				Description: "Version of redis the cluster supports, e.g. '6'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.RedisVersion"),
+			},
+			{
+				Name:        "host_name",
+				Description: "DNS name of the cluster endpoint.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.HostName"),
+			},
+			{
+				Name:        "minimum_tls_version",
+				Description: "The minimum TLS version for the cluster to support, e.g. '1.2'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.MinimumTLSVersion").Transform(ptrToString),
+			},
+			{
+				Name:        "high_availability",
+				Description: "Enabled by default. If disabled, the data set is not replicated.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.HighAvailability").Transform(ptrToString),
+			},
+			{
+				Name:        "public_network_access",
+				Description: "Whether or not public network traffic can access the cluster. Possible values: Enabled, Disabled.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.PublicNetworkAccess").Transform(ptrToString),
+			},
+			{
+				Name:        "redundancy_mode",
+				Description: "Explains the current redundancy strategy of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Properties.RedundancyMode").Transform(ptrToString),
+			},
+			{
+				Name:        "sku_name",
+				Description: "The type of RedisEnterprise cluster to deploy.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("SKU.Name").Transform(ptrToString),
+			},
+			{
+				Name:        "sku_capacity",
+				Description: "The size of the RedisEnterprise cluster.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("SKU.Capacity"),
+			},
+			{
+				Name:        "zones",
+				Description: "The Availability Zones where this cluster will be deployed.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "identity",
+				Description: "The identity of the resource.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "encryption",
+				Description: "Encryption-at-rest configuration for the cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Properties.Encryption"),
+			},
+			{
+				Name:        "maintenance_configuration",
+				Description: "Cluster-level maintenance configuration.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Properties.MaintenanceConfiguration"),
+			},
+			{
+				Name:        "private_endpoint_connections",
+				Description: "List of private endpoint connections associated with the specified RedisEnterprise cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Properties.PrivateEndpointConnections"),
+			},
+			{
+				Name:        "system_data",
+				Description: "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("SystemData"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ID").Transform(idToAkas),
+			},
+
+			// Azure standard columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Location").Transform(formatRegion).Transform(toLower),
+			},
+			{
+				Name:        "resource_group",
+				Description: ColumnDescriptionResourceGroup,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ID").Transform(extractResourceGroupFromID),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listRedisEnterpriseClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listRedisEnterpriseClusters")
+
+	session, err := GetNewSessionUpdated(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_cluster.listRedisEnterpriseClusters", "session_error", err)
+		return nil, err
+	}
+
+	d.WaitForListRateLimit(ctx)
+
+	client, err := armredisenterprise.NewClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_cluster.listRedisEnterpriseClusters", "client_error", err)
+		return nil, err
+	}
+
+	pager := client.NewListPager(nil)
+	for pager.More() {
+		result, err := pager.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("azure_redis_enterprise_cluster.listRedisEnterpriseClusters", "api_error", err)
+			return nil, err
+		}
+		for _, cluster := range result.Value {
+			d.StreamListItem(ctx, *cluster)
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getRedisEnterpriseCluster(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getRedisEnterpriseCluster")
+
+	name := d.EqualsQualString("name")
+	resourceGroup := d.EqualsQualString("resource_group")
+
+	if name == "" || resourceGroup == "" {
+		return nil, nil
+	}
+
+	session, err := GetNewSessionUpdated(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_cluster.getRedisEnterpriseCluster", "session_error", err)
+		return nil, err
+	}
+
+	client, err := armredisenterprise.NewClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_cluster.getRedisEnterpriseCluster", "client_error", err)
+		return nil, err
+	}
+
+	op, err := client.Get(ctx, resourceGroup, name, nil)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_cluster.getRedisEnterpriseCluster", "api_error", err)
+		return nil, err
+	}
+
+	if op.ID != nil {
+		return op.Cluster, nil
+	}
+
+	return nil, nil
+}

--- a/azure/table_azure_redis_enterprise_database.go
+++ b/azure/table_azure_redis_enterprise_database.go
@@ -1,0 +1,269 @@
+package azure
+
+import (
+	"context"
+	"strings"
+
+	armredisenterprise "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v4"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+type redisEnterpriseDatabaseInfo struct {
+	Database      armredisenterprise.Database
+	ClusterName   *string
+	ResourceGroup *string
+	Location      *string
+}
+
+//// TABLE DEFINITION
+
+func tableAzureRedisEnterpriseDatabase(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "azure_redis_enterprise_database",
+		Description: "Azure Redis Enterprise Database",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"cluster_name", "name", "resource_group"}),
+			Hydrate:    getRedisEnterpriseDatabase,
+			Tags: map[string]string{
+				"service": "Microsoft.Cache",
+				"action":  "redisEnterprise/databases/read",
+			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"ResourceNotFound", "ResourceGroupNotFound", "400", "404"}),
+			},
+		},
+		List: &plugin.ListConfig{
+			ParentHydrate: listRedisEnterpriseClusters,
+			Hydrate:       listRedisEnterpriseDatabases,
+			Tags: map[string]string{
+				"service": "Microsoft.Cache",
+				"action":  "redisEnterprise/databases/read",
+			},
+		},
+		Columns: azureColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name of the database resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Name"),
+			},
+			{
+				Name:        "cluster_name",
+				Description: "The name of the RedisEnterprise cluster this database belongs to.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ClusterName"),
+			},
+			{
+				Name:        "id",
+				Description: "The unique id identifying the resource in subscription.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.ID"),
+			},
+			{
+				Name:        "type",
+				Description: "The type of the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Type"),
+			},
+			{
+				Name:        "provisioning_state",
+				Description: "Current provisioning status of the database.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.ProvisioningState").Transform(ptrToString),
+			},
+			{
+				Name:        "resource_state",
+				Description: "Current resource status of the database.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.ResourceState").Transform(ptrToString),
+			},
+			{
+				Name:        "redis_version",
+				Description: "Version of Redis the database is running on, e.g. '6.0' or '7.4'.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.RedisVersion"),
+			},
+			{
+				Name:        "client_protocol",
+				Description: "Specifies whether redis clients can connect using TLS-encrypted or plaintext redis protocols. Possible values: Encrypted, Plaintext.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.ClientProtocol").Transform(ptrToString),
+			},
+			{
+				Name:        "port",
+				Description: "TCP port of the database endpoint.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("Database.Properties.Port"),
+			},
+			{
+				Name:        "clustering_policy",
+				Description: "Clustering policy. Possible values: EnterpriseCluster, OSSCluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.ClusteringPolicy").Transform(ptrToString),
+			},
+			{
+				Name:        "eviction_policy",
+				Description: "Redis eviction policy. Possible values: AllKeysLFU, AllKeysLRU, AllKeysRandom, VolatileLRU, VolatileLFU, VolatileTTL, VolatileRandom, NoEviction.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.EvictionPolicy").Transform(ptrToString),
+			},
+			{
+				Name:        "access_keys_authentication",
+				Description: "Whether access with access keys is enabled. Possible values: Enabled, Disabled.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.AccessKeysAuthentication").Transform(ptrToString),
+			},
+			{
+				Name:        "defer_upgrade",
+				Description: "Option to defer upgrade when newest version is released. Possible values: Deferred, NotDeferred.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Properties.DeferUpgrade").Transform(ptrToString),
+			},
+			{
+				Name:        "persistence",
+				Description: "Persistence settings (AOF/RDB configuration).",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Database.Properties.Persistence"),
+			},
+			{
+				Name:        "modules",
+				Description: "Optional set of redis modules enabled in this database.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Database.Properties.Modules"),
+			},
+			{
+				Name:        "geo_replication",
+				Description: "Optional set of properties to configure geo replication for this database.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Database.Properties.GeoReplication"),
+			},
+			{
+				Name:        "system_data",
+				Description: "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Database.SystemData"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Database.Name"),
+			},
+			{
+				Name:        "akas",
+				Description: ColumnDescriptionAkas,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Database.ID").Transform(idToAkas),
+			},
+
+			// Azure standard columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Location").Transform(formatRegion).Transform(toLower),
+			},
+			{
+				Name:        "resource_group",
+				Description: ColumnDescriptionResourceGroup,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ResourceGroup"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listRedisEnterpriseDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listRedisEnterpriseDatabases")
+
+	cluster := h.Item.(armredisenterprise.Cluster)
+	clusterName := cluster.Name
+	resourceGroup := &strings.Split(*cluster.ID, "/")[4]
+
+	session, err := GetNewSessionUpdated(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.listRedisEnterpriseDatabases", "session_error", err)
+		return nil, err
+	}
+
+	dbClient, err := armredisenterprise.NewDatabasesClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.listRedisEnterpriseDatabases", "client_error", err)
+		return nil, err
+	}
+
+	pager := dbClient.NewListByClusterPager(*resourceGroup, *clusterName, nil)
+	for pager.More() {
+		d.WaitForListRateLimit(ctx)
+		result, err := pager.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("azure_redis_enterprise_database.listRedisEnterpriseDatabases", "api_error", err)
+			return nil, err
+		}
+		for _, db := range result.Value {
+			d.StreamLeafListItem(ctx, redisEnterpriseDatabaseInfo{*db, clusterName, resourceGroup, cluster.Location})
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getRedisEnterpriseDatabase(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getRedisEnterpriseDatabase")
+
+	name := d.EqualsQualString("name")
+	clusterName := d.EqualsQualString("cluster_name")
+	resourceGroup := d.EqualsQualString("resource_group")
+
+	if name == "" || clusterName == "" || resourceGroup == "" {
+		return nil, nil
+	}
+
+	session, err := GetNewSessionUpdated(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.getRedisEnterpriseDatabase", "session_error", err)
+		return nil, err
+	}
+
+	dbClient, err := armredisenterprise.NewDatabasesClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.getRedisEnterpriseDatabase", "client_error", err)
+		return nil, err
+	}
+
+	db, err := dbClient.Get(ctx, resourceGroup, clusterName, name, nil)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.getRedisEnterpriseDatabase", "api_error", err)
+		return nil, err
+	}
+
+	// Fetch the parent cluster to get Location
+	clusterClient, err := armredisenterprise.NewClient(session.SubscriptionID, session.Cred, session.ClientOptions)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.getRedisEnterpriseDatabase", "cluster_client_error", err)
+		return nil, err
+	}
+
+	cluster, err := clusterClient.Get(ctx, resourceGroup, clusterName, nil)
+	if err != nil {
+		plugin.Logger(ctx).Error("azure_redis_enterprise_database.getRedisEnterpriseDatabase", "cluster_api_error", err)
+		return nil, err
+	}
+
+	if db.ID != nil {
+		return redisEnterpriseDatabaseInfo{db.Database, &clusterName, &resourceGroup, cluster.Location}, nil
+	}
+
+	return nil, nil
+}

--- a/azure/utils.go
+++ b/azure/utils.go
@@ -185,7 +185,7 @@ func ptrToString(_ context.Context, d *transform.TransformData) (interface{}, er
 		return nil, nil
 	}
 	v := reflect.ValueOf(d.Value)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil, nil
 		}

--- a/azure/utils.go
+++ b/azure/utils.go
@@ -176,3 +176,27 @@ func formatRegion(ctx context.Context, d *transform.TransformData) (interface{},
 	region := strings.ReplaceAll(valStr, " ", "")
 	return region, nil
 }
+
+// ptrToString dereferences pointer-to-named-string types (e.g. *Kind, *ProvisioningState)
+// that the standard transform.ToString cannot handle because it falls through to fmt.Sprintf("%v")
+// which prints the pointer address instead of the underlying string value.
+func ptrToString(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	if d.Value == nil {
+		return nil, nil
+	}
+	v := reflect.ValueOf(d.Value)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil, nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.String {
+		s := v.String()
+		if s == "" {
+			return nil, nil
+		}
+		return s, nil
+	}
+	return nil, nil
+}

--- a/docs/tables/azure_redis_enterprise_cluster.md
+++ b/docs/tables/azure_redis_enterprise_cluster.md
@@ -1,0 +1,220 @@
+---
+title: "Steampipe Table: azure_redis_enterprise_cluster - Query Azure Redis Enterprise Clusters using SQL"
+description: "Allows users to query Azure Redis Enterprise Clusters, providing details about cluster name, SKU, host name, Redis version, provisioning state, and more."
+folder: "Redis"
+---
+
+# Table: azure_redis_enterprise_cluster - Query Azure Redis Enterprise Clusters using SQL
+
+Azure Cache for Redis Enterprise is the highest-tier, enterprise-grade Redis offering on Azure. It maps to the `Microsoft.Cache/redisEnterprise` resource type and exposes dedicated cluster metadata such as hostname, SKU, Redis version, and TLS configuration that is not available through the generic `azure_resource` table.
+
+## Table Usage Guide
+
+The `azure_redis_enterprise_cluster` table provides insights into each Azure Redis Enterprise cluster within your Azure environment. As a cloud architect or security engineer, you can use this table to inventory clusters, audit TLS settings, and understand SKU/capacity configurations across subscriptions and resource groups.
+
+## Examples
+
+### Basic info
+Retrieve a summary of all Redis Enterprise clusters including their SKU, host name, Redis version, and kind.
+
+```sql+postgres
+select
+  name,
+  kind,
+  host_name,
+  redis_version,
+  sku_name,
+  sku_capacity,
+  provisioning_state,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster;
+```
+
+```sql+sqlite
+select
+  name,
+  kind,
+  host_name,
+  redis_version,
+  sku_name,
+  sku_capacity,
+  provisioning_state,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster;
+```
+
+### List Azure Managed Redis clusters
+Identify Azure Managed Redis (kind `v2`) clusters and inspect their high availability, redundancy, and public network access settings.
+
+```sql+postgres
+select
+  name,
+  kind,
+  high_availability,
+  redundancy_mode,
+  public_network_access,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  kind = 'v2';
+```
+
+```sql+sqlite
+select
+  name,
+  kind,
+  high_availability,
+  redundancy_mode,
+  public_network_access,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  kind = 'v2';
+```
+
+### List clusters with public network access enabled
+Find clusters that are reachable from public networks, which may require additional network controls.
+
+```sql+postgres
+select
+  name,
+  public_network_access,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  public_network_access = 'Enabled';
+```
+
+```sql+sqlite
+select
+  name,
+  public_network_access,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  public_network_access = 'Enabled';
+```
+
+### List clusters not enforcing TLS 1.2
+Identify clusters that may be accepting older TLS versions, which can be a security risk.
+
+```sql+postgres
+select
+  name,
+  region,
+  resource_group,
+  minimum_tls_version
+from
+  azure_redis_enterprise_cluster
+where
+  minimum_tls_version is null
+  or minimum_tls_version <> '1.2';
+```
+
+```sql+sqlite
+select
+  name,
+  region,
+  resource_group,
+  minimum_tls_version
+from
+  azure_redis_enterprise_cluster
+where
+  minimum_tls_version is null
+  or minimum_tls_version <> '1.2';
+```
+
+### List clusters that are not in a succeeded provisioning state
+Find clusters that may be in a degraded or transitional state.
+
+```sql+postgres
+select
+  name,
+  provisioning_state,
+  resource_state,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  provisioning_state <> 'Succeeded';
+```
+
+```sql+sqlite
+select
+  name,
+  provisioning_state,
+  resource_state,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  provisioning_state <> 'Succeeded';
+```
+
+### List clusters with private endpoint connections
+Discover which clusters have private endpoints configured.
+
+```sql+postgres
+select
+  name,
+  region,
+  resource_group,
+  jsonb_array_length(private_endpoint_connections) as private_endpoint_count
+from
+  azure_redis_enterprise_cluster
+where
+  private_endpoint_connections is not null
+  and jsonb_array_length(private_endpoint_connections) > 0;
+```
+
+```sql+sqlite
+select
+  name,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_cluster
+where
+  private_endpoint_connections is not null;
+```
+
+### Count clusters per region
+Get a distribution of Redis Enterprise clusters across Azure regions.
+
+```sql+postgres
+select
+  region,
+  count(*) as cluster_count
+from
+  azure_redis_enterprise_cluster
+group by
+  region
+order by
+  cluster_count desc;
+```
+
+```sql+sqlite
+select
+  region,
+  count(*) as cluster_count
+from
+  azure_redis_enterprise_cluster
+group by
+  region
+order by
+  cluster_count desc;
+```

--- a/docs/tables/azure_redis_enterprise_database.md
+++ b/docs/tables/azure_redis_enterprise_database.md
@@ -1,0 +1,261 @@
+---
+title: "Steampipe Table: azure_redis_enterprise_database - Query Azure Redis Enterprise Databases using SQL"
+description: "Allows users to query Azure Redis Enterprise Databases, providing details about port, client protocol, clustering policy, eviction policy, persistence, and geo-replication settings."
+folder: "Redis"
+---
+
+# Table: azure_redis_enterprise_database - Query Azure Redis Enterprise Databases using SQL
+
+Azure Cache for Redis Enterprise databases (`Microsoft.Cache/redisEnterprise/databases`) represent the individual databases hosted within a Redis Enterprise cluster. Each cluster can host one or more databases with configurable settings such as port, eviction policy, clustering policy, and geo-replication — none of which are exposed through the generic `azure_resource` table.
+
+## Table Usage Guide
+
+The `azure_redis_enterprise_database` table provides granular insights into each database within your Redis Enterprise clusters. As a database administrator or security engineer, you can use this table to audit eviction policies, verify clustering policies, check port configurations, and inspect geo-replication setup across all databases.
+
+## Examples
+
+### Basic info
+List all Redis Enterprise databases with their key configuration attributes.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  redis_version,
+  port,
+  client_protocol,
+  clustering_policy,
+  eviction_policy,
+  provisioning_state,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database;
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  redis_version,
+  port,
+  client_protocol,
+  clustering_policy,
+  eviction_policy,
+  provisioning_state,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database;
+```
+
+### List databases by Redis version
+Find databases running a specific Redis version — useful to identify Azure Managed Redis v2 clusters (version `7.4`).
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  redis_version,
+  access_keys_authentication,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  redis_version = '7.4';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  redis_version,
+  access_keys_authentication,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  redis_version = '7.4';
+```
+
+### List databases with access keys authentication enabled
+Find databases where access key authentication is active — these may need additional audit controls.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  access_keys_authentication,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  access_keys_authentication = 'Enabled';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  access_keys_authentication,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  access_keys_authentication = 'Enabled';
+```
+
+### List databases allowing plaintext (non-TLS) connections
+Identify databases not enforcing TLS for client connections.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  client_protocol,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  client_protocol = 'Plaintext';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  client_protocol,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  client_protocol = 'Plaintext';
+```
+
+### List databases with no eviction policy (NoEviction)
+Find databases configured with NoEviction, which may cause write failures under memory pressure.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  eviction_policy,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  eviction_policy = 'NoEviction';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  eviction_policy,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  eviction_policy = 'NoEviction';
+```
+
+### List databases with geo-replication configured
+Discover databases that have active geo-replication links.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  geo_replication -> 'groupNickname' as geo_group,
+  jsonb_array_length(geo_replication -> 'linkedDatabases') as linked_db_count,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  geo_replication is not null;
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  geo_replication is not null;
+```
+
+### List databases with persistence enabled
+Check which databases have AOF or RDB persistence configured.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  persistence ->> 'aofEnabled' as aof_enabled,
+  persistence ->> 'rdbEnabled' as rdb_enabled,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  (persistence ->> 'aofEnabled')::boolean = true
+  or (persistence ->> 'rdbEnabled')::boolean = true;
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  json_extract(persistence, '$.aofEnabled') as aof_enabled,
+  json_extract(persistence, '$.rdbEnabled') as rdb_enabled,
+  region,
+  resource_group
+from
+  azure_redis_enterprise_database
+where
+  json_extract(persistence, '$.aofEnabled') = 1
+  or json_extract(persistence, '$.rdbEnabled') = 1;
+```
+
+### Get database details for a specific cluster
+Retrieve all databases within a specific Redis Enterprise cluster.
+
+```sql+postgres
+select
+  cluster_name,
+  name,
+  port,
+  clustering_policy,
+  eviction_policy,
+  provisioning_state
+from
+  azure_redis_enterprise_database
+where
+  cluster_name = 'my-enterprise-cluster';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  name,
+  port,
+  clustering_policy,
+  eviction_policy,
+  provisioning_state
+from
+  azure_redis_enterprise_database
+where
+  cluster_name = 'my-enterprise-cluster';
+```

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0-beta.5
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v2 v2.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v3 v3.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v4 v4.0.0-beta.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0 h1:lMW1lD/
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0/go.mod h1:ceIuwmxDWptoW3eCqSXlnPsZFKh4X+R38dWPv7GS9Vs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.2.0 h1:+lnLQhKh3cgSOIOVH61UZ3s/l9d+bAZp5d/spt1+7UI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.2.0/go.mod h1:tStOHrivWUrcBolspvKV70Us1ckESYGYSHdG4LX8zyY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0 h1:dwmV8G0tLD17J+LcTirpFmNKvZBLLuErtGR0h6h8n2c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0/go.mod h1:UmV8UnyCQ+05EvopWqF6CQsFWI5FWcp/AXGVkJguv9E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 h1:Ds0KRF8ggpEGg4Vo42oX1cIt/IfOhHWJBikksZbVxeg=
@@ -99,8 +101,14 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlfl
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v2 v2.1.1/go.mod h1:8Anbzn23yMdpl2DDY4qnFEPY9Vf6CoLphIt4mX59McI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v3 v3.0.0 h1:BIvscO5ZFKaEHoix9jAV6vbatKLiDNb5pj8XjzQR2g4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v3 v3.0.0/go.mod h1:4uHLkZ3JvDvacFcEyB0T/cCeVqlvtHHA7DjvpgvlpdA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v4 v4.0.0-beta.1 h1:XfZ7VtN34ylwyyTFFjGZ0fvMQ9QOdh+JismD0YE5caA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v4 v4.0.0-beta.1/go.mod h1:Jse1KgShop8dL+SoDW7EkwjKiFTuA4g7eStrYah+PYQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0 h1:67nFqWXpo0x5Nz0XEb1yI7s8D+EHy8NsTinYw9sZnLk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 h1:guyQA4b8XB2sbJZXzUnOF9mn0WDBv/ZT7me9wTipKtE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1/go.mod h1:8h8yhzh9o+0HeSIhUxYny+rEQajScrfIpNktvgYG3Q8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.14.0 h1:JfjIyBJvEvQNP/9MEUo1/6eoiPkiag2OZImw32xakcc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.14.0/go.mod h1:HakuHOrWlp2G1WlFvkL7JApTZAbxRJnRiz+w4SYak5s=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=


### PR DESCRIPTION
Adds two new dedicated tables for Azure Cache for Redis Enterprise and Azure Managed Redis (Microsoft.Cache/redisEnterprise):

- azure_redis_enterprise_cluster: cluster-level metadata including kind, SKU, host name, TLS version, high_availability, public_network_access, redundancy_mode, encryption, maintenance_configuration, identity, system_data, and redis_version.

- azure_redis_enterprise_database: database-level metadata including redis_version (the actual running version, e.g. '7.4' for Managed Redis v2), access_keys_authentication, defer_upgrade, client_protocol, port, clustering_policy, eviction_policy, persistence, modules, geo_replication, and system_data.

The generic azure_resource table returns null properties for these resource types. These tables use the armredisenterprise/v4 SDK (v4.0.0-beta.1), which is the only release exposing the Azure Managed Redis v2 fields; the stable v1.2.0 and the original track1 SDK are both pinned to API 2022-01-01 which does not return AMR v2 properties.

Also adds ptrToString helper to azure/utils.go to correctly convert pointer-to-named-string types (e.g. *Kind, *ProvisioningState) used by the armredisenterprise v4 SDK, which the standard transform.ToString does not handle (it prints the pointer address via fmt.Sprintf("%%v")).

Closes #1009

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
$ steampipe query "select name, kind, high_availability, public_network_access, redundancy_mode from azure_redis_enterprise_cluster;"

+-----------------------+------+-------------------+-----------------------+-----------------+
| name                  | kind | high_availability | public_network_access | redundancy_mode |
+-----------------------+------+-------------------+-----------------------+-----------------+
| cache-gov-10-3jgx-stg | v2   | Disabled          | Disabled              | None            |
| cache-test-a1b2-stg   | v2   | Disabled          | Disabled              | None            |
+-----------------------+------+-------------------+-----------------------+-----------------+
```

```
$ steampipe query "select cluster_name, name, redis_version, access_keys_authentication from azure_redis_enterprise_database;"

+-----------------------+---------+---------------+----------------------------+
| cluster_name          | name    | redis_version | access_keys_authentication |
+-----------------------+---------+---------------+----------------------------+
| cache-test-a1b2-stg   | default | 7.4           | Enabled                    |
| cache-gov-10-3jgx-stg | default | 7.4           | Enabled                    |
+-----------------------+---------+---------------+----------------------------+
```
</details>
