### PR TITLE
fix(azure_postgresql_flexible_server): skip configurations hydrate when server is Stopping/Stopped/Updating

### DIFF
--- a/azure/table_azure_postgresql_flexible_server.go
+++ b/azure/table_azure_postgresql_flexible_server.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
@@ -339,6 +340,11 @@ func listPostgreSQLFlexibleServersConfigurations(ctx context.Context, d *plugin.
 	server := h.Item.(armmypostgresflexibleservers.Server)
 	resourceGroup := strings.Split(string(*server.ID), "/")[4]
 	serverName := *server.Name
+
+	// Azure rejects this call with ServerStoppedError/400 while the server is Stopping, Stopped or Updating.
+	if server.Properties != nil && slices.Contains([]string{"Stopping", "Stopped", "Updating"}, string(*server.Properties.State)) {
+		return nil, nil
+	}
 
 	session, err := GetNewSessionUpdated(ctx, d)
 	if err != nil {


### PR DESCRIPTION
## Problem

`azure_postgresql_flexible_server`'s `flexible_server_configurations` column hydrates via `listPostgreSQLFlexibleServersConfigurations`, which calls the `ConfigurationsClient.NewListByServerPager` API unconditionally. When the flexible server is in a `Stopped` (or `Stopping`/`Updating`) state, Azure rejects this call with a `400 ServerStoppedError`, which aborts the entire table scan instead of just that row/column.

`azure_mysql_flexible_server`'s equivalent hydrate (`listMySQLFlexibleServersConfigurations`) already guards against this for MySQL (Azure returns `409 ServerUnavailableForOperation` there) by skipping the API call when `server.Properties.State` is `Stopping`, `Stopped`, or `Updating`. This PR applies the same guard to the PostgreSQL flexible server table.

## Change

- Add `slices` import.
- In `listPostgreSQLFlexibleServersConfigurations`, return `nil, nil` early when `server.Properties.State` is one of `Stopping`, `Stopped`, `Updating`, before calling the Configurations API - mirroring the existing MySQL pattern.

## Notes

- This is an independent fix from #1010 (redis enterprise tables) - different table, no overlapping code.
- Verified with `go build ./azure/...` on this branch (based on current upstream `main`).
