### PR TITLE
Add support for OIDC client assertion authentication

### DIFF
--- a/azure/connection_config.go
+++ b/azure/connection_config.go
@@ -14,6 +14,8 @@ type azureConfig struct {
 	Username              *string  `hcl:"username"`
 	Password              *string  `hcl:"password"`
 	Environment           *string  `hcl:"environment"`
+	ClientAssertion       *string  `hcl:"client_assertion"`
+	ClientAssertionPath   *string  `hcl:"client_assertion_path"`
 	MaxErrorRetryAttempts *int     `hcl:"max_error_retry_attempts"`
 	MinErrorRetryDelay    *int32   `hcl:"min_error_retry_delay"`
 	IgnoreErrorCodes      []string `hcl:"ignore_error_codes,optional"`

--- a/azure/service.go
+++ b/azure/service.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
@@ -52,9 +53,10 @@ type Session struct {
 
 1. Client secret
 2. Client certificate
-3. Username and password
-4. Managed identity
-5. CLI
+3. Client assertion (OIDC)
+4. Username and password
+5. Managed identity
+6. CLI
 */
 func GetNewSessionUpdated(ctx context.Context, d *plugin.QueryData) (session *SessionNew, err error) {
 	logger := plugin.Logger(ctx)
@@ -66,7 +68,7 @@ func GetNewSessionUpdated(ctx context.Context, d *plugin.QueryData) (session *Se
 
 	logger.Debug("Auth session not found in cache, creating new session")
 
-	var tenantID, subscriptionID, clientID, clientSecret, certificatePath, certificatePassword, username, password, environment string
+	var tenantID, subscriptionID, clientID, clientSecret, certificatePath, certificatePassword, username, password, environment, clientAssertion, clientAssertionPath string
 	azureConfig := GetConfig(d.Connection)
 
 	if azureConfig.Environment != nil {
@@ -115,6 +117,18 @@ func GetNewSessionUpdated(ctx context.Context, d *plugin.QueryData) (session *Se
 		password = *azureConfig.Password
 	} else {
 		password = os.Getenv(auth.Password)
+	}
+
+	if azureConfig.ClientAssertion != nil {
+		clientAssertion = *azureConfig.ClientAssertion
+	} else {
+		clientAssertion = os.Getenv("AZURE_CLIENT_ASSERTION")
+	}
+
+	if azureConfig.ClientAssertionPath != nil {
+		clientAssertionPath = *azureConfig.ClientAssertionPath
+	} else {
+		clientAssertionPath = os.Getenv("AZURE_CLIENT_ASSERTION_PATH")
 	}
 
 	//  It's important to note that Microsoft has since integrated these isolated German cloud regions into the global Azure cloud infrastructure. This means that Azure Germany Cloud services are now provided through the global Azure regions with the same high standards of security, privacy, and compliance.
@@ -179,6 +193,12 @@ func GetNewSessionUpdated(ctx context.Context, d *plugin.QueryData) (session *Se
 		)
 		if err != nil {
 			logger.Error("GetNewSessionUpdated", "client_certificate_credential_error", err)
+			return nil, err
+		}
+	} else if tenantID != "" && clientID != "" && (clientAssertion != "" || clientAssertionPath != "") { // OIDC client assertion authentication
+		cred, err = newClientAssertionCredential(tenantID, clientID, clientAssertion, clientAssertionPath)
+		if err != nil {
+			logger.Error("GetNewSessionUpdated", "client_assertion_credential_error", err)
 			return nil, err
 		}
 	} else if tenantID != "" && subscriptionID != "" && clientID != "" && username != "" && password != "" { // Username password authentication
@@ -333,6 +353,60 @@ func WillExpireIn(t time.Time, d time.Duration) bool {
 	return !t.After(time.Now().Add(d))
 }
 
+// azcoreTokenAuthorizer bridges azcore.TokenCredential to autorest.Authorizer,
+// enabling OIDC credentials to be used with legacy SDK clients.
+type azcoreTokenAuthorizer struct {
+	cred  azcore.TokenCredential
+	scope string
+}
+
+// WithAuthorization returns an autorest.PrepareDecorator that adds a bearer
+// token from the azcore.TokenCredential to the request Authorization header.
+func (a *azcoreTokenAuthorizer) WithAuthorization() autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			req, err := p.Prepare(r)
+			if err != nil {
+				return req, err
+			}
+			token, err := a.cred.GetToken(context.Background(), cloudPolicy.TokenRequestOptions{
+				Scopes: []string{a.scope},
+			})
+			if err != nil {
+				return req, err
+			}
+			return autorest.Prepare(req, autorest.WithBearerAuthorization(token.Token))
+		})
+	}
+}
+
+// newClientAssertionCredential creates an azidentity.ClientAssertionCredential
+// from either an inline assertion string or a file path containing the assertion.
+func newClientAssertionCredential(tenantID, clientID, assertion, assertionPath string) (azcore.TokenCredential, error) {
+	return azidentity.NewClientAssertionCredential(
+		tenantID,
+		clientID,
+		func(ctx context.Context) (string, error) {
+			if assertion != "" {
+				return assertion, nil
+			}
+			content, err := os.ReadFile(assertionPath)
+			if err != nil {
+				return "", fmt.Errorf("error reading client assertion from %s: %v", assertionPath, err)
+			}
+			return string(content), nil
+		},
+		nil,
+	)
+}
+
+// Custom settings keys for OIDC configuration passed through
+// auth.EnvironmentSettings.Values to getApplicableAuthorizationDetails.
+const (
+	settingClientAssertion     = "CLIENT_ASSERTION"
+	settingClientAssertionPath = "CLIENT_ASSERTION_PATH"
+)
+
 func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience string) (session *Session, err error) {
 	logger := plugin.Logger(ctx)
 
@@ -409,6 +483,19 @@ func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience strin
 		settings.Values[auth.Password] = os.Getenv(auth.Password)
 	}
 
+	// OIDC configuration
+	if azureConfig.ClientAssertion != nil {
+		settings.Values[settingClientAssertion] = *azureConfig.ClientAssertion
+	} else {
+		settings.Values[settingClientAssertion] = os.Getenv("AZURE_CLIENT_ASSERTION")
+	}
+
+	if azureConfig.ClientAssertionPath != nil {
+		settings.Values[settingClientAssertionPath] = *azureConfig.ClientAssertionPath
+	} else {
+		settings.Values[settingClientAssertionPath] = os.Getenv("AZURE_CLIENT_ASSERTION_PATH")
+	}
+
 	if azureConfig.Environment != nil {
 		env, err := azure.EnvironmentFromName(*azureConfig.Environment)
 		if err != nil {
@@ -473,6 +560,23 @@ func GetNewSession(ctx context.Context, d *plugin.QueryData, tokenAudience strin
 			return nil, err
 		}
 		authorizer = autorest.NewBearerAuthorizer(&adalToken)
+
+	case "OIDC":
+		logger.Trace("Creating authorizer from OIDC client assertion credential")
+		tenantID := settings.Values[auth.TenantID]
+		clientID := settings.Values[auth.ClientID]
+		clientAssertion := settings.Values[settingClientAssertion]
+		clientAssertionPath := settings.Values[settingClientAssertionPath]
+
+		cred, err := newClientAssertionCredential(tenantID, clientID, clientAssertion, clientAssertionPath)
+		if err != nil {
+			logger.Error("GetNewSession", "oidc_credential_error", err)
+			return nil, err
+		}
+
+		scope := resource + "/.default"
+		authorizer = &azcoreTokenAuthorizer{cred: cred, scope: scope}
+
 	default:
 		return nil, fmt.Errorf("invalid Azure authentication method: %s", authMethod)
 	}
@@ -529,13 +633,21 @@ func getApplicableAuthorizationDetails(ctx context.Context, settings auth.Enviro
 	// Azure environment name
 	environmentName := settings.Values[auth.EnvironmentName]
 
-	// CLI is the default authentication method
-	authMethod = "CLI"
-	if subscriptionID == "" || (subscriptionID == "" && tenantID == "") {
+	// OIDC fields
+	clientAssertion := settings.Values[settingClientAssertion]
+	clientAssertionPath := settings.Values[settingClientAssertionPath]
+
+	// OIDC takes priority over Environment and CLI
+	if tenantID != "" && clientID != "" && (clientAssertion != "" || clientAssertionPath != "") {
+		authMethod = "OIDC"
+	} else if subscriptionID == "" || (subscriptionID == "" && tenantID == "") {
+		// CLI is the default authentication method
 		authMethod = "CLI"
 	} else if subscriptionID != "" && tenantID != "" && clientID != "" {
 		// Works for client secret credentials, client certificate credentials, resource owner password, and managed identities
 		authMethod = "Environment"
+	} else {
+		authMethod = "CLI"
 	}
 
 	logger.Debug("getApplicableAuthorizationDetails", "auth_method", authMethod)

--- a/config/azure.spc
+++ b/config/azure.spc
@@ -34,6 +34,15 @@ connection "azure" {
   # subscription_id = "00000000-0000-0000-0000-000000000000"
   # client_id       = "00000000-0000-0000-0000-000000000000"
 
+  # Use OIDC federated identity (https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+  # This method is useful for CI/CD systems like GitHub Actions, GitLab CI, etc.
+  # tenant_id             = "00000000-0000-0000-0000-000000000000"
+  # subscription_id       = "00000000-0000-0000-0000-000000000000"
+  # client_id             = "00000000-0000-0000-0000-000000000000"
+  # client_assertion      = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+  # or
+  # client_assertion_path = "/path/to/oidc-token.txt"
+
   # If no credentials are specified, the plugin will use Azure CLI authentication
 
   # The maximum number of attempts (including the initial call) Steampipe will

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,6 +105,15 @@ connection "azure" {
   # subscription_id = "00000000-0000-0000-0000-000000000000"
   # client_id       = "00000000-0000-0000-0000-000000000000"
 
+  # Use OIDC federated identity (https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+  # This method is useful for CI/CD systems like GitHub Actions, GitLab CI, etc.
+  # tenant_id             = "00000000-0000-0000-0000-000000000000"
+  # subscription_id       = "00000000-0000-0000-0000-000000000000"
+  # client_id             = "00000000-0000-0000-0000-000000000000"
+  # client_assertion      = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+  # or
+  # client_assertion_path = "/path/to/oidc-token.txt"
+
   # If no credentials are specified, the plugin will use Azure CLI authentication
 
   # The maximum number of attempts (including the initial call) Steampipe will
@@ -219,8 +228,9 @@ The Azure plugin support multiple formats/authentication mechanisms and they are
 
 1. [Client Secret Credentials](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-saml-bearer-assertion#prerequisites) if set; otherwise
 2. [Client Certificate Credentials](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials#register-your-certificate-with-microsoft-identity-platform) if set; otherwise
-3. [Resource Owner Password](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth-ropc) if set; otherwise
-4. If no credentials are supplied, then the [az cli](https://docs.microsoft.com/en-us/cli/azure/#:~:text=The%20Azure%20command%2Dline%20interface,with%20an%20emphasis%20on%20automation.) credentials are used
+3. [OIDC Client Assertion](https://learn.microsoft.com/entra/workload-id/workload-identity-federation) if `client_assertion` or `client_assertion_path` is set; otherwise
+4. [Resource Owner Password](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth-ropc) if set; otherwise
+5. If no credentials are supplied, then the [az cli](https://docs.microsoft.com/en-us/cli/azure/#:~:text=The%20Azure%20command%2Dline%20interface,with%20an%20emphasis%20on%20automation.) credentials are used
 
 If connection arguments are provided, they will always take precedence over [Azure SDK environment variables](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/new-version-quickstart.md#setting-environment-variables), and they are tried in the below order:
 
@@ -304,6 +314,38 @@ connection "azure_msi" {
 }
 ```
 
+### OIDC Federated Identity (GitHub Actions, GitLab CI)
+
+Steampipe supports [Entra ID federated identity credentials](https://learn.microsoft.com/entra/workload-id/workload-identity-federation) for OIDC-based authentication from CI/CD systems such as GitHub Actions, GitLab CI, or any external OIDC provider. The OIDC token (client assertion) can be provided inline or as a file path.
+
+- `tenant_id`: Specify the tenant to authenticate with.
+- `subscription_id`: Specify the subscription to query.
+- `client_id`: Specify the app client ID to use.
+- `client_assertion`: The OIDC JWT assertion string (for CI/CD systems that provide the token as an environment variable).
+- `client_assertion_path`: Path to a file containing the OIDC JWT assertion (for CI/CD systems that write the token to a file).
+
+```hcl
+connection "azure_oidc" {
+  plugin           = "azure"
+  tenant_id        = "00000000-0000-0000-0000-000000000000"
+  subscription_id  = "00000000-0000-0000-0000-000000000000"
+  client_id        = "00000000-0000-0000-0000-000000000000"
+  client_assertion = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+Or using a file path:
+
+```hcl
+connection "azure_oidc" {
+  plugin                = "azure"
+  tenant_id             = "00000000-0000-0000-0000-000000000000"
+  subscription_id       = "00000000-0000-0000-0000-000000000000"
+  client_id             = "00000000-0000-0000-0000-000000000000"
+  client_assertion_path = "/path/to/oidc-token.txt"
+}
+```
+
 ### Azure CLI
 
 If no credentials are specified and the SDK environment variables are not set, the plugin will use the active credentials from the Azure CLI. You can run `az login` to set up these credentials.
@@ -328,6 +370,8 @@ export AZURE_CLIENT_ID="00000000-0000-0000-0000-000000000000"
 export AZURE_CLIENT_SECRET="my plaintext secret"
 export AZURE_CERTIFICATE_PATH="path/to/file.pem"
 export AZURE_CERTIFICATE_PASSWORD="my plaintext password"
+export AZURE_CLIENT_ASSERTION="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." # For OIDC federated identity
+export AZURE_CLIENT_ASSERTION_PATH="/path/to/oidc-token.txt" # For OIDC federated identity (file-based)
 ```
 
 ```hcl


### PR DESCRIPTION
- Introduced `client_assertion` and `client_assertion_path` config fields for OIDC federated identity
- Updated authentication flow to support OIDC credentials in both GetNewSessionUpdated and GetNewSession
- Added azcoreTokenAuthorizer bridge for using OIDC credentials with legacy SDK clients
- Enhanced documentation and config examples for new authentication method

closes #1014 

# Integration test logs
<details>
  <summary>Logs</summary>
N/A
</details>

# Example query results
<details>
  <summary>Results</summary>

Test done with this obfuscated configuration

```
      connection "azure" {
        plugin      = "azure"
        type        = "aggregator"
        connections = ["azure_*"]
      }
      
      connection "azure_ c3e096e57a5f8d4f68d0bfd65fc01e66" {
        plugin                = "azure"
        tenant_id             = "8da3500a0f55b6071e7aeea62a6b6950"
        subscription_id       = " c3e096e57a5f8d4f68d0bfd65fc01e66"
        client_id             = "961c9a675b22ac0d408ccaeef8dc7132"
      }
      
      connection "azure_6f9524ded4e33c540b25df35a5da8a9a" {
        plugin                = "azure"
        tenant_id             = "8da3500a0f55b6071e7aeea62a6b6950"
        subscription_id       = "6f9524ded4e33c540b25df35a5da8a9a"
        client_id             = "961c9a675b22ac0d408ccaeef8dc7132"
        client_assertion_path = "/tmp/azure-oidc-token.txt"
      }
```

  
```
$ steampipe query "select md5(display_name) as display_name, md5(subscription_id) as subscription_id, md5(tenant_id) as tenant_id, cloud_environment from azure_subscription limit 5;"
+----------------------------------+----------------------------------+----------------------------------+-------------------+
| display_name                     | subscription_id                  | tenant_id                        | cloud_environment |
+----------------------------------+----------------------------------+----------------------------------+-------------------+
| b352f657e243096b4f3cd55663d9fafa | c3e096e57a5f8d4f68d0bfd65fc01e66 | 8da3500a0f55b6071e7aeea62a6b6950 | AzurePublicCloud  |
| 184bed812c3fac93865bffcb0b97ac57 | 6f9524ded4e33c540b25df35a5da8a9a | 8da3500a0f55b6071e7aeea62a6b6950 | AzurePublicCloud  |
+----------------------------------+----------------------------------+----------------------------------+-------------------+
```
</details>
